### PR TITLE
[LAD] Misc updates for 2.3.9001

### DIFF
--- a/Diagnostic/Utils/HandlerUtil.py
+++ b/Diagnostic/Utils/HandlerUtil.py
@@ -67,13 +67,15 @@ class HandlerContext:
         return
 
 class HandlerUtility:
-    def __init__(self, log, error, short_name):
+    def __init__(self, log, error, short_name, ext_name_in_log_prefix, ext_version):
         self._log = log
         self._error = error
         self._short_name = short_name
+        self._ext_name_in_log_prefix = ext_name_in_log_prefix
+        self._ext_version = ext_version
 
     def _get_log_prefix(self):
-        return '[%s-%s]' %(self._context._name, self._context._version)
+        return '[%s-%s]' %(self._ext_name_in_log_prefix, self._ext_version)
 
     def _get_current_seq_no(self, config_folder):
         seq_no = -1

--- a/Diagnostic/Utils/HandlerUtil.py
+++ b/Diagnostic/Utils/HandlerUtil.py
@@ -67,15 +67,16 @@ class HandlerContext:
         return
 
 class HandlerUtility:
-    def __init__(self, log, error, short_name, ext_name_in_log_prefix, ext_version):
+    def __init__(self, log, error, short_name, ext_name_in_log_prefix="", ext_version=""):
         self._log = log
         self._error = error
         self._short_name = short_name
-        self._ext_name_in_log_prefix = ext_name_in_log_prefix
-        self._ext_version = ext_version
+        self._log_prefix = None
+        if ext_name_in_log_prefix and ext_name_in_log_prefix.strip() and ext_version and ext_version.strip():
+            self._log_prefix = '[%s-%s] ' % (ext_name_in_log_prefix, ext_version)
 
     def _get_log_prefix(self):
-        return '[%s-%s]' %(self._ext_name_in_log_prefix, self._ext_version)
+        return self._log_prefix if self._log_prefix else '[%s-%s] ' % (self._context._name, self._context._version)
 
     def _get_current_seq_no(self, config_folder):
         seq_no = -1

--- a/Diagnostic/diagnostic.py
+++ b/Diagnostic/diagnostic.py
@@ -2,7 +2,7 @@
 #
 # Azure Linux extension
 #
-# Linux Azure Diagnostic Extension v.2.3.7
+# Linux Azure Diagnostic Extension (see below for version)
 # Copyright (c) Microsoft Corporation
 # All rights reserved.   
 # MIT License  
@@ -41,13 +41,15 @@ import Utils.XmlUtil as XmlUtil
 import Utils.ApplicationInsightsUtil as AIUtil
 
 ExtensionShortName = 'LinuxAzureDiagnostic'
+ExtensionFullName = 'Microsoft.OSTCExtensions.LinuxDiagnostic'
+ExtensionVersion = '2.3.9001'   # Must be updated on each new release! Improve this!
 WorkDir = os.getcwd()
 MDSDPidFile = os.path.join(WorkDir, 'mdsd.pid')
 OutputSize = 1024
 EnableSyslog = True
 waagent.LoggerInit('/var/log/waagent.log','/dev/stdout')
 waagent.Log("%s started to handle." %(ExtensionShortName))
-hutil = Util.HandlerUtility(waagent.Log, waagent.Error, ExtensionShortName)
+hutil = Util.HandlerUtility(waagent.Log, waagent.Error, ExtensionShortName, ExtensionFullName, ExtensionVersion)
 hutil.try_parse_context()
 public_settings = hutil.get_public_settings()
 private_settings = hutil.get_protected_settings()
@@ -83,7 +85,7 @@ DebianConfig = {"installomi":"bash "+omi_universal_pkg_name+" --upgrade --force;
 
 RedhatConfig =  {"installomi":"bash "+omi_universal_pkg_name+" --upgrade --force;",
                  "installrequiredpackage":'rpm -q PACKAGE ;  if [ ! $? == 0 ]; then yum install -y PACKAGE; fi',
-                 "packages":('tar','policycoreutils-python'),
+                 "packages":(),
                  "restartrsyslog":"service rsyslog restart",
                  'checkrsyslog':'(rpm -qi rsyslog;rpm -ql rsyslog)|grep "Version\\|'+rsyslog_ommodule_for_check+'"',
                  'mdsd_env_vars': {"SSL_CERT_DIR": "/etc/pki/tls/certs", "SSL_CERT_FILE": "/etc/pki/tls/cert.pem"}
@@ -165,7 +167,7 @@ def getChildNode(p,tag):
            return node
 
 def parse_context(operation):
-    hutil = Util.HandlerUtility(waagent.Log, waagent.Error, ExtensionShortName)
+    hutil = Util.HandlerUtility(waagent.Log, waagent.Error, ExtensionShortName, ExtensionFullName, ExtensionVersion)
     hutil.try_parse_context()
     return
 
@@ -297,7 +299,6 @@ def createPerfSettngs(tree,perfs,forAI=False):
         perfElement.set('omiNamespace',namespace)
         if forAI:
             AIUtil.updateOMIQueryElement(perfElement)
-        XmlUtil.addElement(tree,'Events/OMI',perfElement,["omitag","perf"])
 
 # Updates the MDSD configuration Account elements.
 # Updates existing default Account element with Azure table storage properties.


### PR DESCRIPTION
- Remove unused XML attribute to avoid unnecessary mdsd warning
- Remove unnecessary dependency installation
- Report proper extension version in logs (addressing Issue #140)

@LiweiPeng : Please review this for Issue #140 and other issues you raised (the mdsd warning).

@ahmetalpbalkan : This applies to LAD only (because LAD's Utils directory is forked before we took over), so this change doesn't directly address #143, but I suppose a similar approach could be applied there. Note that each extension's HandlerUtility instantiation calls will need to be updated, which I suppose we should be very careful about... Also I still don't like the fact that the extension's version is hard-coded in the script, but I couldn't find the version string from anywhere else. Let me know if you know about this. Thanks.