### PR TITLE
Simple Makefile to build extensions.

### DIFF
--- a/CustomScript/.gitignore
+++ b/CustomScript/.gitignore
@@ -1,2 +1,0 @@
-test/blob.py
-test/blob_mooncake.py

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+default: clean build
+
+EXTENSIONS = \
+ 	CustomScript \
+ 	DSC \
+ 	OSPatching \
+	VMBackup
+
+clean:
+	rm -f build/*.zip
+
+build: $(EXTENSIONS)
+
+$(EXTENSIONS):
+	$(eval NAME    = $(shell grep -Pom1 "(?<=<Type>)[^<]+" $@/manifest.xml))
+	$(eval VERSION = $(shell grep -Pom1 "(?<=<Version>)[^<]+" $@/manifest.xml))
+
+	@echo "Building '$(NAME)-$(VERSION).zip' ..."
+	@cd $@ && find . -type f | grep -v "/test/" | grep -v "./references" | zip -9 -@ ../build/$(NAME)-$(VERSION).zip > /dev/null
+	@find ./Utils    -type f | grep -v "/test/"                          | zip -9 -@ build/$(NAME)-$(VERSION).zip > /dev/null
+
+.PHONY: clean build $(EXTENSIONS)


### PR DESCRIPTION
Use the version and type (name) from an extension's manifest.xml to
create an extension's zip archive.

Support building with directories that contain whitespace.