### PR TITLE
[Handler] Fix /tmp/kk fix regression on Python 2.6

### DIFF
--- a/Utils/HandlerUtil.py
+++ b/Utils/HandlerUtil.py
@@ -168,7 +168,7 @@ class HandlerUtility:
                 cert=waagent.LibDir+'/'+thumb+'.crt'
                 pkey=waagent.LibDir+'/'+thumb+'.prv'
                 unencodedSettings = base64.standard_b64decode(protectedSettings)
-                openSSLcmd = "openssl smime -inform DER -decrypt -recip {} -inkey {}"
+                openSSLcmd = "openssl smime -inform DER -decrypt -recip {0} -inkey {1}"
                 cleartxt = waagent.RunSendStdin(openSSLcmd.format(cert, pkey), unencodedSettings)[1]
                 if cleartxt == None:
                     self.error("OpenSSh decode error using  thumbprint " + thumb )


### PR DESCRIPTION
/cc @boumenot @mbearup @krkhan 

Python 2.6 doesn't support zero-length format fields, so the previous fix (stop using /tmp/kk from protectedSettings decryption code path) fails on all Python 2.6-based distro versions (mostly RedHat 6-based).

Forgot to add a link to the relevant info: [http://stackoverflow.com/questions/21034954/valueerror-zero-length-field-name-in-format-in-python2-6-6](http://stackoverflow.com/questions/21034954/valueerror-zero-length-field-name-in-format-in-python2-6-6)