### PR TITLE
DSCForLinux: Made fixes for Oracle distro

### DIFF
--- a/DSC/dsc.py
+++ b/DSC/dsc.py
@@ -110,7 +110,7 @@ def get_distro_category():
     distro_name = distro_info[0].lower()
     if distro_name == 'ubuntu' or distro_name == 'debian':
         return DistroCategory.debian
-    elif distro_name == 'centos' or distro_name == 'redhat':
+    elif distro_name == 'centos' or distro_name == 'redhat' or distro_name == 'oracle linux server':
         return DistroCategory.redhat
     elif distro_name == 'suse':
         return DistroCategory.suse 

--- a/DSC/dsc.py
+++ b/DSC/dsc.py
@@ -110,12 +110,12 @@ def get_distro_category():
     distro_name = distro_info[0].lower()
     if distro_name == 'ubuntu' or distro_name == 'debian':
         return DistroCategory.debian
-    elif distro_name == 'centos' or distro_name == 'redhat' or distro_name == 'oracle linux server':
+    elif distro_name == 'centos' or distro_name == 'redhat' or distro_name == 'oracle':
         return DistroCategory.redhat
     elif distro_name == 'suse':
         return DistroCategory.suse 
-    waagent.AddExtensionEvent(name=ExtensionShortName, op='InstallInProgress', isSuccess=True, message="Unsupported distro" + distro_info)
-    hutil.do_exit(51, 'Install', 'error', '51', distro_info + 'is not supported.')
+    waagent.AddExtensionEvent(name=ExtensionShortName, op='InstallInProgress', isSuccess=True, message="Unsupported distro :" + distro_name)
+    hutil.do_exit(51, 'Install', 'error', '51', distro_name + 'is not supported.')
 
 def install():
     hutil.do_parse_context('Install')

--- a/DSC/manifest.xml
+++ b/DSC/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.OSTCExtensions</ProviderNameSpace>
   <Type>DSCForLinux</Type>
-  <Version>2.4.0.0</Version>
+  <Version>2.5.0.0</Version>
   <Label>Microsoft Azure DSC Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>


### PR DESCRIPTION
Oracle by default supports python 2.6. Because of this, some of the python code is NOT working in 2.6 but in latest. @eshaparmar