### PR TITLE
fix the issue of failing to find sudoers.d/waagent on FreeBSD

### DIFF
--- a/VMAccess/vmaccess.py
+++ b/VMAccess/vmaccess.py
@@ -35,6 +35,10 @@ BeginCertificateTag = '-----BEGIN CERTIFICATE-----'
 EndCertificateTag = '-----END CERTIFICATE-----'
 OutputSplitter = ';'
 SshdConfigPath = '/etc/ssh/sshd_config'
+SudoersBaseDir = '/etc/sudoers.d'
+if not os.path.isdir(SudoersBaseDir):
+    ## sudoers.d folder on FreeBSD
+    SudoersBaseDir = '/usr/local/etc/sudoers.d'
 
 def main():
     waagent.LoggerInit('/var/log/waagent.log', '/dev/stdout')
@@ -251,7 +255,7 @@ def _set_user_account_pub_key(protect_settings, hutil):
 
 
 def _get_other_sudoers(userName):
-    sudoersFile = '/etc/sudoers.d/waagent'
+    sudoersFile = SudoersBaseDir + '/waagent'
     if not os.path.isfile(sudoersFile):
         return None
     sudoers = waagent.GetFileContents(sudoersFile).split("\n")
@@ -261,11 +265,11 @@ def _get_other_sudoers(userName):
 
 
 def _save_other_sudoers(sudoers):
-    sudoersFile = '/etc/sudoers.d/waagent'
+    sudoersFile = SudoersBaseDir + '/waagent'
     if sudoers is None:
         return
     waagent.AppendFileContents(sudoersFile, "\n".join(sudoers))
-    os.chmod("/etc/sudoers.d/waagent", 0o440)
+    os.chmod(sudoersFile, 0o440)
 
 
 def _allow_password_auth():


### PR DESCRIPTION
The phenomenon of this bug is: On FreeBSD, user cannot add a new user on portal through "reset password". If you specify a user name which is not existed, and specify the new password on the portal. The result is your existing user on VM cannot execute "sudo" because it was removed from sudoers.d/waagent.

The root cause is found:
On FreeBSD, the sudo was installed in /usr/local/, and the corresponding sudoers.d locates in /usr/local/etc/. So, the current _get_other_sudoers of vmaccess.py returns "None", but the corresponding waagent for FreeBSD can find the correct sudoers.d/waagent, and it sets a new user into that file, but vmaccess.py did not save the previous content. Thus, trigger this bug.

The patch fixes this issue.