### PR TITLE
AzureDiskEncryptionForLinux March Release

### DIFF
--- a/VMEncryption/main/Common.py
+++ b/VMEncryption/main/Common.py
@@ -20,7 +20,7 @@
 class CommonVariables:
     utils_path_name = 'Utils'
     extension_name = 'AzureDiskEncryptionForLinuxTest'
-    extension_version = '0.1.0.999296'
+    extension_version = '0.1.0.999297'
     extension_type = extension_name
     extension_media_link = 'https://amextpaas.blob.core.windows.net/prod/' + extension_name + '-' + str(extension_version) + '.zip'
     extension_label = 'Windows Azure VMEncryption Extension for Linux IaaS'

--- a/VMEncryption/main/Common.py
+++ b/VMEncryption/main/Common.py
@@ -20,7 +20,7 @@
 class CommonVariables:
     utils_path_name = 'Utils'
     extension_name = 'AzureDiskEncryptionForLinuxTest'
-    extension_version = '0.1.0.999288'
+    extension_version = '0.1.0.999289'
     extension_type = extension_name
     extension_media_link = 'https://amextpaas.blob.core.windows.net/prod/' + extension_name + '-' + str(extension_version) + '.zip'
     extension_label = 'Windows Azure VMEncryption Extension for Linux IaaS'

--- a/VMEncryption/main/Common.py
+++ b/VMEncryption/main/Common.py
@@ -20,7 +20,7 @@
 class CommonVariables:
     utils_path_name = 'Utils'
     extension_name = 'AzureDiskEncryptionForLinuxTest'
-    extension_version = '0.1.0.999290'
+    extension_version = '0.1.0.999291'
     extension_type = extension_name
     extension_media_link = 'https://amextpaas.blob.core.windows.net/prod/' + extension_name + '-' + str(extension_version) + '.zip'
     extension_label = 'Windows Azure VMEncryption Extension for Linux IaaS'

--- a/VMEncryption/main/Common.py
+++ b/VMEncryption/main/Common.py
@@ -20,7 +20,7 @@
 class CommonVariables:
     utils_path_name = 'Utils'
     extension_name = 'AzureDiskEncryptionForLinuxTest'
-    extension_version = '0.1.0.999286'
+    extension_version = '0.1.0.999287'
     extension_type = extension_name
     extension_media_link = 'https://amextpaas.blob.core.windows.net/prod/' + extension_name + '-' + str(extension_version) + '.zip'
     extension_label = 'Windows Azure VMEncryption Extension for Linux IaaS'

--- a/VMEncryption/main/Common.py
+++ b/VMEncryption/main/Common.py
@@ -20,7 +20,7 @@
 class CommonVariables:
     utils_path_name = 'Utils'
     extension_name = 'AzureDiskEncryptionForLinuxTest'
-    extension_version = '0.1.0.999289'
+    extension_version = '0.1.0.999290'
     extension_type = extension_name
     extension_media_link = 'https://amextpaas.blob.core.windows.net/prod/' + extension_name + '-' + str(extension_version) + '.zip'
     extension_label = 'Windows Azure VMEncryption Extension for Linux IaaS'

--- a/VMEncryption/main/Common.py
+++ b/VMEncryption/main/Common.py
@@ -20,7 +20,7 @@
 class CommonVariables:
     utils_path_name = 'Utils'
     extension_name = 'AzureDiskEncryptionForLinuxTest'
-    extension_version = '0.1.0.999294'
+    extension_version = '0.1.0.999295'
     extension_type = extension_name
     extension_media_link = 'https://amextpaas.blob.core.windows.net/prod/' + extension_name + '-' + str(extension_version) + '.zip'
     extension_label = 'Windows Azure VMEncryption Extension for Linux IaaS'

--- a/VMEncryption/main/Common.py
+++ b/VMEncryption/main/Common.py
@@ -174,11 +174,13 @@ class DeviceItem(object):
         self.model = None
         self.size = None
         self.majmin = None
+        self.device_id = None
     def __str__(self):
         return ("name:" + str(self.name) + " type:" + str(self.type) +
                 " fstype:" + str(self.file_system) + " mountpoint:" + str(self.mount_point) +
                 " label:" + str(self.label) + " model:" + str(self.model) +
-                " size:" + str(self.size)) + " majmin:" + str(self.majmin)
+                " size:" + str(self.size) + " majmin:" + str(self.majmin) +
+                " device_id:" + str(self.device_id))
 
 class LvmItem(object):
     def __init__(self):

--- a/VMEncryption/main/Common.py
+++ b/VMEncryption/main/Common.py
@@ -20,7 +20,7 @@
 class CommonVariables:
     utils_path_name = 'Utils'
     extension_name = 'AzureDiskEncryptionForLinuxTest'
-    extension_version = '0.1.0.999292'
+    extension_version = '0.1.0.999293'
     extension_type = extension_name
     extension_media_link = 'https://amextpaas.blob.core.windows.net/prod/' + extension_name + '-' + str(extension_version) + '.zip'
     extension_label = 'Windows Azure VMEncryption Extension for Linux IaaS'

--- a/VMEncryption/main/Common.py
+++ b/VMEncryption/main/Common.py
@@ -20,7 +20,7 @@
 class CommonVariables:
     utils_path_name = 'Utils'
     extension_name = 'AzureDiskEncryptionForLinuxTest'
-    extension_version = '0.1.0.999293'
+    extension_version = '0.1.0.999294'
     extension_type = extension_name
     extension_media_link = 'https://amextpaas.blob.core.windows.net/prod/' + extension_name + '-' + str(extension_version) + '.zip'
     extension_label = 'Windows Azure VMEncryption Extension for Linux IaaS'

--- a/VMEncryption/main/Common.py
+++ b/VMEncryption/main/Common.py
@@ -20,7 +20,7 @@
 class CommonVariables:
     utils_path_name = 'Utils'
     extension_name = 'AzureDiskEncryptionForLinuxTest'
-    extension_version = '0.1.0.999287'
+    extension_version = '0.1.0.999288'
     extension_type = extension_name
     extension_media_link = 'https://amextpaas.blob.core.windows.net/prod/' + extension_name + '-' + str(extension_version) + '.zip'
     extension_label = 'Windows Azure VMEncryption Extension for Linux IaaS'

--- a/VMEncryption/main/Common.py
+++ b/VMEncryption/main/Common.py
@@ -20,7 +20,7 @@
 class CommonVariables:
     utils_path_name = 'Utils'
     extension_name = 'AzureDiskEncryptionForLinuxTest'
-    extension_version = '0.1.0.999291'
+    extension_version = '0.1.0.999292'
     extension_type = extension_name
     extension_media_link = 'https://amextpaas.blob.core.windows.net/prod/' + extension_name + '-' + str(extension_version) + '.zip'
     extension_label = 'Windows Azure VMEncryption Extension for Linux IaaS'

--- a/VMEncryption/main/Common.py
+++ b/VMEncryption/main/Common.py
@@ -20,7 +20,7 @@
 class CommonVariables:
     utils_path_name = 'Utils'
     extension_name = 'AzureDiskEncryptionForLinuxTest'
-    extension_version = '0.1.0.999295'
+    extension_version = '0.1.0.999296'
     extension_type = extension_name
     extension_media_link = 'https://amextpaas.blob.core.windows.net/prod/' + extension_name + '-' + str(extension_version) + '.zip'
     extension_label = 'Windows Azure VMEncryption Extension for Linux IaaS'

--- a/VMEncryption/main/DiskUtil.py
+++ b/VMEncryption/main/DiskUtil.py
@@ -888,7 +888,7 @@ class DiskUtil(object):
 
         return DiskUtil.os_disk_lvm
 
-    def should_skip_for_inplace_encryption(self, device_item):
+    def should_skip_for_inplace_encryption(self, device_item, encrypt_volume_type):
         """
         TYPE="raid0"
         TYPE="part"
@@ -898,6 +898,16 @@ class DiskUtil(object):
         if the type is disk, then to check whether it have child-items, say the part, lvm or crypt luks.
         if the answer is yes, then skip it.
         """
+
+        if encrypt_volume_type.lower() == 'data':
+            self.logger.log(msg="enabling encryption for data volumes", level=CommonVariables.WarningLevel)
+            if device_item.device_id.startswith('00000000-0000'):
+                self.logger.log(msg="skipping root disk", level=CommonVariables.WarningLevel)
+                return True
+            if device_item.device_id.startswith('00000000-0001'):
+                self.logger.log(msg="skipping resource disk", level=CommonVariables.WarningLevel)
+                return True
+
         if device_item.file_system is None or device_item.file_system == "":
             self.logger.log(msg=("there's no file system on this device: {0}, so skip it.").format(device_item))
             return True

--- a/VMEncryption/main/DiskUtil.py
+++ b/VMEncryption/main/DiskUtil.py
@@ -678,7 +678,7 @@ class DiskUtil(object):
     def get_device_items_property(self, dev_name, property_name):
         self.logger.log("getting property of device {0}".format(dev_name))
 
-        device_path = get_device_path(dev_name)
+        device_path = self.get_device_path(dev_name)
 
         if property_name == "SIZE":
             get_property_cmd = self.distro_patcher.blockdev_path + " --getsize64 " + device_path

--- a/VMEncryption/main/DiskUtil.py
+++ b/VMEncryption/main/DiskUtil.py
@@ -672,7 +672,7 @@ class DiskUtil(object):
         udev_cmd = "udevadm info -a -p $(udevadm info -q path -n {0}) | grep device_id".format(dev_path)
         proc_comm = ProcessCommunicator()
         self.command_executor.ExecuteInBash(udev_cmd, communicator=proc_comm, suppress_logging=True)
-        device_id = re.findall(r'"{(.*)}"', proc_comm.stdout.strip())
+        device_id = re.findall(r'"{(.*)}"', proc_comm.stdout.strip())[0]
         return device_id
 
     def get_device_items_property(self, dev_name, property_name):

--- a/VMEncryption/main/DiskUtil.py
+++ b/VMEncryption/main/DiskUtil.py
@@ -672,8 +672,8 @@ class DiskUtil(object):
         udev_cmd = "udevadm info -a -p $(udevadm info -q path -n {0}) | grep device_id".format(dev_path)
         proc_comm = ProcessCommunicator()
         self.command_executor.ExecuteInBash(udev_cmd, communicator=proc_comm, suppress_logging=True)
-        device_id = re.findall(r'"{(.*)}"', proc_comm.stdout.strip())[0]
-        return device_id
+        match = re.findall(r'"{(.*)}"', proc_comm.stdout.strip())
+        return match[0] if match else ""
 
     def get_device_items_property(self, dev_name, property_name):
         self.logger.log("getting property of device {0}".format(dev_name))

--- a/VMEncryption/main/EncryptionMarkConfig.py
+++ b/VMEncryption/main/EncryptionMarkConfig.py
@@ -33,6 +33,9 @@ class EncryptionMarkConfig(object):
                                                  'encryption_request_queue',
                                                  self.logger)
 
+    def get_volume_type(self):
+        return self.encryption_mark_config.get_config(CommonVariables.EncryptionVolumeTypeKey)
+
     def get_current_command(self):
         return self.encryption_mark_config.get_config(CommonVariables.EncryptionEncryptionOperationKey)
 

--- a/VMEncryption/main/KeyVaultUtil.py
+++ b/VMEncryption/main/KeyVaultUtil.py
@@ -92,7 +92,7 @@ class KeyVaultUtil(object):
             return secret_id
         except Exception as e:
             self.logger.log("Failed to create_kek_secret with error: {0}, stack trace: {1}".format(e, traceback.format_exc()))
-            return None
+            raise
 
     def get_access_token(self, KeyVaultResourceName, AuthorizeUri, AADClientID, AADClientCertThumbprint, AADClientSecret):
         if not AADClientSecret and not AADClientCertThumbprint:

--- a/VMEncryption/main/Utils/HandlerUtil.py
+++ b/VMEncryption/main/Utils/HandlerUtil.py
@@ -334,6 +334,9 @@ class HandlerUtility:
         latest_seq = str(self.get_latest_seq())
         self._context._status_file = os.path.join(self._context._status_dir, latest_seq + '.status')
 
+        if message is None:
+            message = ""
+
         message = filter(lambda c: c in string.printable, message)
         message = message.encode('ascii', 'ignore')
 

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -1469,7 +1469,7 @@ def daemon_encrypt():
 
         os_encryption = None
 
-        if ((distro_name == 'redhat' and distro_version == '7.2') and
+        if ((distro_name == 'redhat' and distro_version == '7.3') and
               (disk_util.is_os_disk_lvm() or os.path.exists('/volumes.lvm'))):
             from oscrypto.rhel_72_lvm import RHEL72LVMEncryptionStateMachine
             os_encryption = RHEL72LVMEncryptionStateMachine(hutil=hutil,

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -1485,7 +1485,7 @@ def daemon_encrypt():
                                                          encryption_environment=encryption_environment)
         elif ((distro_name == 'redhat' and distro_version == '7.2') or
             (distro_name == 'redhat' and distro_version == '7.3') or
-            (distro_name == 'redhat' and distro_version == '7.3.1611') or
+            (distro_name == 'centos' and distro_version == '7.3.1611') or
             (distro_name == 'centos' and distro_version == '7.2.1511')):
             from oscrypto.rhel_72 import RHEL72EncryptionStateMachine
             os_encryption = RHEL72EncryptionStateMachine(hutil=hutil,

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -155,8 +155,9 @@ def disable_encryption():
                       message='Decryption started')
 
     except Exception as e:
-        message = logger.log(msg="Failed to disable the extension with error: {0}, stack trace: {1}".format(e, traceback.format_exc()), level=CommonVariables.ErrorLevel)
+        message = "Failed to disable the extension with error: {0}, stack trace: {1}".format(e, traceback.format_exc())
 
+        logger.log(msg=message, level=CommonVariables.ErrorLevel)
         hutil.do_exit(exit_code=0,
                       operation='DisableEncryption',
                       status=CommonVariables.extension_error_status,

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -1485,6 +1485,7 @@ def daemon_encrypt():
                                                          encryption_environment=encryption_environment)
         elif ((distro_name == 'redhat' and distro_version == '7.2') or
             (distro_name == 'redhat' and distro_version == '7.3') or
+            (distro_name == 'redhat' and distro_version == '7.3.1611') or
             (distro_name == 'centos' and distro_version == '7.2.1511')):
             from oscrypto.rhel_72 import RHEL72EncryptionStateMachine
             os_encryption = RHEL72EncryptionStateMachine(hutil=hutil,

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -59,6 +59,7 @@ from __builtin__ import int
 def install():
     hutil.do_parse_context('Install')
     hutil.restore_old_configs()
+    hutil.do_status_report(operation='Install', status=CommonVariables.extension_success_status, status_code=str(CommonVariables.success), message='Installing pre-requisites')
     logger.log("Installing pre-requisites")
     DistroPatcher.install_extras()
     hutil.do_exit(0, 'Install', CommonVariables.extension_success_status, str(CommonVariables.success), 'Install Succeeded')

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -116,6 +116,12 @@ def disable_encryption():
         extension_parameter = ExtensionParameter(hutil, logger, DistroPatcher, encryption_environment, protected_settings, public_settings)
 
         disk_util = DiskUtil(hutil=hutil, patching=DistroPatcher, logger=logger, encryption_environment=encryption_environment)
+
+        encryption_status = json.loads(disk_util.get_encryption_status())
+
+        if encryption_status["os"] != "NotEncrypted":
+            raise Exception("Disabling encryption is not supported when OS volume is encrypted")
+
         bek_util = BekUtil(disk_util, logger)
         encryption_config = EncryptionConfig(encryption_environment, logger)
         bek_passphrase_file = bek_util.get_bek_passphrase_file(encryption_config)

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -1277,7 +1277,7 @@ def enable_encryption_all_in_place(passphrase_file, encryption_marker, disk_util
     for device_item in device_items:
         logger.log("device_item == " + str(device_item))
 
-        should_skip = disk_util.should_skip_for_inplace_encryption(device_item)
+        should_skip = disk_util.should_skip_for_inplace_encryption(device_item, encryption_marker.get_volume_type())
         if not should_skip:
             if device_item.name == bek_util.passphrase_device:
                 logger.log("skip for the passphrase disk ".format(device_item))

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -155,14 +155,13 @@ def disable_encryption():
                       message='Decryption started')
 
     except Exception as e:
-        logger.log(msg="Failed to disable the extension with error: {0}, stack trace: {1}".format(e, traceback.format_exc()),
-                   level=CommonVariables.ErrorLevel)
+        message = logger.log(msg="Failed to disable the extension with error: {0}, stack trace: {1}".format(e, traceback.format_exc()), level=CommonVariables.ErrorLevel)
 
         hutil.do_exit(exit_code=0,
                       operation='DisableEncryption',
                       status=CommonVariables.extension_error_status,
                       code=str(CommonVariables.unknown_error),
-                      message='Decryption failed.')
+                      message=message)
 
 def update_encryption_settings():
     hutil.do_parse_context('UpdateEncryptionSettings')

--- a/VMEncryption/main/oscrypto/centos_68/CentOS68EncryptionStateMachine.py
+++ b/VMEncryption/main/oscrypto/centos_68/CentOS68EncryptionStateMachine.py
@@ -193,7 +193,8 @@ class CentOS68EncryptionStateMachine(OSEncryptionStateMachine):
                                             message=message)
                 
                 sleep(10)
-                raise Exception(message)
+                if attempt > 10:
+                    raise Exception(message)
             else:
                 oldroot_unmounted_successfully = True
             finally:

--- a/VMEncryption/main/oscrypto/centos_68/CentOS68EncryptionStateMachine.py
+++ b/VMEncryption/main/oscrypto/centos_68/CentOS68EncryptionStateMachine.py
@@ -191,8 +191,9 @@ class CentOS68EncryptionStateMachine(OSEncryptionStateMachine):
                                             status=CommonVariables.extension_error_status,
                                             status_code=str(CommonVariables.unmount_oldroot_error),
                                             message=message)
-
+                
                 sleep(10)
+                raise Exception(message)
             else:
                 oldroot_unmounted_successfully = True
             finally:

--- a/VMEncryption/main/oscrypto/centos_68/encryptstates/SplitRootPartitionState.py
+++ b/VMEncryption/main/oscrypto/centos_68/encryptstates/SplitRootPartitionState.py
@@ -149,7 +149,9 @@ class SplitRootPartitionState(OSEncryptionState):
             self.command_executor.Execute('at -f /restart-wala.sh now + 1 minutes', True)
             self.command_executor.Execute('service waagent stop', True)
 
-            self.command_executor.Execute("umount /oldroot", True)
+            os.unlink('/var/lib/azure_disk_encryption_config/os_encryption_markers/UnmountOldrootState')
+
+            raise
         
     def should_exit(self):
         self.context.logger.log("Verifying if machine should exit split_root_partition state")

--- a/VMEncryption/main/oscrypto/centos_68/encryptstates/SplitRootPartitionState.py
+++ b/VMEncryption/main/oscrypto/centos_68/encryptstates/SplitRootPartitionState.py
@@ -150,6 +150,7 @@ class SplitRootPartitionState(OSEncryptionState):
             self.command_executor.Execute('service waagent stop', True)
 
             os.unlink('/var/lib/azure_disk_encryption_config/os_encryption_markers/UnmountOldrootState')
+            self.should_exit()
 
             raise
         

--- a/VMEncryption/main/oscrypto/centos_68/encryptstates/UnmountOldrootState.py
+++ b/VMEncryption/main/oscrypto/centos_68/encryptstates/UnmountOldrootState.py
@@ -140,7 +140,7 @@ class UnmountOldrootState(OSEncryptionState):
 
         sleep(3)
 
-        self.command_executor.ExecuteInBash('for mp in `grep /oldroot /proc/mounts | cut -f2 -d" " | sort -r`; do umount $mp; done', True)
+        self.command_executor.ExecuteInBash('for mp in `grep /oldroot /proc/mounts | cut -f2 -d\' \' | sort -r`; do umount $mp; done', True)
 
         sleep(3)
 

--- a/VMEncryption/main/oscrypto/centos_68/encryptstates/UnmountOldrootState.py
+++ b/VMEncryption/main/oscrypto/centos_68/encryptstates/UnmountOldrootState.py
@@ -140,7 +140,7 @@ class UnmountOldrootState(OSEncryptionState):
 
         sleep(3)
 
-        self.command_executor.ExecuteInBash('for mp in $(grep /oldroot /proc/mounts | cut -f2 -d" " | sort -r); do umount $mp; done', True)
+        self.command_executor.ExecuteInBash('for mp in `grep /oldroot /proc/mounts | cut -f2 -d" " | sort -r`; do umount $mp; done', True)
 
         sleep(3)
 

--- a/VMEncryption/main/oscrypto/centos_68/encryptstates/UnmountOldrootState.py
+++ b/VMEncryption/main/oscrypto/centos_68/encryptstates/UnmountOldrootState.py
@@ -140,7 +140,7 @@ class UnmountOldrootState(OSEncryptionState):
 
         sleep(3)
 
-        self.command_executor.Execute('umount -R /oldroot', True)
+        self.command_executor.ExecuteInBash('for mp in $(grep /oldroot /proc/mounts | cut -f2 -d" " | sort -r); do umount $mp; done', True)
 
         sleep(3)
 

--- a/VMEncryption/main/oscrypto/centos_68/encryptstates/UnmountOldrootState.py
+++ b/VMEncryption/main/oscrypto/centos_68/encryptstates/UnmountOldrootState.py
@@ -73,6 +73,7 @@ class UnmountOldrootState(OSEncryptionState):
                 service = splitted[0]
                 self.command_executor.Execute('service {0} restart'.format(service))
 
+        self.command_executor.Execute('umount -a')
         self.command_executor.Execute('swapoff -a', True)
 
         self.bek_util.umount_azure_passhprase(self.encryption_config, force=True)

--- a/VMEncryption/main/oscrypto/centos_68/encryptstates/UnmountOldrootState.py
+++ b/VMEncryption/main/oscrypto/centos_68/encryptstates/UnmountOldrootState.py
@@ -140,7 +140,7 @@ class UnmountOldrootState(OSEncryptionState):
 
         sleep(3)
 
-        self.command_executor.Execute('umount /oldroot', True)
+        self.command_executor.Execute('umount -R /oldroot', True)
 
         sleep(3)
 

--- a/VMEncryption/main/oscrypto/centos_68/encryptstates/UnmountOldrootState.py
+++ b/VMEncryption/main/oscrypto/centos_68/encryptstates/UnmountOldrootState.py
@@ -74,6 +74,8 @@ class UnmountOldrootState(OSEncryptionState):
                 self.command_executor.Execute('service {0} restart'.format(service))
 
         self.command_executor.Execute('umount -a')
+        self.command_executor.Execute('mount -t proc proc /proc')
+        self.command_executor.Execute('mount -t sysfs sysfs /sys')
         self.command_executor.Execute('swapoff -a', True)
 
         self.bek_util.umount_azure_passhprase(self.encryption_config, force=True)

--- a/VMEncryption/main/oscrypto/rhel_68/RHEL68EncryptionStateMachine.py
+++ b/VMEncryption/main/oscrypto/rhel_68/RHEL68EncryptionStateMachine.py
@@ -184,7 +184,9 @@ class RHEL68EncryptionStateMachine(OSEncryptionStateMachine):
                                             message=message)
                 
                 sleep(10)
-                raise Exception(message)
+
+                if attempt > 10:
+                    raise Exception(message)
             else:
                 oldroot_unmounted_successfully = True
             finally:

--- a/VMEncryption/main/oscrypto/rhel_68/RHEL68EncryptionStateMachine.py
+++ b/VMEncryption/main/oscrypto/rhel_68/RHEL68EncryptionStateMachine.py
@@ -182,8 +182,9 @@ class RHEL68EncryptionStateMachine(OSEncryptionStateMachine):
                                             status=CommonVariables.extension_error_status,
                                             status_code=str(CommonVariables.unmount_oldroot_error),
                                             message=message)
-
+                
                 sleep(10)
+                raise Exception(message)
             else:
                 oldroot_unmounted_successfully = True
             finally:

--- a/VMEncryption/main/oscrypto/rhel_68/encryptstates/UnmountOldrootState.py
+++ b/VMEncryption/main/oscrypto/rhel_68/encryptstates/UnmountOldrootState.py
@@ -137,7 +137,7 @@ class UnmountOldrootState(OSEncryptionState):
 
         sleep(3)
 
-        self.command_executor.Execute('umount /oldroot', True)
+        self.command_executor.Execute('umount -R /oldroot', True)
 
         sleep(3)
 

--- a/VMEncryption/main/oscrypto/rhel_68/encryptstates/UnmountOldrootState.py
+++ b/VMEncryption/main/oscrypto/rhel_68/encryptstates/UnmountOldrootState.py
@@ -137,7 +137,7 @@ class UnmountOldrootState(OSEncryptionState):
 
         sleep(3)
 
-        self.command_executor.Execute('umount -R /oldroot', True)
+        self.command_executor.Execute('for mp in $(grep /oldroot /proc/mounts | cut -f2 -d" " | sort -r); do umount $mp; done', True)
 
         sleep(3)
 

--- a/VMEncryption/main/oscrypto/rhel_68/encryptstates/UnmountOldrootState.py
+++ b/VMEncryption/main/oscrypto/rhel_68/encryptstates/UnmountOldrootState.py
@@ -137,7 +137,7 @@ class UnmountOldrootState(OSEncryptionState):
 
         sleep(3)
 
-        self.command_executor.ExecuteInBash('for mp in `grep /oldroot /proc/mounts | cut -f2 -d" " | sort -r`; do umount $mp; done', True)
+        self.command_executor.ExecuteInBash('for mp in `grep /oldroot /proc/mounts | cut -f2 -d\' \' | sort -r`; do umount $mp; done', True)
 
         sleep(3)
 

--- a/VMEncryption/main/oscrypto/rhel_68/encryptstates/UnmountOldrootState.py
+++ b/VMEncryption/main/oscrypto/rhel_68/encryptstates/UnmountOldrootState.py
@@ -137,7 +137,7 @@ class UnmountOldrootState(OSEncryptionState):
 
         sleep(3)
 
-        self.command_executor.Execute('for mp in $(grep /oldroot /proc/mounts | cut -f2 -d" " | sort -r); do umount $mp; done', True)
+        self.command_executor.ExecuteInBash('for mp in $(grep /oldroot /proc/mounts | cut -f2 -d" " | sort -r); do umount $mp; done', True)
 
         sleep(3)
 

--- a/VMEncryption/main/oscrypto/rhel_68/encryptstates/UnmountOldrootState.py
+++ b/VMEncryption/main/oscrypto/rhel_68/encryptstates/UnmountOldrootState.py
@@ -137,7 +137,7 @@ class UnmountOldrootState(OSEncryptionState):
 
         sleep(3)
 
-        self.command_executor.ExecuteInBash('for mp in $(grep /oldroot /proc/mounts | cut -f2 -d" " | sort -r); do umount $mp; done', True)
+        self.command_executor.ExecuteInBash('for mp in `grep /oldroot /proc/mounts | cut -f2 -d" " | sort -r`; do umount $mp; done', True)
 
         sleep(3)
 

--- a/VMEncryption/main/oscrypto/rhel_72/RHEL72EncryptionStateMachine.py
+++ b/VMEncryption/main/oscrypto/rhel_72/RHEL72EncryptionStateMachine.py
@@ -184,7 +184,8 @@ class RHEL72EncryptionStateMachine(OSEncryptionStateMachine):
                                             message=message)
 
                 sleep(10)
-                raise Exception(message)
+                if attempt > 10:
+                    raise Exception(message)
             else:
                 oldroot_unmounted_successfully = True
             finally:

--- a/VMEncryption/main/oscrypto/rhel_72/encryptstates/PrereqState.py
+++ b/VMEncryption/main/oscrypto/rhel_72/encryptstates/PrereqState.py
@@ -47,6 +47,7 @@ class PrereqState(OSEncryptionState):
 
         if ((distro_info[0] == 'redhat' and distro_info[1] == '7.2') or
             (distro_info[0] == 'redhat' and distro_info[1] == '7.3') or
+            (distro_info[0] == 'centos' and distro_info[1] == '7.3.1611') or
             (distro_info[0] == 'centos' and distro_info[1] == '7.2.1511')):
             self.context.logger.log("Enabling OS volume encryption on {0} {1}".format(distro_info[0],
                                                                                       distro_info[1]))

--- a/VMEncryption/main/oscrypto/rhel_72_lvm/RHEL72LVMEncryptionStateMachine.py
+++ b/VMEncryption/main/oscrypto/rhel_72_lvm/RHEL72LVMEncryptionStateMachine.py
@@ -186,7 +186,8 @@ class RHEL72LVMEncryptionStateMachine(OSEncryptionStateMachine):
                                             message=message)
 
                 sleep(10)
-                raise Exception(message)
+                if attempt > 10:
+                    raise Exception(message)
             else:
                 oldroot_unmounted_successfully = True
             finally:

--- a/VMEncryption/main/oscrypto/rhel_72_lvm/encryptstates/PrereqState.py
+++ b/VMEncryption/main/oscrypto/rhel_72_lvm/encryptstates/PrereqState.py
@@ -46,7 +46,7 @@ class PrereqState(OSEncryptionState):
         self.context.logger.log("Distro info: {0}".format(distro_info))
 
         if (((distro_info[0] == 'centos' and distro_info[1] == '7.3.1611') or
-             (distro_info[0] == 'redhat' and distro_info[1] == '7.2')) and
+             (distro_info[0] == 'redhat' and distro_info[1] == '7.3')) and
             self.disk_util.is_os_disk_lvm()):
             self.context.logger.log("Enabling OS volume encryption on {0} {1}".format(distro_info[0],
                                                                                       distro_info[1]))

--- a/VMEncryption/main/oscrypto/ubuntu_1404/Ubuntu1404EncryptionStateMachine.py
+++ b/VMEncryption/main/oscrypto/ubuntu_1404/Ubuntu1404EncryptionStateMachine.py
@@ -181,7 +181,8 @@ class Ubuntu1404EncryptionStateMachine(OSEncryptionStateMachine):
                                             message=message)
 
                 sleep(10)
-                raise Exception(message)
+                if attempt > 10:
+                    raise Exception(message)
             else:
                 oldroot_unmounted_successfully = True
             finally:

--- a/VMEncryption/main/oscrypto/ubuntu_1604/Ubuntu1604EncryptionStateMachine.py
+++ b/VMEncryption/main/oscrypto/ubuntu_1604/Ubuntu1604EncryptionStateMachine.py
@@ -181,7 +181,8 @@ class Ubuntu1604EncryptionStateMachine(OSEncryptionStateMachine):
                                             message=message)
 
                 sleep(10)
-                raise Exception(message)
+                if attempt > 10:
+                    raise Exception(message)
             else:
                 oldroot_unmounted_successfully = True
             finally:

--- a/VMEncryption/main/patch/centosPatching.py
+++ b/VMEncryption/main/patch/centosPatching.py
@@ -123,6 +123,11 @@ class centosPatching(redhatPatching):
                     'openssl-devel',
                     'python-devel']
 
+        if self.distro_info[1].startswith("6."):
+            packages.remove('cryptsetup')
+            packages.remove('procps-ng')
+            packages.remove('util-linux')
+
         if self.command_executor.Execute("rpm -q " + " ".join(packages)):
             self.command_executor.Execute("yum install -y " + " ".join(packages))
 

--- a/VMEncryption/main/patch/redhatPatching.py
+++ b/VMEncryption/main/patch/redhatPatching.py
@@ -128,6 +128,11 @@ class redhatPatching(AbstractPatching):
                     'openssl-devel',
                     'python-devel']
 
+        if self.distro_info[1].startswith("6."):
+            packages.remove('cryptsetup')
+            packages.remove('procps-ng')
+            packages.remove('util-linux')
+
         if self.command_executor.Execute("rpm -q " + " ".join(packages)):
             self.command_executor.Execute("yum install -y " + " ".join(packages))
 


### PR DESCRIPTION
- Support OS disk encryption on CentOS 7.3
- Support OS disk encryption on RHEL 6.8
- Support OS disk encryption on CentOS 6.8
- Support LVM OS disk encryption on RHEL & CentOS 7.3
- Skip OS disk and resource disk volumes based on device serial IDs if only data disks are being encrypted. So that if customer has unsupported OS partitioning scheme, they can still use data disk encryption.
- Cleaned up redundant package depencies
- Fail decryption explicitly if OS is encrypted
- Logging improvements
- Bugfixes