### PR TITLE
Report traceback when unhandled exception occurs while building configs.

### DIFF
--- a/Diagnostic/diagnostic.py
+++ b/Diagnostic/diagnostic.py
@@ -193,7 +193,8 @@ def create_core_components_configs():
     try:
         config_valid, config_invalid_reason = configurator.generate_all_configs()
     except Exception as e:
-        config_invalid_reason = 'Unknown exception occurred from generate_all_configs(). Msg: {0}'.format(e)
+        config_invalid_reason =\
+            'Exception while generating configs: {0}. Traceback: {1}'.format(e, traceback.format_exc())
         hutil.error(config_invalid_reason)
         config_valid = False
 


### PR DESCRIPTION
Exceptions shouldn't leak from the configuration processing code. If they do, though, a traceback would make it easier to find the problem.