### PR TITLE
[Handler] Stop using /tmp/kk when decrypting protectedSettings

### DIFF
--- a/Diagnostic/diagnostic.py
+++ b/Diagnostic/diagnostic.py
@@ -27,8 +27,6 @@ import traceback
 import xml.dom.minidom
 import xml.etree.ElementTree as ET
 import threading
-import logging
-
 import Utils.HandlerUtil as Util
 import Utils.LadDiagnosticUtil as LadUtil
 import Utils.XmlUtil as XmlUtil

--- a/Utils/HandlerUtil.py
+++ b/Utils/HandlerUtil.py
@@ -167,13 +167,12 @@ class HandlerUtility:
                 thumb=handlerSettings['protectedSettingsCertThumbprint']
                 cert=waagent.LibDir+'/'+thumb+'.crt'
                 pkey=waagent.LibDir+'/'+thumb+'.prv'
-                waagent.SetFileContents('/tmp/kk', protectedSettings)
-                cleartxt=None
-                cleartxt=waagent.RunGetOutput("base64 -d /tmp/kk | openssl smime  -inform DER -decrypt -recip " +  cert + "  -inkey " + pkey )[1]
-                os.remove("/tmp/kk")
+                unencodedSettings = base64.standard_b64decode(protectedSettings)
+                openSSLcmd = "openssl smime -inform DER -decrypt -recip {} -inkey {}"
+                cleartxt = waagent.RunSendStdin(openSSLcmd.format(cert, pkey), unencodedSettings)[1]
                 if cleartxt == None:
                     self.error("OpenSSh decode error using  thumbprint " + thumb )
-                    do_exit(1,operation,'error','1', operation + ' Failed')
+                    self.do_exit(1,"Enable",'error','1', 'Failed decrypting protectedSettings')
                 jctxt=''
                 try:
                     jctxt=json.loads(cleartxt)


### PR DESCRIPTION
This change (originally from @jasonzio) is to stop using /tmp/kk while decrypting protectedSettings. Since this affects all OSTC extensions, this needs to be reviewed separately by folks other than LAD devs. @boumenot , would you please add other people who should review this change as well? I'm asking you for this, thinking you'd know more people involved with the other OSTC extensions. Thanks.