### PR TITLE
vmaccess: None check for password

### DIFF
--- a/VMAccess/CHANGELOG.md
+++ b/VMAccess/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.5.0 (2016-09-07)
+- Check for None before checking the lenght of a user's password.  This is 
+  fallout from allowing and rejecting empty passwords.
+
 ## 1.4.4.0 (2016-09-06)
 - Do not set ChallengeResponseAuthenticaiton.  This value should not
   be changed by VMAccess.

--- a/VMAccess/manifest.xml
+++ b/VMAccess/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.OSTCExtensions</ProviderNameSpace>
   <Type>VMAccessForLinux</Type>
-  <Version>1.4.4.0</Version>
+  <Version>1.4.5.0</Version>
   <Label>Microsoft Azure VM Access Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>

--- a/VMAccess/vmaccess.py
+++ b/VMAccess/vmaccess.py
@@ -156,7 +156,7 @@ def _set_user_account_pub_key(protect_settings, hutil):
     if not user_pass and not cert_txt and not ovf_env.SshPublicKeys:
         raise Exception("No password or ssh_key is specified.")
 
-    if len(user_pass) == 0:
+    if user_pass is not None and len(user_pass) == 0:
         user_pass = None
         hutil.log("empty passwords are not allowed, ignoring password reset")
 


### PR DESCRIPTION
Now that VMAccess accepts a empty password, and ignores it the old and
expected behavior of not passing it in the first place must still be
honored.