### PR TITLE
AzureEnhancedMonitor V2

### DIFF
--- a/AzureEnhancedMonitor/README.md
+++ b/AzureEnhancedMonitor/README.md
@@ -58,4 +58,4 @@ You could also use `sudo make install` to install the lib or `make test` to run 
 ```
 vim /var/lib/AzureEnhancedMonitor/PerfCounters
 ```
-or use any other text editor to open it
+Or use any other text editor to open it.

--- a/AzureEnhancedMonitor/README.md
+++ b/AzureEnhancedMonitor/README.md
@@ -1,0 +1,61 @@
+# How to enable Azure Enhanced Monitoring on Linux VM
+
+This is an instruction about how to enable Azure Enhanced Monitoring on Azure Linux VM.
+
+## Prepare your develop machine
+
+First of all, you need to prepare your develop machine to manipulate Linux VM on Azure. We have provided a script to automate this process. The script will install nodejs, npm and azure-cli on your develop machine. It will also install a nodejs package for configuring Azure Enhanced Monitoring Extension. Currently, the script supports Ubuntu, CentOS, SUSE etc. If you want to use other Linux distribution as your develop machine, you may need to [install nodejs manually](https://github.com/joyent/node/wiki/installing-node.js-via-package-manager).
+
+```
+curl -LO https://github.com/Azure/azure-linux-extensions/releases/download/azure-enhanced-monitor-1.0-alpha2/install.sh
+sudo sh install.sh
+```
+## Configure Azure Enhanced Monitoring
+
+1. After previous step, you should be able to use the command `setaem`. You could check this by running the following commands.
+
+    ```
+    sudo setaem -h
+    sudo setaem -v 
+    ```
+2. Then, you need to configure your Azure Account with the following command.
+
+    ```
+    #If you are using an org. id.
+    sudo azure login -u <user_name>
+    ```
+    Or
+
+    ```
+    sudo azure account import <publish_settings_file>
+    ```
+3. Now, you should be able to use the following command to enable Azure Enhanced Monitoring on your Azure Linux VM.
+
+    ```
+    sudo setaem <service_name> <vm_name>
+    ```
+    Or
+    ```  
+    #If service name is the same with vm.
+    sudo setaem <vm_name>
+    ```
+
+## Build c lib for reading performance counters
+
+We also provided a lib written in c for reading performance counters.
+
+```
+curl -LO https://github.com/Azure/azure-linux-extensions/releases/download/azure-enhanced-monitor-1.0-alpha2/clib.tar.gz
+tar zxf clib.tar.gz
+cd clib
+make
+```
+
+You could also use `sudo make install` to install the lib or `make test` to run some check on your build.
+
+## Check AEM information
+
+```
+vim /var/lib/AzureEnhancedMonitor/PerfCounters
+```
+or use any other text editor to open it

--- a/AzureEnhancedMonitor/ext/aem.py
+++ b/AzureEnhancedMonitor/ext/aem.py
@@ -65,8 +65,8 @@ LastestErrorRecord = "LastestErrorRecord"
 
 def getLastestErrorRecord():
 	eventFile=os.path.join(LibDir, LastestErrorRecord)
-	if os.path.isfile(eventFile):
-		f = open('eventFile', 'r')
+	if os.path.exists(eventFile) and os.path.isfile(eventFile):
+		f = open(eventFile, 'r')
 		return f.read()
 
 	return "0"
@@ -148,7 +148,7 @@ def getAzureDiagnosticCPUData(accountName, accountKey, hostBase,
     except Exception, e:
         waagent.Error(("Failed to retrieve diagnostic data(CPU): {0} {1}"
                        "").format(printable(e), traceback.format_exc()))
-	updateLastestErrorRecord(FAILED_TO_RETRIEVE_MDS_DATA)
+        updateLastestErrorRecord(FAILED_TO_RETRIEVE_MDS_DATA)
         AddExtensionEvent(message=FAILED_TO_RETRIEVE_MDS_DATA)
         return None
     
@@ -172,7 +172,7 @@ def getAzureDiagnosticMemoryData(accountName, accountKey, hostBase,
     except Exception, e:
         waagent.Error(("Failed to retrieve diagnostic data(Memory): {0} {1}"
                        "").format(printable(e), traceback.format_exc()))
-	updateLastestErrorRecord(FAILED_TO_RETRIEVE_MDS_DATA)
+        updateLastestErrorRecord(FAILED_TO_RETRIEVE_MDS_DATA)
         AddExtensionEvent(message=FAILED_TO_RETRIEVE_MDS_DATA)
         return None
 
@@ -419,7 +419,7 @@ class NetworkInfo(object):
             return int(match.group(1))
         else:
             waagent.Error("Failed to parse netstat output: {0}".format(netstat))
-	    updateLastestErrorRecord(FAILED_TO_RETRIEVE_LOCAL_DATA)
+            updateLastestErrorRecord(FAILED_TO_RETRIEVE_LOCAL_DATA)
             AddExtensionEvent(message=FAILED_TO_RETRIEVE_LOCAL_DATA)
             return None
 
@@ -812,7 +812,7 @@ def getStorageMetrics(account, key, hostBase, table, startKey, endKey):
     except Exception, e:
         waagent.Error(("Failed to retrieve storage metrics data: {0} {1}"
                        "").format(printable(e), traceback.format_exc()))
-	updateLastestErrorRecord(FAILED_TO_RETRIEVE_STORAGE_DATA)
+        updateLastestErrorRecord(FAILED_TO_RETRIEVE_STORAGE_DATA)
         AddExtensionEvent(message=FAILED_TO_RETRIEVE_STORAGE_DATA)
         return None
 
@@ -1247,7 +1247,7 @@ class PerfCounterWriter(object):
 
         waagent.Error(("Failed to serialize perf counter to file:"
                        "{0}").format(eventFile))
-	updateLastestErrorRecord(FAILED_TO_SERIALIZE_PERF_COUNTERS)
+        updateLastestErrorRecord(FAILED_TO_SERIALIZE_PERF_COUNTERS)
         AddExtensionEvent(message=FAILED_TO_SERIALIZE_PERF_COUNTERS)
         raise
 

--- a/AzureEnhancedMonitor/ext/aem.py
+++ b/AzureEnhancedMonitor/ext/aem.py
@@ -63,7 +63,7 @@ LibDir = "/var/lib/AzureEnhancedMonitor"
 
 LastestErrorRecord = "LastestErrorRecord"
 
-def GetLastestErrorRecord():
+def getLastestErrorRecord():
 	eventFile=os.path.join(LibDir, LastestErrorRecord)
 	if os.path.isfile(eventFile):
 		f = open('eventFile', 'r')
@@ -71,7 +71,7 @@ def GetLastestErrorRecord():
 
 	return "0"
 
-def UpdateLastestErrorRecord(s):
+def updateLastestErrorRecord(s):
 	eventFile=os.path.join(LibDir, LastestErrorRecord)
 	maxRetry = 3
 	for i in range(0, maxRetry):
@@ -148,7 +148,7 @@ def getAzureDiagnosticCPUData(accountName, accountKey, hostBase,
     except Exception, e:
         waagent.Error(("Failed to retrieve diagnostic data(CPU): {0} {1}"
                        "").format(printable(e), traceback.format_exc()))
-	UpdateLastestErrorRecord(FAILED_TO_RETRIEVE_MDS_DATA)
+	updateLastestErrorRecord(FAILED_TO_RETRIEVE_MDS_DATA)
         AddExtensionEvent(message=FAILED_TO_RETRIEVE_MDS_DATA)
         return None
     
@@ -172,7 +172,7 @@ def getAzureDiagnosticMemoryData(accountName, accountKey, hostBase,
     except Exception, e:
         waagent.Error(("Failed to retrieve diagnostic data(Memory): {0} {1}"
                        "").format(printable(e), traceback.format_exc()))
-	UpdateLastestErrorRecord(FAILED_TO_RETRIEVE_MDS_DATA)
+	updateLastestErrorRecord(FAILED_TO_RETRIEVE_MDS_DATA)
         AddExtensionEvent(message=FAILED_TO_RETRIEVE_MDS_DATA)
         return None
 
@@ -419,7 +419,7 @@ class NetworkInfo(object):
             return int(match.group(1))
         else:
             waagent.Error("Failed to parse netstat output: {0}".format(netstat))
-	    UpdateLastestErrorRecord(FAILED_TO_RETRIEVE_LOCAL_DATA)
+	    updateLastestErrorRecord(FAILED_TO_RETRIEVE_LOCAL_DATA)
             AddExtensionEvent(message=FAILED_TO_RETRIEVE_LOCAL_DATA)
             return None
 
@@ -597,8 +597,8 @@ class VMDataSource(object):
         #Hardware change
         counters.append(self.createCounterLastHardwareChange(metrics))
 		
-	#Errors
-	counters.append(self.createCounterErrors(metrics))
+        #Error
+        counters.append(self.createCounterError())
 		
         return counters
     
@@ -609,11 +609,11 @@ class VMDataSource(object):
                            value = metrics.getLastHardwareChange(),
                            unit="posixtime")
 
-    def createCounterErrors(self, metrics):
+    def createCounterError(self):
         return PerfCounter(counterType = PerfCounterType.COUNTER_TYPE_LARGE,
                            category = "config",
                            name = "Error",
-                           value = GetLastestErrorRecord())
+                           value = getLastestErrorRecord())
 						   
     def createCounterCurrHwFrequency(self, metrics):
         return PerfCounter(counterType = PerfCounterType.COUNTER_TYPE_DOUBLE,
@@ -812,7 +812,7 @@ def getStorageMetrics(account, key, hostBase, table, startKey, endKey):
     except Exception, e:
         waagent.Error(("Failed to retrieve storage metrics data: {0} {1}"
                        "").format(printable(e), traceback.format_exc()))
-	UpdateLastestErrorRecord(FAILED_TO_RETRIEVE_STORAGE_DATA)
+	updateLastestErrorRecord(FAILED_TO_RETRIEVE_STORAGE_DATA)
         AddExtensionEvent(message=FAILED_TO_RETRIEVE_STORAGE_DATA)
         return None
 
@@ -1247,7 +1247,7 @@ class PerfCounterWriter(object):
 
         waagent.Error(("Failed to serialize perf counter to file:"
                        "{0}").format(eventFile))
-	UpdateLastestErrorRecord(FAILED_TO_SERIALIZE_PERF_COUNTERS)
+	updateLastestErrorRecord(FAILED_TO_SERIALIZE_PERF_COUNTERS)
         AddExtensionEvent(message=FAILED_TO_SERIALIZE_PERF_COUNTERS)
         raise
 

--- a/AzureEnhancedMonitor/ext/aem.py
+++ b/AzureEnhancedMonitor/ext/aem.py
@@ -61,18 +61,18 @@ AzureTableDelay = 60 * AzureTableDelayInMinute
 AzureEnhancedMonitorVersion = "1.0.0"
 LibDir = "/var/lib/AzureEnhancedMonitor"
 
-LastestErrorRecord = "LastestErrorRecord"
+LatestErrorRecord = "LatestErrorRecord"
 
-def getLastestErrorRecord():
-	eventFile=os.path.join(LibDir, LastestErrorRecord)
+def getLatestErrorRecord():
+	eventFile=os.path.join(LibDir, LatestErrorRecord)
 	if os.path.exists(eventFile) and os.path.isfile(eventFile):
 		f = open(eventFile, 'r')
 		return f.read()
 
 	return "0"
 
-def updateLastestErrorRecord(s):
-	eventFile=os.path.join(LibDir, LastestErrorRecord)
+def updateLatestErrorRecord(s):
+	eventFile=os.path.join(LibDir, LatestErrorRecord)
 	maxRetry = 3
 	for i in range(0, maxRetry):
 		try:
@@ -82,9 +82,9 @@ def updateLastestErrorRecord(s):
 		except IOError, e:
 			time.sleep(1)
 
-	waagent.Error(("Failed to serialize lastest error record to file:"
+	waagent.Error(("Failed to serialize latest error record to file:"
 					"{0}").format(eventFile))
-	AddExtensionEvent(message="failed to write lastest error record")
+	AddExtensionEvent(message="failed to write latest error record")
 	raise
 			
 def printable(s):
@@ -148,7 +148,7 @@ def getAzureDiagnosticCPUData(accountName, accountKey, hostBase,
     except Exception, e:
         waagent.Error(("Failed to retrieve diagnostic data(CPU): {0} {1}"
                        "").format(printable(e), traceback.format_exc()))
-        updateLastestErrorRecord(FAILED_TO_RETRIEVE_MDS_DATA)
+        updateLatestErrorRecord(FAILED_TO_RETRIEVE_MDS_DATA)
         AddExtensionEvent(message=FAILED_TO_RETRIEVE_MDS_DATA)
         return None
     
@@ -172,7 +172,7 @@ def getAzureDiagnosticMemoryData(accountName, accountKey, hostBase,
     except Exception, e:
         waagent.Error(("Failed to retrieve diagnostic data(Memory): {0} {1}"
                        "").format(printable(e), traceback.format_exc()))
-        updateLastestErrorRecord(FAILED_TO_RETRIEVE_MDS_DATA)
+        updateLatestErrorRecord(FAILED_TO_RETRIEVE_MDS_DATA)
         AddExtensionEvent(message=FAILED_TO_RETRIEVE_MDS_DATA)
         return None
 
@@ -419,7 +419,7 @@ class NetworkInfo(object):
             return int(match.group(1))
         else:
             waagent.Error("Failed to parse netstat output: {0}".format(netstat))
-            updateLastestErrorRecord(FAILED_TO_RETRIEVE_LOCAL_DATA)
+            updateLatestErrorRecord(FAILED_TO_RETRIEVE_LOCAL_DATA)
             AddExtensionEvent(message=FAILED_TO_RETRIEVE_LOCAL_DATA)
             return None
 
@@ -613,7 +613,7 @@ class VMDataSource(object):
         return PerfCounter(counterType = PerfCounterType.COUNTER_TYPE_LARGE,
                            category = "config",
                            name = "Error",
-                           value = getLastestErrorRecord())
+                           value = getLatestErrorRecord())
 						   
     def createCounterCurrHwFrequency(self, metrics):
         return PerfCounter(counterType = PerfCounterType.COUNTER_TYPE_DOUBLE,
@@ -812,7 +812,7 @@ def getStorageMetrics(account, key, hostBase, table, startKey, endKey):
     except Exception, e:
         waagent.Error(("Failed to retrieve storage metrics data: {0} {1}"
                        "").format(printable(e), traceback.format_exc()))
-        updateLastestErrorRecord(FAILED_TO_RETRIEVE_STORAGE_DATA)
+        updateLatestErrorRecord(FAILED_TO_RETRIEVE_STORAGE_DATA)
         AddExtensionEvent(message=FAILED_TO_RETRIEVE_STORAGE_DATA)
         return None
 
@@ -1247,7 +1247,7 @@ class PerfCounterWriter(object):
 
         waagent.Error(("Failed to serialize perf counter to file:"
                        "{0}").format(eventFile))
-        updateLastestErrorRecord(FAILED_TO_SERIALIZE_PERF_COUNTERS)
+        updateLatestErrorRecord(FAILED_TO_SERIALIZE_PERF_COUNTERS)
         AddExtensionEvent(message=FAILED_TO_SERIALIZE_PERF_COUNTERS)
         raise
 

--- a/AzureEnhancedMonitor/ext/aem.py
+++ b/AzureEnhancedMonitor/ext/aem.py
@@ -58,35 +58,35 @@ MonitoringInterval = 60 * MonitoringIntervalInMinute
 AzureTableDelayInMinute = 5 #Five minute
 AzureTableDelay = 60 * AzureTableDelayInMinute
 
-AzureEnhancedMonitorVersion = "1.0.0"
+AzureEnhancedMonitorVersion = "2.0.0"
 LibDir = "/var/lib/AzureEnhancedMonitor"
 
 LatestErrorRecord = "LatestErrorRecord"
 
 def getLatestErrorRecord():
-	eventFile=os.path.join(LibDir, LatestErrorRecord)
-	if os.path.exists(eventFile) and os.path.isfile(eventFile):
-		f = open(eventFile, 'r')
-		return f.read()
+    eventFile=os.path.join(LibDir, LatestErrorRecord)
+    if os.path.exists(eventFile) and os.path.isfile(eventFile):
+        f = open(eventFile, 'r')
+        return f.read()
 
-	return "0"
+    return "0"
 
 def updateLatestErrorRecord(s):
-	eventFile=os.path.join(LibDir, LatestErrorRecord)
-	maxRetry = 3
-	for i in range(0, maxRetry):
-		try:
-			with open(eventFile, "w+") as F:
-				F.write(s.encode("utf8"))
-			return
-		except IOError, e:
-			time.sleep(1)
+    eventFile=os.path.join(LibDir, LatestErrorRecord)
+    maxRetry = 3
+    for i in range(0, maxRetry):
+        try:
+            with open(eventFile, "w+") as F:
+                F.write(s.encode("utf8"))
+                return
+        except IOError, e:
+            time.sleep(1)
 
-	waagent.Error(("Failed to serialize latest error record to file:"
-					"{0}").format(eventFile))
-	AddExtensionEvent(message="failed to write latest error record")
-	raise
-			
+    waagent.Error(("Failed to serialize latest error record to file:"
+                    "{0}").format(eventFile))
+    AddExtensionEvent(message="failed to write latest error record")
+    raise
+
 def printable(s):
     return filter(lambda c : c in string.printable, str(s))
 
@@ -397,16 +397,16 @@ class NetworkInfo(object):
         return self.nicNames
 
     def getNetworkReadBytes(self, adapterId):
-	if adapterId in self.networkReadBytes :
-		return self.networkReadBytes[adapterId]
-	else:
-		return 0
+        if adapterId in self.networkReadBytes :
+            return self.networkReadBytes[adapterId]
+        else:
+            return 0
 
     def getNetworkWriteBytes(self, adapterId):
         if adapterId in self.networkWriteBytes :
-		return self.networkWriteBytes[adapterId]
-	else:
-		return 0
+            return self.networkWriteBytes[adapterId]
+        else:
+            return 0
 
     def getNetstat(self):
         retCode, output = waagent.RunGetOutput("netstat -s", chk_err=False)
@@ -585,21 +585,21 @@ class VMDataSource(object):
         #Network
         adapterIds = metrics.getNetworkAdapterIds()
         for adapterId in adapterIds:
-		if adapterId.startswith('eth'):
-			counters.append(self.createCounterAdapterId(adapterId))
-			counters.append(self.createCounterNetworkMapping(metrics, adapterId))
-			counters.append(self.createCounterMinNetworkBandwidth(metrics, adapterId))
-			counters.append(self.createCounterMaxNetworkBandwidth(metrics, adapterId))
-			counters.append(self.createCounterNetworkReadBytes(metrics, adapterId))
-			counters.append(self.createCounterNetworkWriteBytes(metrics, adapterId))
+            if adapterId.startswith('eth'):
+                counters.append(self.createCounterAdapterId(adapterId))
+                counters.append(self.createCounterNetworkMapping(metrics, adapterId))
+                counters.append(self.createCounterMinNetworkBandwidth(metrics, adapterId))
+                counters.append(self.createCounterMaxNetworkBandwidth(metrics, adapterId))
+                counters.append(self.createCounterNetworkReadBytes(metrics, adapterId))
+                counters.append(self.createCounterNetworkWriteBytes(metrics, adapterId))
         counters.append(self.createCounterNetworkPacketRetransmitted(metrics))
         
         #Hardware change
         counters.append(self.createCounterLastHardwareChange(metrics))
-		
+
         #Error
         counters.append(self.createCounterError())
-		
+
         return counters
     
     def createCounterLastHardwareChange(self, metrics):
@@ -614,7 +614,7 @@ class VMDataSource(object):
                            category = "config",
                            name = "Error",
                            value = getLatestErrorRecord())
-						   
+
     def createCounterCurrHwFrequency(self, metrics):
         return PerfCounter(counterType = PerfCounterType.COUNTER_TYPE_DOUBLE,
                            category = "cpu",
@@ -760,7 +760,7 @@ class VMDataSource(object):
         return PerfCounter(counterType = PerfCounterType.COUNTER_TYPE_LARGE,
                            category = "network",
                            name = "Network Read Bytes",
-						   instance = adapterId,
+                           instance = adapterId,
                            value = metrics.getNetworkReadBytes(adapterId),
                            unit = "byte/s")
 
@@ -768,7 +768,7 @@ class VMDataSource(object):
         return PerfCounter(counterType = PerfCounterType.COUNTER_TYPE_LARGE,
                            category = "network",
                            name = "Network Write Bytes",
-						   instance = adapterId,
+                           instance = adapterId,
                            value = metrics.getNetworkWriteBytes(adapterId),
                            unit = "byte/s")
 

--- a/AzureEnhancedMonitor/ext/aem.py
+++ b/AzureEnhancedMonitor/ext/aem.py
@@ -585,14 +585,15 @@ class VMDataSource(object):
         #Network
         adapterIds = metrics.getNetworkAdapterIds()
         for adapterId in adapterIds:
-            counters.append(self.createCounterAdapterId(adapterId))
-            counters.append(self.createCounterNetworkMapping(metrics, adapterId))
-            counters.append(self.createCounterMinNetworkBandwidth(metrics, 
-                                                                  adapterId))
-            counters.append(self.createCounterMaxNetworkBandwidth(metrics,
-                                                                  adapterId))
-			counters.append(self.createCounterNetworkReadBytes(metrics, adapterId))
-			counters.append(self.createCounterNetworkWriteBytes(metrics, adapterId))
+			if adapterIds.startswith('eth')
+				counters.append(self.createCounterAdapterId(adapterId))
+				counters.append(self.createCounterNetworkMapping(metrics, adapterId))
+				counters.append(self.createCounterMinNetworkBandwidth(metrics, 
+																	  adapterId))
+				counters.append(self.createCounterMaxNetworkBandwidth(metrics,
+																	  adapterId))
+				counters.append(self.createCounterNetworkReadBytes(metrics, adapterId))
+				counters.append(self.createCounterNetworkWriteBytes(metrics, adapterId))
         counters.append(self.createCounterNetworkPacketRetransmitted(metrics))
         
         #Hardware change

--- a/AzureEnhancedMonitor/ext/aem.py
+++ b/AzureEnhancedMonitor/ext/aem.py
@@ -27,7 +27,7 @@ import datetime
 import psutil
 import string
 import urlparse
-from azure.storage import TableService, Entity
+from azure.storage.table import TableService, Entity
 from Utils.WAAgentUtil import waagent, AddExtensionEvent
 import Utils.HandlerUtil as Util
 
@@ -148,7 +148,7 @@ def getAzureDiagnosticCPUData(accountName, accountKey, hostBase,
     except Exception, e:
         waagent.Error(("Failed to retrieve diagnostic data(CPU): {0} {1}"
                        "").format(printable(e), traceback.format_exc()))
-		UpdateLastestErrorRecord(FAILED_TO_RETRIEVE_MDS_DATA)
+	UpdateLastestErrorRecord(FAILED_TO_RETRIEVE_MDS_DATA)
         AddExtensionEvent(message=FAILED_TO_RETRIEVE_MDS_DATA)
         return None
     
@@ -172,7 +172,7 @@ def getAzureDiagnosticMemoryData(accountName, accountKey, hostBase,
     except Exception, e:
         waagent.Error(("Failed to retrieve diagnostic data(Memory): {0} {1}"
                        "").format(printable(e), traceback.format_exc()))
-		UpdateLastestErrorRecord(FAILED_TO_RETRIEVE_MDS_DATA)
+	UpdateLastestErrorRecord(FAILED_TO_RETRIEVE_MDS_DATA)
         AddExtensionEvent(message=FAILED_TO_RETRIEVE_MDS_DATA)
         return None
 
@@ -383,30 +383,30 @@ class NetworkInfo(object):
         self.nicNames = []
         self.readBytes = 0
         self.writeBytes = 0
-		self.networkReadBytes = {}
-		self.networkWriteBytes = {}
+	self.networkReadBytes = {}
+	self.networkWriteBytes = {}
         for nicName, stat in self.nics.iteritems():
             if nicName != 'lo':
                 self.nicNames.append(nicName)
                 self.readBytes = self.readBytes + stat[1] #bytes_recv
                 self.writeBytes = self.writeBytes + stat[0] #bytes_sent
-				self.networkReadBytes[nicName] = stat[1]
-				self.networkWriteBytes[nicName] = stat[0]
+		self.networkReadBytes[nicName] = stat[1]
+		self.networkWriteBytes[nicName] = stat[0]
 
     def getAdapterIds(self):
         return self.nicNames
 
     def getNetworkReadBytes(self, adapterId):
-		if adapterId in self.networkReadBytes :
-			return self.networkReadBytes[adapterId]
-		else
-			return 0
+	if adapterId in self.networkReadBytes :
+		return self.networkReadBytes[adapterId]
+	else:
+		return 0
 
     def getNetworkWriteBytes(self, adapterId):
         if adapterId in self.networkWriteBytes :
-			return self.networkWriteBytes[adapterId]
-		else
-			return 0
+		return self.networkWriteBytes[adapterId]
+	else:
+		return 0
 
     def getNetstat(self):
         retCode, output = waagent.RunGetOutput("netstat -s", chk_err=False)
@@ -419,7 +419,7 @@ class NetworkInfo(object):
             return int(match.group(1))
         else:
             waagent.Error("Failed to parse netstat output: {0}".format(netstat))
-			UpdateLastestErrorRecord(FAILED_TO_RETRIEVE_LOCAL_DATA)
+	    UpdateLastestErrorRecord(FAILED_TO_RETRIEVE_LOCAL_DATA)
             AddExtensionEvent(message=FAILED_TO_RETRIEVE_LOCAL_DATA)
             return None
 
@@ -585,22 +585,20 @@ class VMDataSource(object):
         #Network
         adapterIds = metrics.getNetworkAdapterIds()
         for adapterId in adapterIds:
-			if adapterIds.startswith('eth')
-				counters.append(self.createCounterAdapterId(adapterId))
-				counters.append(self.createCounterNetworkMapping(metrics, adapterId))
-				counters.append(self.createCounterMinNetworkBandwidth(metrics, 
-																	  adapterId))
-				counters.append(self.createCounterMaxNetworkBandwidth(metrics,
-																	  adapterId))
-				counters.append(self.createCounterNetworkReadBytes(metrics, adapterId))
-				counters.append(self.createCounterNetworkWriteBytes(metrics, adapterId))
+		if adapterId.startswith('eth'):
+			counters.append(self.createCounterAdapterId(adapterId))
+			counters.append(self.createCounterNetworkMapping(metrics, adapterId))
+			counters.append(self.createCounterMinNetworkBandwidth(metrics, adapterId))
+			counters.append(self.createCounterMaxNetworkBandwidth(metrics, adapterId))
+			counters.append(self.createCounterNetworkReadBytes(metrics, adapterId))
+			counters.append(self.createCounterNetworkWriteBytes(metrics, adapterId))
         counters.append(self.createCounterNetworkPacketRetransmitted(metrics))
         
         #Hardware change
         counters.append(self.createCounterLastHardwareChange(metrics))
 		
-		#Errors
-		counters.append(self.createCounterErrors(metrics))
+	#Errors
+	counters.append(self.createCounterErrors(metrics))
 		
         return counters
     
@@ -611,7 +609,7 @@ class VMDataSource(object):
                            value = metrics.getLastHardwareChange(),
                            unit="posixtime")
 
-	def createCounterErrors(self, metrics):
+    def createCounterErrors(self, metrics):
         return PerfCounter(counterType = PerfCounterType.COUNTER_TYPE_LARGE,
                            category = "config",
                            name = "Error",
@@ -774,7 +772,7 @@ class VMDataSource(object):
                            value = metrics.getNetworkWriteBytes(adapterId),
                            unit = "byte/s")
 
-    def createCounterNetworkPacketRetransmitted(self, metrics, adapterId):
+    def createCounterNetworkPacketRetransmitted(self, metrics):
         return PerfCounter(counterType = PerfCounterType.COUNTER_TYPE_INT,
                            category = "network",
                            name = "Packets Retransmitted",
@@ -814,7 +812,7 @@ def getStorageMetrics(account, key, hostBase, table, startKey, endKey):
     except Exception, e:
         waagent.Error(("Failed to retrieve storage metrics data: {0} {1}"
                        "").format(printable(e), traceback.format_exc()))
-		UpdateLastestErrorRecord(FAILED_TO_RETRIEVE_STORAGE_DATA)
+	UpdateLastestErrorRecord(FAILED_TO_RETRIEVE_STORAGE_DATA)
         AddExtensionEvent(message=FAILED_TO_RETRIEVE_STORAGE_DATA)
         return None
 
@@ -1249,7 +1247,7 @@ class PerfCounterWriter(object):
 
         waagent.Error(("Failed to serialize perf counter to file:"
                        "{0}").format(eventFile))
-		UpdateLastestErrorRecord(FAILED_TO_SERIALIZE_PERF_COUNTERS)
+	UpdateLastestErrorRecord(FAILED_TO_SERIALIZE_PERF_COUNTERS)
         AddExtensionEvent(message=FAILED_TO_SERIALIZE_PERF_COUNTERS)
         raise
 

--- a/AzureEnhancedMonitor/ext/aem.py
+++ b/AzureEnhancedMonitor/ext/aem.py
@@ -75,17 +75,17 @@ def UpdateLastestErrorRecord(s):
 	eventFile=os.path.join(LibDir, LastestErrorRecord)
 	maxRetry = 3
 	for i in range(0, maxRetry):
-        try:
-            with open(eventFile, "w+") as F:
+		try:
+			with open(eventFile, "w+") as F:
 				F.write(s.encode("utf8"))
-            return
-        except IOError, e:
-            time.sleep(1)
+			return
+		except IOError, e:
+			time.sleep(1)
 
-    waagent.Error(("Failed to serialize lastest error record to file:"
-                   "{0}").format(eventFile))
-    AddExtensionEvent(message="failed to write lastest error record")
-    raise
+	waagent.Error(("Failed to serialize lastest error record to file:"
+					"{0}").format(eventFile))
+	AddExtensionEvent(message="failed to write lastest error record")
+	raise
 			
 def printable(s):
     return filter(lambda c : c in string.printable, str(s))

--- a/AzureEnhancedMonitor/ext/aem.py
+++ b/AzureEnhancedMonitor/ext/aem.py
@@ -383,15 +383,15 @@ class NetworkInfo(object):
         self.nicNames = []
         self.readBytes = 0
         self.writeBytes = 0
-	self.networkReadBytes = {}
-	self.networkWriteBytes = {}
+        self.networkReadBytes = {}
+        self.networkWriteBytes = {}
         for nicName, stat in self.nics.iteritems():
             if nicName != 'lo':
                 self.nicNames.append(nicName)
                 self.readBytes = self.readBytes + stat[1] #bytes_recv
                 self.writeBytes = self.writeBytes + stat[0] #bytes_sent
-		self.networkReadBytes[nicName] = stat[1]
-		self.networkWriteBytes[nicName] = stat[0]
+                self.networkReadBytes[nicName] = stat[1]
+                self.networkWriteBytes[nicName] = stat[0]
 
     def getAdapterIds(self):
         return self.nicNames

--- a/AzureEnhancedMonitor/ext/test/test_aem.py
+++ b/AzureEnhancedMonitor/ext/test/test_aem.py
@@ -148,7 +148,7 @@ class TestAEM(unittest.TestCase):
         name = "Data Provider Version"
         counter = next((c for c in counters if c.name == name))
         self.assertNotEquals(None, counter)
-        self.assertEquals("1.0.0", counter.value)
+        self.assertEquals("2.0.0", counter.value)
 
         name = "Memory Over-Provisioning"
         counter = next((c for c in counters if c.name == name))

--- a/AzureEnhancedMonitor/nodejs/setaem.js
+++ b/AzureEnhancedMonitor/nodejs/setaem.js
@@ -37,7 +37,7 @@ var aemExtVersion = "1.0";
 
 var ladExtName = "LinuxDiagnostic";
 var ladExtPublisher = "Microsoft.OSTCExtensions";
-var ladExtVersion = "1.0";
+var ladExtVersion = "2.0";
 
 var ROLECONTENT = "IaaS";
 var AzureEndpoint = "windows.net";
@@ -207,7 +207,8 @@ var setAzureVMEnhancedMonitorForLinux = function(svcName, vmName){
                 'key' : ladExtName + "PrivateConfigParameter",
                 'value' : JSON.stringify({
                     'storageAccountName' : accounts[0].name,
-                    'storageAccountKey' : accounts[0].key
+                    'storageAccountKey' : accounts[0].key,
+					'endpoint' : accounts[0].substring((accounts[0].search(/\./)) + 1, accounts[0].length);
                 }),
                 'type':'Private'
             }]

--- a/AzureEnhancedMonitor/nodejs/setaem.js
+++ b/AzureEnhancedMonitor/nodejs/setaem.js
@@ -193,7 +193,7 @@ var setAzureVMEnhancedMonitorForLinux = function(svcName, vmName){
         aemConfig.setPublic("wad.name", accounts[0].name);
         aemConfig.setPrivate("wad.key", accounts[0].key);
         var ladUri = accounts[0].tableEndpoint + ladMetricesTable;
-		console.log("!!!!!!"+accounts[0].tableEndpoint);
+		console.log("[INFO]Your endpoint is: "+accounts[0].tableEndpoint);
         aemConfig.setPublic("wad.uri", ladUri);
     }).then(function(){
         //Update vm

--- a/AzureEnhancedMonitor/nodejs/setaem.js
+++ b/AzureEnhancedMonitor/nodejs/setaem.js
@@ -193,7 +193,7 @@ var setAzureVMEnhancedMonitorForLinux = function(svcName, vmName){
         aemConfig.setPublic("wad.name", accounts[0].name);
         aemConfig.setPrivate("wad.key", accounts[0].key);
         var ladUri = accounts[0].tableEndpoint + ladMetricesTable;
-		console.log("[INFO]Your endpoint is: "+accounts[0].tableEndpoint);
+        console.log("[INFO]Your endpoint is: "+accounts[0].tableEndpoint);
         aemConfig.setPublic("wad.uri", ladUri);
     }).then(function(){
         //Update vm
@@ -209,7 +209,7 @@ var setAzureVMEnhancedMonitorForLinux = function(svcName, vmName){
                 'value' : JSON.stringify({
                     'storageAccountName' : accounts[0].name,
                     'storageAccountKey' : accounts[0].key,
-					'endpoint' : accounts[0].tableEndpoint.substring((accounts[0].tableEndpoint.search(/\./)) + 1, accounts[0].tableEndpoint.length)
+                    'endpoint' : accounts[0].tableEndpoint.substring((accounts[0].tableEndpoint.search(/\./)) + 1, accounts[0].tableEndpoint.length)
                 }),
                 'type':'Private'
             }]

--- a/AzureEnhancedMonitor/nodejs/setaem.js
+++ b/AzureEnhancedMonitor/nodejs/setaem.js
@@ -193,6 +193,7 @@ var setAzureVMEnhancedMonitorForLinux = function(svcName, vmName){
         aemConfig.setPublic("wad.name", accounts[0].name);
         aemConfig.setPrivate("wad.key", accounts[0].key);
         var ladUri = accounts[0].tableEndpoint + ladMetricesTable;
+		console.log("!!!!!!"+accounts[0].tableEndpoint);
         aemConfig.setPublic("wad.uri", ladUri);
     }).then(function(){
         //Update vm
@@ -208,7 +209,7 @@ var setAzureVMEnhancedMonitorForLinux = function(svcName, vmName){
                 'value' : JSON.stringify({
                     'storageAccountName' : accounts[0].name,
                     'storageAccountKey' : accounts[0].key,
-					'endpoint' : accounts[0].substring((accounts[0].search(/\./)) + 1, accounts[0].length);
+					'endpoint' : accounts[0].tableEndpoint.substring((accounts[0].tableEndpoint.search(/\./)) + 1, accounts[0].tableEndpoint.length)
                 }),
                 'type':'Private'
             }]


### PR DESCRIPTION
1.	Switch to LinuxDiagnostic extension version 2.0
-Switched.

2.	Add support for table endpoint, pass table endpoint to LinuxDiagnostic extension as param.
-Updated the node js script.

a.	Add/modify perf counters, for details, see the email thread bellow
-Extension status has been displayed on Azure Portal. And It is checked by Handler, if just check it in PrefCounters, you can't judge whether it is dead status or not. So I don't think it should be write in PrefCounters.

b.	Add an perf counter(\config\errors) for error code
-Added. By record the latest error in disk.

c.	\network({0})\Network Read Bytes and \network({0})\Network Write Bytes are reported per NIC instance. Network adapter must be of Ethernet type, other NICs are filtered out.
Before the counters were cumulative values (sum) for all NICs.
-For each AdapterId, Network Read/Write Bytes are given.

d.	NIC instance counters \network({0})\Minimum Network Bandwidth and \network({0})\Maximum Network Bandwidth are removed, and replaced by counters for VM bandwidth:
\network\VM Minimum Network Bandwidth and \network\VM Maximum Network Bandwidth
-Return hardcoded value is 1000 Mbit/s.
