### PR TITLE
[LAD] Prepare for unified static mdsd build

### DIFF
--- a/Diagnostic/license.txt
+++ b/Diagnostic/license.txt
@@ -1,4 +1,4 @@
-Linux Azure Diagnostic Extension v.2.3.3
+Linux Azure Diagnostic Extension v.2.3.8
 Copyright (c) Microsoft Corporation
 All rights reserved. 
 MIT License


### PR DESCRIPTION
mdsd is now built as statically as possible, allowing us not to distinguish distros/versions. So update diagnostic.py's mdsd install code for this change.