### PR TITLE
Handle missing DeploymentId gracefully (don't add as IdentityComponent)

### DIFF
--- a/Diagnostic/diagnostic.py
+++ b/Diagnostic/diagnostic.py
@@ -423,9 +423,10 @@ def configSettings():
     mdsdCfg = ET.ElementTree()
     mdsdCfg._setroot(XmlUtil.createElement(mdsdCfgstr))
 
-    # update deployment id
+    # Add DeploymentId (if available) to identity columns
     deployment_id = get_deployment_id()
-    XmlUtil.setXmlValue(mdsdCfg, "Management/Identity/IdentityComponent", "", deployment_id, ["name", "DeploymentId"])
+    if deployment_id:
+        XmlUtil.setXmlValue(mdsdCfg, "Management/Identity/IdentityComponent", "", deployment_id, ["name", "DeploymentId"])
 
     try:
         resourceId = getResourceId()
@@ -1121,6 +1122,10 @@ def tail(log_file, output_size = OutputSize):
 def get_deployment_id():
     identity = "unknown"
     env_cfg_path = os.path.join(WorkDir, os.pardir, "HostingEnvironmentConfig.xml")
+    if not os.path.exists(env_cfg_path):
+        hutil.log("No Deployment ID (not running in a hosted environment")
+        return None
+
     try:
         with open(env_cfg_path, 'r') as env_cfg_file:
             xml_text = env_cfg_file.read()


### PR DESCRIPTION
If running in a non-hosted environment, the HostingEnvironmentConfig.xml file will be unavailable, which means the DeploymentId is unavailable (and almost certainly irrelevant). Rather than throwing an error, just skip adding the DeploymentId as an IdentityComponent in the mdsd config (i.e. don't bother adding it as an extra column present in every table row driven by portal configuration).