### PR TITLE
csfl: re-release 1.5.2.1 as 1.1.1

### DIFF
--- a/CustomScript/manifest.xml
+++ b/CustomScript/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.OSTCExtensions</ProviderNameSpace>
   <Type>CustomScriptForLinux</Type>
-  <Version>1.5.2.1</Version>
+  <Version>1.1.1</Version>
   <Label>Microsoft Azure Custom Script Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>


### PR DESCRIPTION
There are a few customers still running 1.1, and the failure rate is rather high.  Customers are no opting in auto upgrade, so are stuck at a bad version.  I am re-releasing 1.5.2.1 as 1.1.1 in the hopes that the failure rate will go down without disturbing the customer.