### PR TITLE
Allow VMAccess to work in a system container

### DIFF
--- a/Common/WALinuxAgent-2.0.16/waagent
+++ b/Common/WALinuxAgent-2.0.16/waagent
@@ -97,7 +97,7 @@ RulesFiles = [ "/lib/udev/rules.d/75-persistent-net-generator.rules",
 VarLibDhcpDirectories = ["/var/lib/dhclient", "/var/lib/dhcpcd", "/var/lib/dhcp"]
 EtcDhcpClientConfFiles = ["/etc/dhcp/dhclient.conf", "/etc/dhcp3/dhclient.conf"]
 global LibDir
-LibDir = "/var/lib/waagent"
+LibDir = "/var/lib/waagent" if 'WALA_ROOT' not in os.environ else os.path.join(os.environ['WALA_ROOT'], "var/lib/waagent")
 global provisioned
 provisioned=False
 global provisionError

--- a/Utils/HandlerUtil.py
+++ b/Utils/HandlerUtil.py
@@ -64,6 +64,7 @@ from xml.etree import ElementTree
 from os.path import join
 from Utils.WAAgentUtil import waagent
 from waagent import LoggerInit
+import azurelinuxagent.common.conf as conf
 
 DateTimeFormat = "%Y-%m-%dT%H:%M:%SZ"
 
@@ -165,8 +166,10 @@ class HandlerUtility:
                     handlerSettings["protectedSettingsCertThumbprint"] is not None:
                 protectedSettings = handlerSettings['protectedSettings']
                 thumb=handlerSettings['protectedSettingsCertThumbprint']
-                cert=waagent.LibDir+'/'+thumb+'.crt'
-                pkey=waagent.LibDir+'/'+thumb+'.prv'
+                conf.load_conf_from_file("/etc/waagent.conf")
+                libdir = conf.get_lib_dir()
+                cert=os.path.join(libdir, thumb+'.crt')
+                pkey=os.path.join(libdir, thumb+'.prv')
                 unencodedSettings = base64.standard_b64decode(protectedSettings)
                 openSSLcmd = "openssl smime -inform DER -decrypt -recip {0} -inkey {1}"
                 cleartxt = waagent.RunSendStdin(openSSLcmd.format(cert, pkey), unencodedSettings)[1]

--- a/Utils/WAAgentUtil.py
+++ b/Utils/WAAgentUtil.py
@@ -27,6 +27,8 @@ import os.path
 #
 def searchWAAgent():
     agentPath = '/usr/sbin/waagent'
+    if 'WALA_ROOT' in os.environ:
+        agentPath = os.path.join(os.environ['WALA_ROOT'], agentPath.lstrip(os.path.sep))
     if(os.path.isfile(agentPath)):
         return agentPath
     user_paths = os.environ['PYTHONPATH'].split(os.pathsep)


### PR DESCRIPTION
When you run the WALinuxAgent in a system container, the locations are
often different than a normal system -- almost like a chroot.  This
contains minor patches to help the VMAccess extension detect and deal
with that.