### PR TITLE
Require SAS token cred; reject storageKey cred

### DIFF
--- a/Diagnostic/ChangeLogs
+++ b/Diagnostic/ChangeLogs
@@ -1,3 +1,7 @@
+2017-09-05: LAD-3.0.111
+    - Ensure SAS storage token is supplied
+    - Explicitly reject deprecated use of LAD 2.3's storageAccountKey
+
 2017-08-11: LAD-3.0.109
     - Fix waagent-related issue on Debian distros
     - Add additional unit tests

--- a/Diagnostic/README.md
+++ b/Diagnostic/README.md
@@ -2,7 +2,7 @@
 
 Allow the owner of a Linux-based Azure Virtual Machine to obtain diagnostic data.
 
-Current version is 3.0.108.
+Current version is 3.0.111.
 
 Linux Azure Diagnostic (LAD) extension version 3.0 is released with the following changes:
 

--- a/Diagnostic/Utils/lad_ext_settings.py
+++ b/Diagnostic/Utils/lad_ext_settings.py
@@ -89,6 +89,9 @@ class LadExtSettings(ExtSettings):
         # The logic below could have been a general-purpose JSON tree walker, but since the specific
         # knowledge of where secrets are needs be applied anyway, it's coded for this specific schema anyway.
         # Secrets are stored only in the following paths: .storageAccountSasToken, and .sinksConfig.sink[].sasURL.
+        # LAD 2.3 used to support storageAccountKey; although LAD 3.0 does not support it, some users might mistakenly
+        # supply it. We redact it, if present, even though we're going to throw an error later on; the protected
+        # settings are logged before we inspect them to pull out the credentials.
 
         # Get and work on a copy of the handler settings dict. Note that it must be a deep copy!
         # dict(self.get_handler_settings()) doesn't work!
@@ -97,6 +100,8 @@ class LadExtSettings(ExtSettings):
         if protected_settings:
             if 'storageAccountSasToken' in protected_settings:
                 protected_settings['storageAccountSasToken'] = 'REDACTED_SECRET'
+            if 'storageAccountKey' in protected_settings:
+                protected_settings['storageAccountKey'] = 'REDACTED_SECRET'
             if 'sinksConfig' in protected_settings and 'sink' in protected_settings['sinksConfig']:
                 for each_sink_dict in protected_settings['sinksConfig']['sink']:
                     if 'sasURL' in each_sink_dict:

--- a/Diagnostic/lad_config_all.py
+++ b/Diagnostic/lad_config_all.py
@@ -452,14 +452,16 @@ class LadConfigAll:
 
         # 6. Actually update the storage account settings on mdsd config XML tree (based on extension's
         #    protectedSettings).
-        account = self._ext_settings.read_protected_config('storageAccountName')
+        account = self._ext_settings.read_protected_config('storageAccountName').strip()
         if not account:
-            return False, "Empty storageAccountName"
+            return False, "Must specify storageAccountName"
+        if self._ext_settings.read_protected_config('storageAccountKey'):
+            return False, "The storageAccountKey protected setting is not supported and must not be used"
         token = self._ext_settings.read_protected_config('storageAccountSasToken').strip()
+        if not token or token == '?':
+            return False, "Must specify storageAccountSasToken"
         if '?' == token[0]:
             token = token[1:]
-        if not token:
-            return False, "Empty storageAccountSasToken"
         endpoint = get_storage_endpoint_with_account(account,
                                                      self._ext_settings.read_protected_config('storageAccountEndPoint'))
         self._update_account_settings(account, token, endpoint)


### PR DESCRIPTION
Fixes #451 
Also, reject any attempt to support storage key _a la_ LAD 2.3; while LAD 2.3 continues to support that for backwards compatibility, it's not a good thing from a security standpoint. With this change, if a user attempts to pass that to LAD 3.0, the extension will refuse to start up.
