### PR TITLE
Fix for Internal DNS Check

### DIFF
--- a/CustomScript/customscript.py
+++ b/CustomScript/customscript.py
@@ -39,6 +39,7 @@ import json
 from codecs import *
 from azure.storage import BlobService
 from Utils.WAAgentUtil import waagent
+from distutils.util import strtobool
 import Utils.HandlerUtil as Util
 import Utils.ScriptUtil as ScriptUtil
 
@@ -279,7 +280,7 @@ def daemon(hutil):
         if 'wait' in public_settings:
             wait = public_settings.get('wait')
         if 'enableInternalDNSCheck' in public_settings:
-            enable_idns_check = public_settings.get('enableInternalDNSCheck')
+            enable_idns_check = strtobool(public_settings.get('enableInternalDNSCheck'))
 
     prepare_download_dir(hutil.get_seq_no())
     retry_count = download_files_with_retry(hutil, retry_count, wait)


### PR DESCRIPTION
I needed the ability to disable the internal DNS check, and while the public_setting is exposed, there is a bug where it was not being handled correctly and didn't work.  Setting a var to a string value makes it a 'true' boolean value when used for a boolean operation regardless of what the string value actually is.

This change uses the strtobool function to convert the string value that is optionally defined in public_settings ('enableInternalDNSCheck') into a true boolean value for the 'enable_idns_check' variable, so that the idns check is executes as expected.  Omitting 'enableInternalDNSCheck' from the public_settings results in a default of 'true' (as it was) while allowing a string value of 'y, yes, t, true, on or 1' for boolean true and a string value of 'n, no, f, false, off and 0' as a boolean false.