### PR TITLE
CentOS 6.8 support in RDMAUpdate, VMBackup, and VMEncryption extensions.

### DIFF
--- a/RDMAUpdate/main/patch/centosPatching.py
+++ b/RDMAUpdate/main/patch/centosPatching.py
@@ -36,7 +36,7 @@ class centosPatching(redhatPatching):
     def __init__(self,logger,distro_info):
         super(centosPatching,self).__init__(logger,distro_info)
         self.logger = logger
-        if(distro_info[1] == "6.7" or distro_info[1] == "6.6" or distro_info[1] == "6.5"):
+        if(distro_info[1] == "6.8" or distro_info[1] == "6.7" or distro_info[1] == "6.6" or distro_info[1] == "6.5"):
             self.base64_path = '/usr/bin/base64'
             self.bash_path = '/bin/bash'
             self.blkid_path = '/sbin/blkid'

--- a/VMBackup/main/patch/centosPatching.py
+++ b/VMBackup/main/patch/centosPatching.py
@@ -36,7 +36,7 @@ class centosPatching(redhatPatching):
     def __init__(self,logger,distro_info):
         super(centosPatching,self).__init__(logger,distro_info)
         self.logger = logger
-        if(distro_info[1] == "6.7" or distro_info[1] == "6.6" or distro_info[1] == "6.5"):
+        if(distro_info[1] == "6.8" or distro_info[1] == "6.7" or distro_info[1] == "6.6" or distro_info[1] == "6.5"):
             self.base64_path = '/usr/bin/base64'
             self.bash_path = '/bin/bash'
             self.blkid_path = '/sbin/blkid'

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -554,7 +554,7 @@ def encrypt_inplace_without_seperate_header_file(passphrase_file, device_item, d
         if(current_phase == CommonVariables.EncryptionPhaseBackupHeader):
             logger.log(msg=("the current phase is " + str(CommonVariables.EncryptionPhaseBackupHeader)), level = CommonVariables.InfoLevel)
             if(not ongoing_item_config.get_file_system().lower() in ["ext2", "ext3", "ext4"]):
-                logger.log(msg = "we only support ext file systems for centos 6.5/6.6/6.7 and redhat 6.7", level = CommonVariables.WarningLevel)
+                logger.log(msg = "we only support ext file systems for centos 6.5/6.6/6.7/6.8 and redhat 6.7", level = CommonVariables.WarningLevel)
                 ongoing_item_config.clear_config()
                 return current_phase
 

--- a/VMEncryption/main/patch/centosPatching.py
+++ b/VMEncryption/main/patch/centosPatching.py
@@ -36,7 +36,7 @@ class centosPatching(redhatPatching):
     def __init__(self,logger,distro_info):
         super(centosPatching,self).__init__(logger,distro_info)
         self.logger = logger
-        if(distro_info[1] == "6.7" or distro_info[1] == "6.6" or distro_info[1] == "6.5"):
+        if(distro_info[1] == "6.8" or distro_info[1] == "6.7" or distro_info[1] == "6.6" or distro_info[1] == "6.5"):
             self.base64_path = '/usr/bin/base64'
             self.bash_path = '/bin/bash'
             self.blkid_path = '/sbin/blkid'


### PR DESCRIPTION
Attempting to use Azure Recovery Services Vault with our OpenLogic-based CentOS 6.8 VMs (updated from the 6.7 marketplace images), we traced a failure back to the `centosPatching.py` file in the VMBackup extension. This file maps paths of specific command line utilities used by the extension, and already differentiates CentOS 6.5, 6.6, and 6.7, but since 6.8 was not included, mapped these paths on the last version incorrectly. This ultimately led to an inability to back the VM up via Azure Recovery Services Vault due to a failure to be able to interact with the necessary command line utilities. In the process of resolving this issue for VMBackup, we also noticed that RDMAUpdate and VMEncryption had similar problems, and decided to resolve those too.