### PR TITLE
Add run_interval to in_sudo_tail fluentd config

### DIFF
--- a/Diagnostic/Utils/lad_logging_config.py
+++ b/Diagnostic/Utils/lad_logging_config.py
@@ -329,6 +329,7 @@ class LadLoggingConfig:
   pos_file /var/opt/microsoft/omsagent/LAD/tmp/filelogs.pos
   tag mdsd.filelog.*
   format none
+  run_interval 15s
 </source>
 
 # Add FileTag field, rename message to Msg


### PR DESCRIPTION
The sudo_tail input plug-in requires a run_interval which controls how often it checks for new content in the file(s) it's monitoring.