### PR TITLE
Fix race when starting -daemon instance. Improve error messages.

### DIFF
--- a/Diagnostic/Utils/misc_helpers.py
+++ b/Diagnostic/Utils/misc_helpers.py
@@ -148,7 +148,8 @@ class LadLogHelper(object):
         :return: None
         """
         config_invalid_log = "Invalid config settings given: " + config_invalid_reason + \
-                             ". Can't proceed, but this will be still considered a success as it's an external error."
+                             ". Can't proceed, although this install/enable operation is reported as successful so " \
+                             "the VM can complete successful startup."
         self._logger_log(config_invalid_log)
         self._status_reporter(ext_event_type, 'success', '0', config_invalid_log)
         self._waagent_event_adder(name=self._ext_name,
@@ -165,16 +166,16 @@ class LadLogHelper(object):
         :param mdsd_cfg_xml: Content of xmlCfg.xml to be sent to Geneva
         :return: None
         """
-        message = "Invalid mdsd config given. Can't enable. This extension install/enable operation is reported as " \
-                  "successful so the VM can complete successful startup. Linux Diagnostic Extension will exit. " \
-                  "Config validation message: {0}.".format(config_validate_cmd_msg)
+        message = "Problem(s) detected in generated mdsd configuration. Can't enable, although this install/enable " \
+                  "operation is reported as successful so the VM can complete successful startup. Linux Diagnostic " \
+                  "Extension will exit. Config validation message: {0}".format(config_validate_cmd_msg)
         self._logger_log(message)
         self._status_reporter(ext_event_type, 'success', '0', message)
         self._waagent_event_adder(name=self._ext_name,
-                                  op=ext_event_type,
-                                  isSuccess=True,  # Note this is True, because it is a user error.
-                                  version=self._ext_ver,
-                                  message="Invalid mdsd config encountered: {0}".format(mdsd_cfg_xml))
+                      op=ext_event_type,
+                      isSuccess=True,  # Note this is True, because it is a user error.
+                      version=self._ext_ver,
+                      message="Problem(s) detected in generated mdsd configuration: {0}".format(mdsd_cfg_xml))
 
 def read_uuid():
     uuid = ''

--- a/Diagnostic/diagnostic.py
+++ b/Diagnostic/diagnostic.py
@@ -291,7 +291,9 @@ def main(command):
                     stop_mdsd()
                     start_daemon()
             hutil.set_inused_config_seq(hutil.get_seq_no())
-            hutil.do_status_report(g_ext_op_type, "success", '0', "Enable succeeded")
+            hutil.do_status_report(g_ext_op_type, "success", '0', "Enable succeeded, extension daemon started")
+            # If the -daemon detects a problem, e.g. bad configuration, it will overwrite this status with a more
+            # informative one. If it succeeds, all is well.
 
         elif g_ext_op_type is "Daemon":
             configurator = create_core_components_configs()
@@ -310,19 +312,14 @@ def main(command):
 
 def start_daemon():
     """
-    Start diagnostic.py as a daemon for long running mdsd and its monitoring
+    Start diagnostic.py as a daemon for scheduled tasks and to monitor mdsd daemon. If Popen() has a problem it will
+    raise an exception (often OSError)
     :return: None
     """
     args = ['python', g_diagnostic_py_filepath, "-daemon"]
     log = open(os.path.join(os.getcwd(), 'daemon.log'), 'w')
     hutil.log('start daemon ' + str(args))
     subprocess.Popen(args, stdout=log, stderr=log)
-    wait_n = 20
-    while len(get_lad_pids()) == 0 and wait_n > 0:
-        time.sleep(5)
-        wait_n -= 1
-    if wait_n <= 0:
-        hutil.error("wait daemon start time out")
 
 
 def start_watcher_thread():
@@ -479,7 +476,7 @@ def start_mdsd(configurator):
             hutil.error("MDSD crashed:" + mdsd_crash_msg)
 
         # mdsd all 3 allowed quick/consecutive crashes exhausted
-        hutil.do_status_report(waagent_ext_event_type, "error", '1', "mdsd stopped:" + mdsd_crash_msg)
+        hutil.do_status_report(waagent_ext_event_type, "error", '1', "mdsd stopped: " + mdsd_crash_msg)
         # Need to tear down omsagent setup for LAD before returning/exiting if it was set up earlier
         oms.tear_down_omsagent_for_lad(RunGetOutput, False)
         try:
@@ -494,14 +491,14 @@ def start_mdsd(configurator):
     except Exception as e:
         if mdsd_stdout_stream:
             hutil.error("Error :" + tail(mdsd_stdout_redirect_path))
-        hutil.error(("Failed to launch mdsd with error:{0},"
-                     "stacktrace:{1}").format(e, traceback.format_exc()))
-        hutil.do_status_report(waagent_ext_event_type, 'error', '1', 'Launch script failed:{0}'.format(e))
+        errmsg = "Failed to launch mdsd with error: {0}, traceback: {1}".format(e, traceback.format_exc())
+        hutil.error(errmsg)
+        hutil.do_status_report(waagent_ext_event_type, 'error', '1', errmsg)
         waagent.AddExtensionEvent(name=hutil.get_name(),
                                   op=waagent_ext_event_type,
                                   isSuccess=False,
                                   version=hutil.get_extension_version(),
-                                  message="Launch script failed:" + str(e))
+                                  message=errmsg)
     finally:
         if mdsd_stdout_stream:
             mdsd_stdout_stream.close()


### PR DESCRIPTION
During -enable on non-systemd distros, diagnostic.py would start another instance of LAD in the -daemon role, checking every five seconds to see if the child started. If the child started and died during one of the 5-second sleep periods (writing a substatus in the process), the -enable parent would miss that. After a total of 20 (now futile) waiting periods, the -enable parent would overwrite the substatus written by the failed -daemon instance. This change eliminates the waiting period. Instead, the -enable instance starts the -daemon instance and immediately writes a "I've started the daemon" substatus. The -daemon instance will overwrite that with either success or failure, appropriately.

When running on systemd-enabled distros, that's exactly how LAD already behaves.
