### PR TITLE
current_slice_index is undefined, use current_slice_index_value

### DIFF
--- a/VMEncryption/main/OnGoingItemConfig.py
+++ b/VMEncryption/main/OnGoingItemConfig.py
@@ -87,7 +87,7 @@ class OnGoingItemConfig(object):
         if(current_slice_index_value is None or current_slice_index_value == ""):
             return None
         else:
-            return long(current_slice_index)
+            return long(current_slice_index_value)
 
     def get_from_end(self):
         return self.ongoing_item_config.get_config(CommonVariables.OngoingItemFromEndKey)


### PR DESCRIPTION
Fixes the crash:

> 2016/04/10 23:31:36 [Microsoft.OSTCExtensions.AzureDiskEncryptionForLinux-1.0]2351: Error Failed to enable the extension with error: global name 'current_slice_index' is not defined, stack trace: Traceback (most recent call last):
> 2016/04/10 23:31:36   File "./main/handle.py", line 734, in daemon
> 2016/04/10 23:31:36     ongoing_item_config.load_value_from_file()
> 2016/04/10 23:31:36   File "/var/lib/waagent/Microsoft.OSTCExtensions.AzureDiskEncryptionForLinux-0.1.0.999104/main/OnGoingItemConfig.py", line 132, in load_value_from_file
> 2016/04/10 23:31:36     self.current_slice_index = self.get_current_slice_index()
> 2016/04/10 23:31:36   File "/var/lib/waagent/Microsoft.OSTCExtensions.AzureDiskEncryptionForLinux-0.1.0.999104/main/OnGoingItemConfig.py", line 90, in get_current_slice_index
> 2016/04/10 23:31:36     return long(current_slice_index)
> 2016/04/10 23:31:36 NameError: global name 'current_slice_index' is not defined
> 2016/04/10 23:31:36 