### PR TITLE
OmsAgent: retry logic fix and small updates

### DIFF
--- a/OmsAgent/Fairfax/HandlerManifest.json
+++ b/OmsAgent/Fairfax/HandlerManifest.json
@@ -1,7 +1,7 @@
 [
   {
     "name":  "OmsAgentForLinux",
-    "version": "1.3.127.4",
+    "version": "1.3.127.5",
     "handlerManifest": {
       "installCommand": "omsagent_ff.py -install",
       "uninstallCommand": "omsagent_ff.py -uninstall",

--- a/OmsAgent/Fairfax/HandlerManifest.json
+++ b/OmsAgent/Fairfax/HandlerManifest.json
@@ -1,7 +1,7 @@
 [
   {
     "name":  "OmsAgentForLinux",
-    "version": "1.3.127.5",
+    "version": "1.3.127.7",
     "handlerManifest": {
       "installCommand": "omsagent_ff.py -install",
       "uninstallCommand": "omsagent_ff.py -uninstall",

--- a/OmsAgent/Fairfax/omsagent_ff.py
+++ b/OmsAgent/Fairfax/omsagent_ff.py
@@ -37,7 +37,7 @@ except Exception as e:
 
 # Global Variables
 PackagesDirectory = 'packages'
-BundleFileName = 'omsagent-1.3.4-127.universal.x64.sh'
+BundleFileName = 'omsagent-1.3.5-127.universal.x64.sh'
 
 # Always use upgrade - will handle install if scx, omi are not installed or
 # upgrade if they are
@@ -731,7 +731,7 @@ def log_and_exit(hutil, operation, exit_code = 1, message = ''):
     if hutil is not None:
         hutil.do_exit(exit_code, operation, exit_status, str(exit_code), message)
     else:
-        update_status_file(operation, exit_code, exit_status, message)
+        update_status_file(operation, str(exit_code), exit_status, message)
         sys.exit(exit_code)
 
 

--- a/OmsAgent/HandlerManifest.json
+++ b/OmsAgent/HandlerManifest.json
@@ -1,7 +1,7 @@
 [
   {
     "name":  "OmsAgentForLinux",
-    "version": "1.3.127.5",
+    "version": "1.3.127.7",
     "handlerManifest": {
       "installCommand": "omsagent.py -install",
       "uninstallCommand": "omsagent.py -uninstall",

--- a/OmsAgent/HandlerManifest.json
+++ b/OmsAgent/HandlerManifest.json
@@ -1,7 +1,7 @@
 [
   {
     "name":  "OmsAgentForLinux",
-    "version": "1.3.127.4",
+    "version": "1.3.127.5",
     "handlerManifest": {
       "installCommand": "omsagent.py -install",
       "uninstallCommand": "omsagent.py -uninstall",

--- a/OmsAgent/README.md
+++ b/OmsAgent/README.md
@@ -230,29 +230,17 @@ and the tail of the output is logged into the log directory specified
 in HandlerEnvironment.json and reported back to Azure
 * The operation log of the extension is `/var/log/azure/<extension-name>/<version>/extension.log` file.
 
-### Error codes and their meanings
+### Common error codes and their meanings
 
 | Error Code | Meaning | Possible Action |
 | :---: | --- | --- |
-| 2 | Invalid option provided to the shell bundle | |
-| 3 | No option provided to the shell bundle | |
-| 4 | Invalid package type | |
-| 5 | The shell bundle must be executed as root | |
-| 6 | Invalid package architecture | |
 | 10 | VM is already connected to an OMS workspace | To connect the VM to the workspace specified in the extension schema, set stopOnMultipleConnections to false in public settings or remove this property. This VM gets billed once for each workspace it is connected to. |
 | 11 | Invalid config provided to the extension | Follow the preceding examples to set all property values necessary for deployment. |
-| 20 | Installation of SCX/OMI failed | |
-| 21 | Installation of SCX/Provider kits failed | |
-| 22 | Installation of bundled package failed | |
-| 23 | SCX or OMI package already installed | |
-| 30 | Internal bundle error | |
+| 12 | The dpkg package manager is locked | Make sure all dpkg update operations on the machine have finished and retry. |
 | 51 | This extension is not supported on the VM's operation system | |
-| 60 | Unsupported version of OpenSSL | Install a version of OpenSSL meeting our [package requirements](https://github.com/Microsoft/OMS-Agent-for-Linux/blob/master/docs/OMS-Agent-for-Linux.md#package-requirements). |
 | 61 | Missing Python ctypes library | Install the Python ctypes library or package (python-ctypes). |
-| 62 | Missing tar program | Install tar. |
-| 63 | Missing sed program | Install sed. |
 
-Additional troubleshooting information can be found on the [OMS-Agent-for-Linux Troubleshooting Guide](https://github.com/Microsoft/OMS-Agent-for-Linux/blob/master/docs/Troubleshooting.md#).
+Additional error codes and troubleshooting information can be found on the [OMS-Agent-for-Linux Troubleshooting Guide](https://github.com/Microsoft/OMS-Agent-for-Linux/blob/master/docs/Troubleshooting.md#).
 
 
 [azure-powershell]: https://azure.microsoft.com/en-us/documentation/articles/powershell-install-configure/

--- a/OmsAgent/omsagent.py
+++ b/OmsAgent/omsagent.py
@@ -37,7 +37,7 @@ except Exception as e:
 
 # Global Variables
 PackagesDirectory = 'packages'
-BundleFileName = 'omsagent-1.3.4-127.universal.x64.sh'
+BundleFileName = 'omsagent-1.3.5-127.universal.x64.sh'
 
 # Always use upgrade - will handle install if scx, omi are not installed or
 # upgrade if they are
@@ -731,7 +731,7 @@ def log_and_exit(hutil, operation, exit_code = 1, message = ''):
     if hutil is not None:
         hutil.do_exit(exit_code, operation, exit_status, str(exit_code), message)
     else:
-        update_status_file(operation, exit_code, exit_status, message)
+        update_status_file(operation, str(exit_code), exit_status, message)
         sys.exit(exit_code)
 
 

--- a/OmsAgent/omsagent.py
+++ b/OmsAgent/omsagent.py
@@ -48,8 +48,7 @@ WorkspaceCheckCommandTemplate = '{0} -l'
 OnboardCommandWithOptionalParamsTemplate = '{0} -w {1} -s {2} {3}'
 OmsAgentServiceScript = '/opt/microsoft/omsagent/bin/service_control'
 DisableOmsAgentServiceCommandTemplate = '{0} disable'
-InstallPythonCtypesErrorCode = 61
-InstallTarErrorCode = 62
+DPKGLockedErrorCode = 12
 
 # Configuration
 SettingsSequenceNumber = None
@@ -99,19 +98,17 @@ def main():
         hutil = parse_context(operation)
         exit_code = operations[operation](hutil)
 
-        # For common problems, provide a more descriptive message
+        # Exit code 1 indicates a general problem that doesn't have a more
+        # specific error code; it often indicates a missing dependency
         if exit_code is 1 and operation == 'Install':
             message = 'Install failed with exit code 1. Please check that ' \
-                      'dependencies such as curl and python-ctypes are ' \
-                      'installed.'
-        elif exit_code is InstallTarErrorCode and operation == 'Install':
-            message = 'Install failed with exit code {0}: please install ' \
-                      'tar'.format(InstallTarErrorCode)
-        elif (exit_code is InstallPythonCtypesErrorCode
-                and operation == 'Install'):
-            message = 'Install failed with exit code {0}: please install ' \
-                      'the Python ctypes library or package (python-' \
-                      'ctypes)'.format(InstallPythonCtypesErrorCode)
+                      'dependencies are installed. For details, check logs ' \
+                      'in /var/log/azure/Microsoft.EnterpriseCloud.' \
+                      'Monitoring.OmsAgentForLinux'
+        elif (exit_code is DPKGLockedErrorCode and operation == 'Install'):
+            message = 'Install failed with exit code {0} because the ' \
+                      'package manager on the VM is currently locked: ' \
+                      'please wait and try again'.format(DPKGLockedErrorCode)
         elif exit_code is not 0:
             message = '{0} failed with exit code {1}'.format(operation,
                                                              exit_code)
@@ -432,11 +429,14 @@ def run_command_with_retries(hutil, cmd, retries, check_error = True,
     """
     try_count = 0
     sleep_time = initial_sleep_time # seconds
+    dpkg_locked_search = r'^.*dpkg.+lock.*$'
+    dpkg_locked_re = re.compile(dpkg_locked_search, re.M)
+
     while try_count <= retries:
         exit_code, output = run_command_and_log(hutil, cmd, check_error, log_cmd)
         if exit_code is 0:
             break
-        elif not re.match('^.*dpkg.+lock.*$', output):
+        if not dpkg_locked_re.search(output):
             break
         try_count += 1
         hutil_log_info(hutil, 'Retrying command "{0}" because package manager ' \
@@ -444,6 +444,11 @@ def run_command_with_retries(hutil, cmd, retries, check_error = True,
                               '{1}'.format(cmd, exit_code))
         time.sleep(sleep_time)
         sleep_time *= sleep_increase_factor
+
+    if exit_code is not 0 and dpkg_locked_re.search(output):
+        hutil_log_info(hutil, 'The package manager still appears to be ' \
+                              'locked, so installation cannot completed.')
+        exit_code = DPKGLockedErrorCode
 
     return exit_code
 


### PR DESCRIPTION
Retry logic was not matching output correctly - fixed and tested.
Extension version 1.3.127.5 has been published with omsagent bundle version 1.3.5-127: I have updated the files reflecting that in this PR.
Added error code 12 to signify when dpkg was still locked after our retries; currently there are several, seemingly random, error codes that can be returned when this is the case. This will save time in debugging from logs.

@NarineM 