### PR TITLE
[LAD] Move installing rsyslog components later to prevent premature return

### DIFF
--- a/Diagnostic/diagnostic.py
+++ b/Diagnostic/diagnostic.py
@@ -194,12 +194,6 @@ def setup_dependencies_and_mdsd():
         hutil.error(install_package_error)
         return 2, install_package_error
 
-    if EnableSyslog:
-        error, msg = install_rsyslogom()
-        if error != 0:
-            hutil.error(msg)
-            return 3, msg
-
     # Run mdsd prep commands
     if 'mdsd_prep_cmds' in distConfig:
         for cmd in distConfig['mdsd_prep_cmds']:
@@ -208,7 +202,13 @@ def setup_dependencies_and_mdsd():
     # Install/start OMI
     omi_err, omi_msg = install_omi()
     if omi_err is not 0:
-        return 4, omi_msg
+        return 3, omi_msg
+
+    if EnableSyslog:
+        error, msg = install_rsyslogom()
+        if error != 0:
+            hutil.error(msg)
+            return 4, msg
 
     return 0, 'success'
 


### PR DESCRIPTION
Attempts to install the diagnostics extension via the portal (Select VM -> Diagnostic settings -> select storage account & check "Basic metrics" -> Status = On -> Save) onto a Linux VM that does _not_ have rsyslog installed returns prematurely resulting in an incomplete and non-functioning installation of the extension as OMI isn't installed and started resulting in problems starting `mdsd` too.

<details>
<summary><code>extension.log</code> failure excerpt</summary>

```
2016/11/02 21:49:36 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] sequence number is 0
2016/11/02 21:49:36 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] setting file path is/var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011/config/0.settings
2016/11/02 21:49:36 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] JSON config: {
2016/11/02 21:49:36   "runtimeSettings": [
2016/11/02 21:49:36     {
2016/11/02 21:49:36       "handlerSettings": {
2016/11/02 21:49:36         "protectedSettingsCertThumbprint": "[REDACTED]",
2016/11/02 21:49:36         "protectedSettings": "[REDACTED]",
2016/11/02 21:49:36         "publicSettings": {"StorageAccount":"[REDACTED]","xmlCfg":"[REDACTED]"}
2016/11/02 21:49:36       }
2016/11/02 21:49:36     }
2016/11/02 21:49:36   ]
2016/11/02 21:49:36 }
2016/11/02 21:49:36 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Config decoded correctly.
2016/11/02 21:49:36 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Disable verbose log
2016/11/02 21:49:36 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Deployment ID found: f6e3a991-69a5-42ea-956e-373020f1dcf4.
2016/11/02 21:49:36 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Application Insights key not found.
2016/11/02 21:49:36 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Keys in privateSettings (and some non-secret values): storageAccountName, storageAccountKey, storageAccountEndPoint:https://core.windows.net
2016/11/02 21:49:36 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Event volume not found in config. Using default value: Medium
2016/11/02 21:49:36 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Dispatching command:-install
2016/11/02 21:49:36 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Install,success,0,Install succeeded
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] sequence number is 0
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] setting file path is/var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011/config/0.settings
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] JSON config: {
2016/11/02 21:49:41   "runtimeSettings": [
2016/11/02 21:49:41     {
2016/11/02 21:49:41       "handlerSettings": {
2016/11/02 21:49:41         "protectedSettingsCertThumbprint": "[REDACTED]",
2016/11/02 21:49:41         "protectedSettings": "[REDACTED]",
2016/11/02 21:49:41         "publicSettings": {"StorageAccount":"[REDACTED]","xmlCfg":"[REDACTED]"}
2016/11/02 21:49:41       }
2016/11/02 21:49:41     }
2016/11/02 21:49:41   ]
2016/11/02 21:49:41 }
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Config decoded correctly.
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Disable verbose log
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Deployment ID found: f6e3a991-69a5-42ea-956e-373020f1dcf4.
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Application Insights key not found.
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Keys in privateSettings (and some non-secret values): storageAccountName, storageAccountKey, storageAccountEndPoint:https://core.windows.net
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Event volume not found in config. Using default value: Medium
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Dispatching command:-enable
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] get pid:[]
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] start daemon ['python', '/var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011/diagnostic.py', '-daemon']
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] sequence number is 0
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] setting file path is/var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011/config/0.settings
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] JSON config: {
2016/11/02 21:49:41   "runtimeSettings": [
2016/11/02 21:49:41     {
2016/11/02 21:49:41       "handlerSettings": {
2016/11/02 21:49:41         "protectedSettingsCertThumbprint": "[REDACTED]",
2016/11/02 21:49:41         "protectedSettings": "[REDACTED]",
2016/11/02 21:49:41         "publicSettings": {"StorageAccount":"[REDACTED]","xmlCfg":"[REDACTED]"}
2016/11/02 21:49:41       }
2016/11/02 21:49:41     }
2016/11/02 21:49:41   ]
2016/11/02 21:49:41 }
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Config decoded correctly.
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Disable verbose log
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Deployment ID found: f6e3a991-69a5-42ea-956e-373020f1dcf4.
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Application Insights key not found.
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Keys in privateSettings (and some non-secret values): storageAccountName, storageAccountKey, storageAccountEndPoint:https://core.windows.net
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Event volume not found in config. Using default value: Medium
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Dispatching command:-daemon
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011]
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] RunCmd (dpkg-query -s rsyslog;dpkg-query -L rsyslog) |grep "Version\|omprog.so"
2016/11/02 21:49:41 ERROR:CalledProcessError.  Error Code is 1
2016/11/02 21:49:41 ERROR:CalledProcessError.  Command string was (dpkg-query -s rsyslog;dpkg-query -L rsyslog) |grep "Version\|omprog.so"
2016/11/02 21:49:41 ERROR:CalledProcessError.  Command result was dpkg-query: package 'rsyslog' is not installed and no information is available
2016/11/02 21:49:41 ERROR:Use dpkg --info (= dpkg-deb --info) to examine archive files,
2016/11/02 21:49:41 ERROR:and dpkg --contents (= dpkg-deb --contents) to list their contents.
2016/11/02 21:49:41 ERROR:dpkg-query: package 'rsyslog' is not installed
2016/11/02 21:49:41 ERROR:Use dpkg --info (= dpkg-deb --info) to examine archive files,
2016/11/02 21:49:41 ERROR:and dpkg --contents (= dpkg-deb --contents) to list their contents.
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Return 1:dpkg-query: package 'rsyslog' is not installed and no information is available
2016/11/02 21:49:41 Use dpkg --info (= dpkg-deb --info) to examine archive files,
2016/11/02 21:49:41 and dpkg --contents (= dpkg-deb --contents) to list their contents.
2016/11/02 21:49:41 dpkg-query: package 'rsyslog' is not installed
2016/11/02 21:49:41 Use dpkg --info (= dpkg-deb --info) to examine archive files,
2016/11/02 21:49:41 and dpkg --contents (= dpkg-deb --contents) to list their contents.
2016/11/02 21:49:41
2016/11/02 21:49:41 ERROR:[Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] rsyslog not installed
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] RunCmd /opt/omi/bin/service_control is-running
2016/11/02 21:49:41 ERROR:CalledProcessError.  Error Code is 127
2016/11/02 21:49:41 ERROR:CalledProcessError.  Command string was /opt/omi/bin/service_control is-running
2016/11/02 21:49:41 ERROR:CalledProcessError.  Command result was /bin/sh: 1: /opt/omi/bin/service_control: not found
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Return 127:/bin/sh: 1: /opt/omi/bin/service_control: not found
2016/11/02 21:49:41
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] RunCmd /opt/omi/bin/service_control restart
2016/11/02 21:49:41 ERROR:CalledProcessError.  Error Code is 127
2016/11/02 21:49:41 ERROR:CalledProcessError.  Command string was /opt/omi/bin/service_control restart
2016/11/02 21:49:41 ERROR:CalledProcessError.  Command result was /bin/sh: 1: /opt/omi/bin/service_control: not found
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Return 127:/bin/sh: 1: /opt/omi/bin/service_control: not found
2016/11/02 21:49:41
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] RunCmd /var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011/bin/mdsd -v -c /var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011/./xmlCfg.xml
2016/11/02 21:49:41 ERROR:CalledProcessError.  Error Code is 127
2016/11/02 21:49:41 ERROR:CalledProcessError.  Command string was /var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011/bin/mdsd -v -c /var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011/./xmlCfg.xml
2016/11/02 21:49:41 ERROR:CalledProcessError.  Command result was /var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011/bin/mdsd: error while loading shared libraries: libmicxx.so: cannot open shared object file: No such file or directory
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Return 127:/var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011/bin/mdsd: error while loading shared libraries: libmicxx.so: cannot open shared object file: No such file or directory
2016/11/02 21:49:41
2016/11/02 21:49:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Invalid mdsd config given. Can't enable. This extension install/enable operation is still considered a success as it's an external error. Config validation result: /var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011/bin/mdsd: error while loading shared libraries: libmicxx.so: cannot open shared object file: No such file or directory
2016/11/02 21:49:41 . Terminating LAD as it can't proceed.
2016/11/02 21:49:51 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] return not alive cat: /proc/27950/cmdline: No such file or directory
2016/11/02 21:50:01 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] return not alive cat: /proc/27950/cmdline: No such file or directory
2016/11/02 21:50:11 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] return not alive cat: /proc/27950/cmdline: No such file or directory
2016/11/02 21:50:21 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] return not alive cat: /proc/27950/cmdline: No such file or directory
2016/11/02 21:50:31 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] return not alive cat: /proc/27950/cmdline: No such file or directory
2016/11/02 21:50:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] return not alive cat: /proc/27950/cmdline: No such file or directory
2016/11/02 21:50:51 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] return not alive cat: /proc/27950/cmdline: No such file or directory
2016/11/02 21:51:01 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] return not alive cat: /proc/27950/cmdline: No such file or directory
2016/11/02 21:51:11 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] return not alive cat: /proc/27950/cmdline: No such file or directory
2016/11/02 21:51:21 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] return not alive cat: /proc/27950/cmdline: No such file or directory
2016/11/02 21:51:31 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] return not alive cat: /proc/27950/cmdline: No such file or directory
2016/11/02 21:51:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] return not alive cat: /proc/27950/cmdline: No such file or directory
2016/11/02 21:51:51 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] return not alive cat: /proc/27950/cmdline: No such file or directory
2016/11/02 21:52:01 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] return not alive cat: /proc/27950/cmdline: No such file or directory
2016/11/02 21:52:11 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] return not alive cat: /proc/27950/cmdline: No such file or directory
2016/11/02 21:52:21 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] return not alive cat: /proc/27950/cmdline: No such file or directory
2016/11/02 21:52:31 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] return not alive cat: /proc/27950/cmdline: No such file or directory
2016/11/02 21:52:41 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] return not alive cat: /proc/27950/cmdline: No such file or directory
2016/11/02 21:52:51 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] return not alive cat: /proc/27950/cmdline: No such file or directory
2016/11/02 21:53:01 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] return not alive cat: /proc/27950/cmdline: No such file or directory
2016/11/02 21:53:01 ERROR:[Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] wait daemon start time out
2016/11/02 21:53:01 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Enable,success,0,Enable succeeded
```
  
</details><br>

I'd say that last line is very misleading as no attempt has been made to install OMI which in turn results in problems with `mdsd` starting which in turn results in no metrics reporting at all effectively rendering the installation of the extension useless and technically a failure, but I'll leave that judgment call to those more au fait with the product.

This isn't the case if you explicitly disable syslog by installing the extension via the CLI using a `public.json` file that disables syslog as it bypasses this section entirely.  This however comes as the cost that you can't view your statistics in the portal as [documented](https://github.com/Azure/azure-linux-extensions/tree/master/Diagnostic#important-notice).

As rsyslog is _not_ a required component, the failure to locate it or install the necessary output modules should not affect the installation of the rest of the components.  Rather than removing the `return 3, msg` line I've gone with moving the installation of the rsyslog output module and configuration files to _after_ all of the required components so if there are any problems with installing the rsyslog components, it doesn't affect the other "required" components whilst still allowing the return code and message to bubble up.

With this change in place, the extension successfully installs everything except the rsyslog components, as expected:

<details>
<summary><code>extension.log</code> success excerpt</summary>

```
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] sequence number is 2
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] setting file path is/var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011/config/2.settings
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] JSON config: {
2016/11/02 22:07:30   "runtimeSettings": [
2016/11/02 22:07:30     {
2016/11/02 22:07:30       "handlerSettings": {
2016/11/02 22:07:30         "protectedSettingsCertThumbprint": "[REDACTED]",
2016/11/02 22:07:30         "protectedSettings": "[REDACTED]",
2016/11/02 22:07:30         "publicSettings": {"StorageAccount":"[REDACTED]","xmlCfg":"[REDACTED]"}
2016/11/02 22:07:30       }
2016/11/02 22:07:30     }
2016/11/02 22:07:30   ]
2016/11/02 22:07:30 }
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Config decoded correctly.
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Disable verbose log
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Deployment ID found: f6e3a991-69a5-42ea-956e-373020f1dcf4.
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Application Insights key not found.
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Keys in privateSettings (and some non-secret values): storageAccountName, storageAccountKey, storageAccountEndPoint:https://core.windows.net
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Event volume not found in config. Using default value: Medium
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Dispatching command:-enable
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] return not alive cat: /proc/29351/cmdline: No such file or directory
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] get pid:[]
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] return not alive cat: /proc/29351/cmdline: No such file or directory
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] start daemon ['python', '/var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011/diagnostic.py', '-daemon']
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] return not alive cat: /proc/29351/cmdline: No such file or directory
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] sequence number is 2
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] setting file path is/var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011/config/2.settings
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] JSON config: {
2016/11/02 22:07:30   "runtimeSettings": [
2016/11/02 22:07:30     {
2016/11/02 22:07:30       "handlerSettings": {
2016/11/02 22:07:30         "protectedSettingsCertThumbprint": "[REDACTED]",
2016/11/02 22:07:30         "protectedSettings": "[REDACTED]",
2016/11/02 22:07:30         "publicSettings": {"StorageAccount":"[REDACTED]","xmlCfg":"[REDACTED]"}
2016/11/02 22:07:30       }
2016/11/02 22:07:30     }
2016/11/02 22:07:30   ]
2016/11/02 22:07:30 }
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Config decoded correctly.
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Disable verbose log
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Deployment ID found: f6e3a991-69a5-42ea-956e-373020f1dcf4.
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Application Insights key not found.
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Keys in privateSettings (and some non-secret values): storageAccountName, storageAccountKey, storageAccountEndPoint:https://core.windows.net
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Event volume not found in config. Using default value: Medium
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Dispatching command:-daemon
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011]
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] RunCmd which mysql
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Return 0:/usr/bin/mysql
2016/11/02 22:07:30
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] RunCmd which apache2 || which httpd || which httpd2
2016/11/02 22:07:30 ERROR:CalledProcessError.  Error Code is 1
2016/11/02 22:07:30 ERROR:CalledProcessError.  Command string was which apache2 || which httpd || which httpd2
2016/11/02 22:07:30 ERROR:CalledProcessError.  Command result was
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Return 1:
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] RunCmd /opt/omi/bin/omiserver -v
2016/11/02 22:07:30 ERROR:CalledProcessError.  Error Code is 127
2016/11/02 22:07:30 ERROR:CalledProcessError.  Command string was /opt/omi/bin/omiserver -v
2016/11/02 22:07:30 ERROR:CalledProcessError.  Command result was /bin/sh: 1: /opt/omi/bin/omiserver: not found
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Return 127:/bin/sh: 1: /opt/omi/bin/omiserver: not found
2016/11/02 22:07:30
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Begin omi installation.
2016/11/02 22:07:30 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] RunCmd bash scx-1.6.2-241.universal.x64.sh --upgrade;
2016/11/02 22:07:33 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Return 0:Extracting...
2016/11/02 22:07:33 Updating cross-platform agent ...
2016/11/02 22:07:33 ----- Installing package: omi (omi-1.0.8-4.universal.x64) -----
2016/11/02 22:07:33 Selecting previously unselected package omi.
2016/11/02 22:07:33 (Reading database ... 178831 files and directories currently installed.)
2016/11/02 22:07:33 Preparing to unpack .../omi-1.0.8-4.universal.x64.deb ...
2016/11/02 22:07:33 Unpacking omi (1.0.8.4) ...
2016/11/02 22:07:33 Setting up omi (1.0.8.4) ...
2016/11/02 22:07:33 Generating a 2048 bit RSA private key
2016/11/02 22:07:33 ..................................................+++
2016/11/02 22:07:33 ......................................................................+++
2016/11/02 22:07:33 unable to write 'random state'
2016/11/02 22:07:33 writing new private key to '/etc/opt/omi/ssl/omikey.pem'
2016/11/02 22:07:33 -----
2016/11/02 22:07:33 Configuring OMI service ...
2016/11/02 22:07:33 Created symlink from /etc/systemd/system/multi-user.target.wants/omid.service to /usr/lib/systemd/system/omid.service.
2016/11/02 22:07:33 Processing triggers for systemd (215-17+deb8u5) ...
2016/11/02 22:07:33 ----- Updating package: scx (scx-1.6.2-241.universal.x64) -----
2016/11/02 22:07:33 Selecting previously unselected package scx.
2016/11/02 22:07:33 (Reading database ... 178867 files and directories currently installed.)
2016/11/02 22:07:33 Preparing to unpack .../scx-1.6.2-241.universal.x64.deb ...
2016/11/02 22:07:33 Unpacking scx (1.6.2.241) ...
2016/11/02 22:07:33 Setting up scx (1.6.2.241) ...
2016/11/02 22:07:33 Generating certificate with hostname="13-68-119-121"
2016/11/02 22:07:33
2016/11/02 22:07:33 WARNING!
2016/11/02 22:07:33 Could not read 256 bytes of random data from /dev/random. Will revert to less secure /dev/urandom.
2016/11/02 22:07:33 See the security guide for how to regenerate certificates at a later time when more random data might be available.
2016/11/02 22:07:33
2016/11/02 22:07:33 ----- Updating bundled packages -----
2016/11/02 22:07:33 Checking if Apache is installed ...
2016/11/02 22:07:33   Apache not found, will not install
2016/11/02 22:07:33 Checking if MySQL is installed ...
2016/11/02 22:07:33   MySQL not found, will not install
2016/11/02 22:07:33
2016/11/02 22:07:33 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] RunCmd grep '^\s*httpsport\s*=' /etc/opt/omi/conf/omiserver.conf | grep -v '^\s*httpsport\s*=\s*0\s*$'
2016/11/02 22:07:33 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Return 0:httpsport=0,1270
2016/11/02 22:07:33
2016/11/02 22:07:33 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] RunCmd /opt/omi/bin/omiconfigeditor httpsport -s 0 < /etc/opt/omi/conf/omiserver.conf > /etc/opt/omi/conf/omiserver.conf_temp
2016/11/02 22:07:33 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Return 0:
2016/11/02 22:07:33 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] RunCmd mv /etc/opt/omi/conf/omiserver.conf_temp /etc/opt/omi/conf/omiserver.conf
2016/11/02 22:07:33 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Return 0:
2016/11/02 22:07:33 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] RunCmd ps -ef | grep mysql | grep -v grep
2016/11/02 22:07:33 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Return 0:root     14204     1  0 21:47 ?        00:00:00 /bin/sh /usr/bin/mysqld_safe
2016/11/02 22:07:33 mysql    15074 14204  0 21:47 ?        00:00:11 /usr/sbin/mysqld --basedir=/usr --datadir=/data/user/mysql --plugin-dir=/usr/lib/mysql/plugin --user=mysql --log-error=/var/log/mysql/mysql.err --pid-file=/var/run/mysqld/mysqld.pid --socket=/var/run/mysqld/mysqld.sock --port=3306
2016/11/02 22:07:33
2016/11/02 22:07:33 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] RunCmd ps -ef | grep -E 'httpd|apache2' | grep -v grep
2016/11/02 22:07:33 ERROR:CalledProcessError.  Error Code is 1
2016/11/02 22:07:33 ERROR:CalledProcessError.  Command string was ps -ef | grep -E 'httpd|apache2' | grep -v grep
2016/11/02 22:07:33 ERROR:CalledProcessError.  Command result was
2016/11/02 22:07:33 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Return 1:
2016/11/02 22:07:33 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] RunCmd /opt/omi/bin/service_control restart
2016/11/02 22:07:33 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Return 0:
2016/11/02 22:07:33 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] RunCmd (dpkg-query -s rsyslog;dpkg-query -L rsyslog) |grep "Version\|omprog.so"
2016/11/02 22:07:33 ERROR:CalledProcessError.  Error Code is 1
2016/11/02 22:07:33 ERROR:CalledProcessError.  Command string was (dpkg-query -s rsyslog;dpkg-query -L rsyslog) |grep "Version\|omprog.so"
2016/11/02 22:07:33 ERROR:CalledProcessError.  Command result was dpkg-query: package 'rsyslog' is not installed and no information is available
2016/11/02 22:07:33 ERROR:Use dpkg --info (= dpkg-deb --info) to examine archive files,
2016/11/02 22:07:33 ERROR:and dpkg --contents (= dpkg-deb --contents) to list their contents.
2016/11/02 22:07:33 ERROR:dpkg-query: package 'rsyslog' is not installed
2016/11/02 22:07:33 ERROR:Use dpkg --info (= dpkg-deb --info) to examine archive files,
2016/11/02 22:07:33 ERROR:and dpkg --contents (= dpkg-deb --contents) to list their contents.
2016/11/02 22:07:33 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Return 1:dpkg-query: package 'rsyslog' is not installed and no information is available
2016/11/02 22:07:33 Use dpkg --info (= dpkg-deb --info) to examine archive files,
2016/11/02 22:07:33 and dpkg --contents (= dpkg-deb --contents) to list their contents.
2016/11/02 22:07:33 dpkg-query: package 'rsyslog' is not installed
2016/11/02 22:07:33 Use dpkg --info (= dpkg-deb --info) to examine archive files,
2016/11/02 22:07:33 and dpkg --contents (= dpkg-deb --contents) to list their contents.
2016/11/02 22:07:33
2016/11/02 22:07:33 ERROR:[Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] rsyslog not installed
2016/11/02 22:07:33 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] RunCmd /opt/omi/bin/service_control is-running
2016/11/02 22:07:33 ERROR:CalledProcessError.  Error Code is 1
2016/11/02 22:07:33 ERROR:CalledProcessError.  Command string was /opt/omi/bin/service_control is-running
2016/11/02 22:07:33 ERROR:CalledProcessError.  Command result was
2016/11/02 22:07:33 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Return 1:
2016/11/02 22:07:33 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] RunCmd /var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011/bin/mdsd -v -c /var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011/./xmlCfg.xml
2016/11/02 22:07:33 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Return 0:Parse succeeded with no messages.
2016/11/02 22:07:33
2016/11/02 22:07:33 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] RunCmd rm -f /var/run/mdsd/lad_mdsd.pidport
2016/11/02 22:07:33 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Return 0:
2016/11/02 22:07:33 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Start mdsd ['/var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011/bin/mdsd', '-A', '-C', '-c', '/var/lib/waagent/Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011/./xmlCfg.xml', '-p', '29131', '-R', '-r', 'lad_mdsd', '-e', '/var/log/azure/Microsoft.OSTCExtensions.LinuxDiagnostic/2.3.9011/mdsd.err', '-w', '/var/log/azure/Microsoft.OSTCExtensions.LinuxDiagnostic/2.3.9011/mdsd.warn', '-o', '/var/log/azure/Microsoft.OSTCExtensions.LinuxDiagnostic/2.3.9011/mdsd.info']
2016/11/02 22:07:40 [Microsoft.OSTCExtensions.LinuxDiagnostic-2.3.9011] Enable,success,0,Enable succeeded
```

</details><br>

This has only been tested on Debian 8.5 (Jessie) with syslog-ng.  I wouldn't expect things to behave any differently on other operating systems _not_ running rsyslog though.
