### PR TITLE
VMEncryption: Centos partition issue fix

### DIFF
--- a/VMEncryption/main/Common.py
+++ b/VMEncryption/main/Common.py
@@ -20,7 +20,7 @@
 class CommonVariables:
     utils_path_name = 'Utils'
     extension_name = 'AzureDiskEncryptionForLinux'
-    extension_version = '0.1.0.999305'
+    extension_version = '0.1.0.999306'
     extension_type = extension_name
     extension_media_link = 'https://amextpaas.blob.core.windows.net/prod/' + extension_name + '-' + str(extension_version) + '.zip'
     extension_label = 'Windows Azure VMEncryption Extension for Linux IaaS'

--- a/VMEncryption/main/oscrypto/centos_68/encryptstates/SplitRootPartitionState.py
+++ b/VMEncryption/main/oscrypto/centos_68/encryptstates/SplitRootPartitionState.py
@@ -118,7 +118,7 @@ class SplitRootPartitionState(OSEncryptionState):
         self.command_executor.Execute("partprobe", False)
 
         retry_counter = 0
-        while not os.path.isfile(self.bootfs_block_device) and retry_counter < 10:
+        while not os.path.exists(self.bootfs_block_device) and retry_counter < 10:
             sleep(5)
             self.command_executor.Execute("partprobe", False)
             retry_counter += 1

--- a/VMEncryption/main/oscrypto/centos_68/encryptstates/SplitRootPartitionState.py
+++ b/VMEncryption/main/oscrypto/centos_68/encryptstates/SplitRootPartitionState.py
@@ -116,6 +116,13 @@ class SplitRootPartitionState(OSEncryptionState):
         disk.commit()
         
         self.command_executor.Execute("partprobe", False)
+
+        retry_counter = 0
+        while not os.path.isfile(self.bootfs_block_device) and retry_counter < 10:
+            sleep(5)
+            self.command_executor.Execute("partprobe", False)
+            retry_counter += 1
+
         self.command_executor.Execute("mkfs.ext2 {0}".format(self.bootfs_block_device), True)
         
         boot_partition_uuid = self._get_uuid(self.bootfs_block_device)


### PR DESCRIPTION
Fix for https://icm.ad.msft.net/imp/v3/incidents/details/49002787/home

For this fix we wait for the partition table changes to be read before proceeding to format the new drives.