### PR TITLE
vmaccess: backup sshd_config and restart SSHD

### DIFF
--- a/VMAccess/CHANGELOG.md
+++ b/VMAccess/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.4.2.0 (2016-08-25)
 - Ensure expiration (if specified) is used when creating an account
+- Backup sshd_config before any edits are made.
+- Ensure sshd_config is restarted when edits are made.
 
 ## 1.4.1.0 (2016-07-27)
 - Install operation posts incorrect status [#206]

--- a/VMAccess/vmaccess.py
+++ b/VMAccess/vmaccess.py
@@ -34,7 +34,7 @@ ExtensionShortName = 'VMAccess'
 BeginCertificateTag = '-----BEGIN CERTIFICATE-----'
 EndCertificateTag = '-----END CERTIFICATE-----'
 OutputSplitter = ';'
-
+SshdConfigPath = '/etc/ssh/sshd_config'
 
 def main():
     waagent.LoggerInit('/var/log/waagent.log', '/dev/stdout')
@@ -81,21 +81,32 @@ def enable():
             hutil.log("Succeeded in check and open ssh port.")
 
         hutil.exit_if_enabled()
+        if _is_sshd_config_modified(protect_settings):
+            _backup_sshd_config(SshdConfigPath)
 
         if reset_ssh:
-            _reset_sshd_config("/etc/ssh/sshd_config")
+            _reset_sshd_config(SshdConfigPath)
             hutil.log("Succeeded in reset sshd_config.")
+
         if remove_user:
             _remove_user_account(remove_user, hutil)
+
         _set_user_account_pub_key(protect_settings, hutil)
 
-        check_and_repair_disk(hutil)
+        if _is_sshd_config_modified(protect_settings):
+            waagent.MyDistro.restartSshService()
 
+        check_and_repair_disk(hutil)
         hutil.do_exit(0, 'Enable', 'success', '0', 'Enable succeeded.')
     except Exception as e:
         hutil.error(("Failed to enable the extension with error: {0}, "
             "stack trace: {1}").format(str(e), traceback.format_exc()))
         hutil.do_exit(1, 'Enable', 'error', '0', 'Enable failed.')
+
+
+def _is_sshd_config_modified(protected_settings):
+    result = protected_settings.get('reset_ssh') or protected_settings.get('password')
+    return result is not None
 
 
 def uninstall():
@@ -112,7 +123,7 @@ def disable():
 
 def update():
     hutil = Util.HandlerUtility(waagent.Log, waagent.Error)
-    hutil.do_parse_context('Upadate')
+    hutil.do_parse_context('Update')
     hutil.do_exit(0, 'Update', 'success', '0', 'Update Succeeded')
 
 
@@ -172,7 +183,7 @@ def _set_user_account_pub_key(protect_settings, hutil):
             pub_path = os.path.join('/home/', user_name, '.ssh',
                 'authorized_keys')
             ovf_env.UserName = user_name
-            if(no_convert):
+            if no_convert:
                 if cert_txt:
                     pub_path = ovf_env.PrepareDir(pub_path)
                     final_cert_txt = cert_txt
@@ -237,11 +248,10 @@ def _save_other_sudoers(sudoers):
 
 
 def _allow_password_auth():
-    configPath = '/etc/ssh/sshd_config'
-    config = waagent.GetFileContents(configPath).split("\n")
+    config = waagent.GetFileContents(SshdConfigPath).split("\n")
     _set_sshd_config(config, "PasswordAuthentication", "yes")
     _set_sshd_config(config, "ChallengeResponseAuthentication", "yes")
-    waagent.ReplaceFileContentsAtomic(configPath, "\n".join(config))
+    waagent.ReplaceFileContentsAtomic(SshdConfigPath, "\n".join(config))
 
 
 def _set_sshd_config(config, name, val):
@@ -267,7 +277,6 @@ def _reset_sshd_config(sshd_file_path):
         config_file_path = os.path.join(os.getcwd(), 'resources', '%s_%s' % (distro_name, 'default'))
         if not(os.path.exists(config_file_path)):
             config_file_path = os.path.join(os.getcwd(), 'resources', 'default')
-    _backup_sshd_config(sshd_file_path)
 
     if distro_name == "CoreOS":
         # Parse sshd port from config_file_path


### PR DESCRIPTION
If the user specifies a password, then VMAccess must ensure password
authentication will be accepted by SSHD.  In this case, the code failed
to backup sshd_config, and failed to restart the daemon to ensure the
config change took effect.