### PR TITLE
Update to script timeout execution

### DIFF
--- a/CustomScript/README.md
+++ b/CustomScript/README.md
@@ -13,7 +13,7 @@ CustomScript Extension can:
 * Remove BOM in Shell and Python scripts automatically
 * Protect sensitive data in `commandToExecute`
 
-**Note:** The timeout for script download is 200 seconds. There is no timeout period for script execution.
+**Note:** The timeout for script download is 200 seconds. There is a 90-minute timeout period for script execution.”.
 
 # User Guide
 


### PR DESCRIPTION
Per CSS, the script timeout execution period is 90-minutes. There is an active support request where custom is encountering this issue and is referring to this doc which states there is no timeout period. Jarrett Renshaw can provide specifics to SR if required.
