### PR TITLE
Small fixes to open issues

### DIFF
--- a/Diagnostic/ChangeLogs
+++ b/Diagnostic/ChangeLogs
@@ -1,3 +1,10 @@
+2017-05-10: LAD-3.0.103
+    - Allow '*' in syslog spec, add more fields in syslog records for
+      EventHubs
+
+2017-05-08: LAD-3.0.101
+    - New release of LAD 3.0. Refer to README.md
+
 2017-01-13: LAD-2.3.9021
     - Fix rsyslogd core dump issue when re-enabling the extension
     - Take latest mdsd binary that fixes other issues like missing perf

--- a/Diagnostic/README.md
+++ b/Diagnostic/README.md
@@ -1,20 +1,22 @@
-# Diagnostic Extension
+# Linux Diagnostic Extension (LAD)
 
-Allow the owner of the Azure Virtual Machines to obtain diagnostic data for a Linux virtual machine.
+Allow the owner of a Linux-based Azure Virtual Machine to obtain diagnostic data.
 
-Latest version is 3.0.107.
+Current version is 3.0.107.
 
 Linux Azure Diagnostic (LAD) extension version 3.0 is released with the following changes:
 
-- Fully configurable Azure Portal metrics: Currently only available through CLI. Azure Portal configuration support will be coming soon.
+- Fully configurable Azure Portal metrics, including a broader set of metrics to choose from.
 - Syslog message collection is now opt-in (off by default), and customers can selectively pick and choose syslog facilities and minimum severities of their interests.
 - Customers can now use CLI to configure their Azure Linux VMs for Azure Portal VM metrics charting experiences.
 - Customers can now send any metrics and logs as Azure EventHubs events (additional Azure EventHubs charges may apply).
 - Customers can also store any metrics and logs in Azure Storage JSON blobs (additional Azure Storage charges may apply).
 
-Please note that LAD 3.0 is NOT compatible with LAD 2.3. Therefore, if you'd like to use LAD 3.0, you must first uninstall existing LAD 2.3 on your VMs and reinstall LAD 3.0. Please note that LAD 2.3 will be deprecated soon, so please do upgrade to LAD 3.0 as soon as possible. Currently only CLI-based installation is available, and the Azure Portal installation/configuration of LAD 3.0 will be coming soon.
+LAD 3.0 is NOT compatible with LAD 2.3. Users of LAD 2.3 must first uninstall that extension before installing LAD 3.0.
 
-This README.md file will be finalized very soon with the official documentation. In the meantime, please refer to [this document](virtual-machines-linux-diagnostic-extension-v3.md) for more details on LAD 3.0.
+LAD 3.0 is installed and configured via Azure CLI, Azure PowerShell cmdlets, or Azure Resource Manager templates. The Azure Portal controls installation and configuration of LAD 2.3 only. The Azure Metrics UI can display performance counters collected by either version of LAD.
+
+Please refer to [this document](https://docs.microsoft.com/azure/virtual-machines/linux/diagnostic-extension) for more details on configuring and using LAD 3.0. [tests/lad2_3_compatible_portal_pub_settings.json](tests/lad2_3_compatible_portal_pub_settings.json) contains a sample JSON configuration which sets LAD 3.0 to collecting exactly the same metrics and logs as the default configuration for LAD 2.3 collected. 
 
 ## Supported Linux Distributions
 
@@ -22,7 +24,7 @@ Please note that the distros/versions listed below apply only to Azure-endorsed 
 images. 3rd party BYOL/BYOS images (e.g., appliances) are not generally supported for the
 Linux Diagnostic extension.
 
-- Ubuntu 12.04 and higher.
+- Ubuntu 14.04 and higher.
 - CentOS 6.5 and higher
 - Oracle Linux 6.4.0.0.0 and higher
 - OpenSUSE 13.1 and higher

--- a/Diagnostic/README.md
+++ b/Diagnostic/README.md
@@ -2,7 +2,7 @@
 
 Allow the owner of the Azure Virtual Machines to obtain diagnostic data for a Linux virtual machine.
 
-Latest version is 3.0.101.
+Latest version is 3.0.103.
 
 Linux Azure Diagnostic (LAD) extension version 3.0 is released with the following changes:
 

--- a/Diagnostic/Utils/LadDiagnosticUtil.py
+++ b/Diagnostic/Utils/LadDiagnosticUtil.py
@@ -92,7 +92,7 @@ def getSinkList(feature_config):
     :rtype: [str]
     """
     if feature_config and 'sinks' in feature_config and feature_config['sinks']:
-        return feature_config['sinks'].split(',')
+        return map(str.strip, feature_config['sinks'].split(','))
     return []
 
 

--- a/Diagnostic/Utils/LadDiagnosticUtil.py
+++ b/Diagnostic/Utils/LadDiagnosticUtil.py
@@ -92,7 +92,7 @@ def getSinkList(feature_config):
     :rtype: [str]
     """
     if feature_config and 'sinks' in feature_config and feature_config['sinks']:
-        return map(str.strip, feature_config['sinks'].split(','))
+        return [sink_name.strip() for sink_name in feature_config['sinks'].split(',')]
     return []
 
 

--- a/Diagnostic/diagnostic.py
+++ b/Diagnostic/diagnostic.py
@@ -193,7 +193,8 @@ def create_core_components_configs():
     try:
         config_valid, config_invalid_reason = configurator.generate_all_configs()
     except Exception as e:
-        hutil.error('Unknown exception occurred from generate_all_configs(). Msg: {0}'.format(e))
+        config_invalid_reason = 'Unknown exception occurred from generate_all_configs(). Msg: {0}'.format(e)
+        hutil.error(config_invalid_reason)
         config_valid = False
 
     if not config_valid:

--- a/Diagnostic/lad_config_all.py
+++ b/Diagnostic/lad_config_all.py
@@ -456,7 +456,9 @@ class LadConfigAll:
         account = self._ext_settings.read_protected_config('storageAccountName')
         if not account:
             return False, "Empty storageAccountName"
-        token = self._ext_settings.read_protected_config('storageAccountSasToken')
+        token = self._ext_settings.read_protected_config('storageAccountSasToken').strip()
+        if '?' == token[0]:
+            token = token[1:]
         if not token:
             return False, "Empty storageAccountSasToken"
         endpoint = get_storage_endpoint_with_account(account,

--- a/Diagnostic/manifest.xml
+++ b/Diagnostic/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.Azure.Diagnostics</ProviderNameSpace>
   <Type>LinuxDiagnostic</Type>
-  <Version>3.0.102.1</Version>
+  <Version>3.0.103</Version>
   <Label>Microsoft Azure Diagnostic Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>

--- a/Diagnostic/tests/var_lib_waagent/lad_dir/config/lad_settings_metric.json
+++ b/Diagnostic/tests/var_lib_waagent/lad_dir/config/lad_settings_metric.json
@@ -4,7 +4,7 @@
       "handlerSettings": {
         "protectedSettings": {
           "storageAccountEndPoint": "https://core.windows.net/",
-          "storageAccountSasToken": "NOT_A_REAL_TOKEN",
+          "storageAccountSasToken": "?NOT_A_REAL_TOKEN",
           "storageAccountName": "ladunittestfakeaccount",
           "sinksConfig": {
             "sink": [


### PR DESCRIPTION
Use omsagent's sudo_tail input plug-in to read files regardless of mode (#390)
Set valid extension substatus if parsing the config raises an exception (#398)
Handle leading '?' in SAS token (#399)
Strip names when splitting sink names (#400)
Run all the unit tests as part of BVT
Small corrections to README
Fixed typos in LAD 2.3-compatible config sample (in tests/)
