### PR TITLE
[LAD] Update memory leak threshold for current mdsd behavior

### DIFF
--- a/Diagnostic/ChangeLogs
+++ b/Diagnostic/ChangeLogs
@@ -1,4 +1,4 @@
-2017-01-08: LAD-2.3.9019
+2017-01-13: LAD-2.3.9021
     - Fix rsyslogd core dump issue when re-enabling the extension
     - Take latest mdsd binary that fixes other issues like missing perf
       counter logs when there's a race condition between mdsd and omiserver.

--- a/Diagnostic/diagnostic.py
+++ b/Diagnostic/diagnostic.py
@@ -701,10 +701,11 @@ def check_suspected_memory_leak(pid):
     memory_leak_suspected = False
 
     try:
-        # Check /proc/[pid]/status file for "VmSize" to find out the process's virtual memory usage
+        # Check /proc/[pid]/status file for "VmRSS" to find out the process's virtual memory usage
+        # Note: "VmSize" for some reason starts out very high (>2000000) at this moment, so can't use that.
         with open("/proc/{0}/status".format(pid)) as proc_file:
             for line in proc_file:
-                if line.startswith("VmSize:"):  # Example line: "VmSize:   33904 kB"
+                if line.startswith("VmRSS:"):  # Example line: "VmRSS:   33904 kB"
                     memory_usage_in_KB = int(line.split()[1])
                     memory_leak_suspected = memory_usage_in_KB > memory_leak_threshold_in_KB
                     break

--- a/Diagnostic/manifest.xml
+++ b/Diagnostic/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.OSTCExtensions</ProviderNameSpace>
   <Type>LinuxDiagnostic</Type>
-  <Version>2.3.9019</Version>
+  <Version>2.3.9021</Version>
   <Label>Microsoft Azure Diagnostic Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>


### PR DESCRIPTION
Current mdsd behavior is that its VmSize is already >2000000 even at the beginning, so the original logic won't work. Changing the unit from VmSize to VmRSS for that reason.

Also need to bump up the version number, because the faulty code is already deployed (only to 1 region, following the safe deployment practice).