### PR TITLE
Code changes for VMSS reimage

### DIFF
--- a/VMEncryption/VMEncryption.pyproj
+++ b/VMEncryption/VMEncryption.pyproj
@@ -22,7 +22,6 @@
   </PropertyGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
-    <PtvsTargetsFile>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets</PtvsTargetsFile>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="MANIFEST.in" />
@@ -174,6 +173,5 @@
     <Folder Include="main\patch\" />
     <Folder Include="main\Utils\" />
   </ItemGroup>
-  <Import Project="$(PtvsTargetsFile)" Condition="Exists($(PtvsTargetsFile))" />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" Condition="!Exists($(PtvsTargetsFile))" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets" />
 </Project>

--- a/VMEncryption/VMEncryption.pyproj
+++ b/VMEncryption/VMEncryption.pyproj
@@ -64,6 +64,7 @@
     <Compile Include="main\patch\debianPatching.py">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="main\ResourceDiskUtil.py" />
     <Compile Include="main\TransactionalCopyTask.py">
       <SubType>Code</SubType>
     </Compile>

--- a/VMEncryption/main/BekUtil.py
+++ b/VMEncryption/main/BekUtil.py
@@ -98,6 +98,11 @@ class BekUtil(object):
 
                     if os.path.exists(os.path.join(self.bek_filesystem_mount_point, bek_filename)):
                         return os.path.join(self.bek_filesystem_mount_point, bek_filename)
+
+                    for file in os.listdir(self.bek_filesystem_mount_point):
+                        if bek_filename in file:
+                            return os.path.join(self.bek_filesystem_mount_point, file)
+
                 except Exception as e:
                     message = "Failed to get BEK from {0} with error: {1}".format(azure_device, e)
                     self.logger.log(message)

--- a/VMEncryption/main/DiskUtil.py
+++ b/VMEncryption/main/DiskUtil.py
@@ -122,7 +122,7 @@ class DiskUtil(object):
                 device_item_path = self.get_device_path(device_item.name)
                 device_item_real_path = os.path.realpath(device_item_path)
                 for crypt_item in crypt_items:
-                    if rootfs_crypt_item_found.path.realpath(crypt_item.dev_path) == device_item_real_path:
+                    if os.path.realpath(crypt_item.dev_path) == device_item_real_path:
                         found_in_crypt_mount = True
                         break
                 if found_in_crypt_mount:

--- a/VMEncryption/main/DiskUtil.py
+++ b/VMEncryption/main/DiskUtil.py
@@ -105,7 +105,7 @@ class DiskUtil(object):
         crypt_item.mount_point = crypt_mount_item_properties[3]
         crypt_item.file_system = crypt_mount_item_properties[4]
         crypt_item.uses_cleartext_key = True if crypt_mount_item_properties[5] == "True" else False
-        crypt_item.current_luks_slot = int(crypt_mount_item_properties[6]) if crypt_mount_item_properties.length > 6 else -1
+        crypt_item.current_luks_slot = int(crypt_mount_item_properties[6]) if len(crypt_mount_item_properties) > 6 else -1
 
         return crypt_item
 
@@ -174,8 +174,8 @@ class DiskUtil(object):
                         if not line.strip():
                             continue
                         # copy the crypt_item from the backup to the central os location
-                        crypt_item = parse_azure_crypt_mount_line(line)
-                        self.add_crypt_item(crypt_item)
+                        parsed_crypt_item = self.parse_azure_crypt_mount_line(line)
+                        self.add_crypt_item(parsed_crypt_item)
 
                 # close the file and then unmount and close
                 self.umount(temp_mount_point)
@@ -202,7 +202,7 @@ class DiskUtil(object):
                     if not line.strip():
                         continue
 
-                    crypt_item = parse_azure_crypt_mount_line(line)
+                    crypt_item = self.parse_azure_crypt_mount_line(line)
 
                     if crypt_item.mount_point == "/":
                         rootfs_crypt_item_found = True
@@ -269,13 +269,13 @@ class DiskUtil(object):
                                   str(crypt_item.current_luks_slot)) + "\n"
 
             with open(self.encryption_environment.azure_crypt_mount_config_path,'a') as wf:
-                wf.write(new_mount_content)
+                wf.write(mount_content_item)
 
             if backup_folder is not None:
                 backup_file = os.path.join(backup_folder, "azure_crypt_mount_line")
                 self.make_sure_path_exists(backup_folder)
                 with open(backup_file, "w") as wf:
-                    wf.write(new_mount_content)
+                    wf.write(mount_content_item)
 
             return True
         except Exception as e:

--- a/VMEncryption/main/DiskUtil.py
+++ b/VMEncryption/main/DiskUtil.py
@@ -171,6 +171,7 @@ class DiskUtil(object):
                 }
         """
         proc_comm = ProcessCommunicator()
+        lsblk_command = "lsblk -p -o NAME,FSTYPE,MOUNTPOINT --json"
         self.command_executor.Execute(lsblk_command, communicator=proc_comm, raise_exception_on_failure=True, suppress_logging=True)
 
         lsblk_tree = json.loads(proc_comm.stdout)["blockdevices"]

--- a/VMEncryption/main/EncryptionSettingsUtil.py
+++ b/VMEncryption/main/EncryptionSettingsUtil.py
@@ -147,7 +147,7 @@ class EncryptionSettingsUtil(object):
 
         # Get all the currently encrypted items from the Azure Crypt Mount file (hopefully this has been consolidated by now)
         existing_crypt_items = disk_util.get_crypt_items()
-        existing_crypt_dev_items = self.get_disk_items_from_crypt_items(existing_crypt_items)
+        existing_crypt_dev_items = self.get_disk_items_from_crypt_items(existing_crypt_items, disk_util)
 
         all_device_items = existing_crypt_dev_items + extra_device_items
 

--- a/VMEncryption/main/EncryptionSettingsUtil.py
+++ b/VMEncryption/main/EncryptionSettingsUtil.py
@@ -149,18 +149,18 @@ class EncryptionSettingsUtil(object):
 
         def controller_id_and_lun_to_settings_data(scsi_controller, lun_number):
             return {
-                    "ControllerType": "SCSI",
-                    "ControllerId": scsi_controller,
-                    "SlotId": lun_number,
-                    "Volumes": [{
-                            "VolumeType": "DataVolume",
-                            "ProtectorFileName": protector_name,
-                            "SecretTags": dict_to_name_value_array({
-                                "DiskEncryptionKeyFileName": CommonVariables.encryption_key_file_name + "_" + str(scsi_controller) + "_" + str(lun_number),
-                                "DiskEncryptionKeyEncryptionKeyURL": kek_url,
-                                "DiskEncryptionKeyEncryptionAlgorithm": kek_algorithm,
-                                "MachineName": machine_name})
-                        }]
+                "ControllerType": "SCSI",
+                "ControllerId": scsi_controller,
+                "SlotId": lun_number,
+                "Volumes": [{
+                    "VolumeType": "DataVolume",
+                    "ProtectorFileName": protector_name,
+                    "SecretTags": dict_to_name_value_array({
+                        "DiskEncryptionKeyFileName": CommonVariables.encryption_key_file_name + "_" + str(scsi_controller) + "_" + str(lun_number),
+                        "DiskEncryptionKeyEncryptionKeyURL": kek_url,
+                        "DiskEncryptionKeyEncryptionAlgorithm": kek_algorithm,
+                        "MachineName": machine_name})
+                    }]
                 }
 
         data_disks_settings_data = [ controller_id_and_lun_to_settings_data(scsi_controller, lun_number)
@@ -174,24 +174,7 @@ class EncryptionSettingsUtil(object):
             "KekUrl": kek_url,
             "KekVaultResourceId": kek_kv_id,
             "KekAlgorithm": kek_algorithm,
-            "Disks": [
-                {
-                    "ControllerType": "IDE",
-                    "ControllerId": 0,
-                    "SlotId": 0,
-                    "Volumes": [
-                        {
-                            "VolumeType": "OsVolume",
-                            "ProtectorFileName": protector_name,
-                            "SecretTags": dict_to_name_value_array({
-                                "DiskEncryptionKeyFileName": CommonVariables.encryption_key_file_name,
-                                "DiskEncryptionKeyEncryptionKeyURL": kek_url,
-                                "DiskEncryptionKeyEncryptionAlgorithm": kek_algorithm,
-                                "MachineName": machine_name})
-                        }
-                    ]
-                }
-            ] + data_disks_settings_data
+            "Disks": data_disks_settings_data
         }
         return data
 

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -276,7 +276,8 @@ def update_encryption_settings():
                 kv_id=extension_parameter.KeyVaultResourceId,
                 kek_url=extension_parameter.KeyEncryptionKeyURL,
                 kek_kv_id=extension_parameter.KekVaultResourceId,
-                kek_algorithm=extension_parameter.KeyEncryptionAlgorithm)
+                kek_algorithm=extension_parameter.KeyEncryptionAlgorithm,
+                disk_util=disk_util)
             settings.write_settings_file(data)
             settings.post_to_wireserver()
             settings.remove_protector_file(new_protector_name)
@@ -695,7 +696,8 @@ def enable_encryption():
                         kv_id=extension_parameter.KeyVaultResourceId,
                         kek_url=extension_parameter.KeyEncryptionKeyURL,
                         kek_kv_id=extension_parameter.KekVaultResourceId,
-                        kek_algorithm=extension_parameter.KeyEncryptionAlgorithm)
+                        kek_algorithm=extension_parameter.KeyEncryptionAlgorithm,
+                        disk_util=disk_util)
                     settings.write_settings_file(data)
                     settings.post_to_wireserver()
                     settings.remove_protector_file(new_protector_name)
@@ -1361,26 +1363,18 @@ def enable_encryption_all_in_place(passphrase_file, encryption_marker, disk_util
             logger.log("error occured when do the umount for: {0} with code: {1}".format(device_item.mount_point, umount_status_code))
         else:
             logger.log(msg=("encrypting: {0}".format(device_item)))
-            no_header_file_support = not_support_header_option_distro(DistroPatcher)
             status_prefix = "Encrypting data volume {0}/{1}".format(device_num + 1,
                                                                     len(device_items_to_encrypt))
 
             #TODO check the file system before encrypting it.
-            if no_header_file_support:
-                logger.log(msg="this is the centos 6 or redhat 6 or sles 11 series, need to resize data drive",
-                           level=CommonVariables.WarningLevel)
+            logger.log(msg="For VMSS we only do inplace headers",
+                       level=CommonVariables.WarningLevel)
 
-                encryption_result_phase = encrypt_inplace_without_seperate_header_file(passphrase_file=passphrase_file,
-                                                                                       device_item=device_item,
-                                                                                       disk_util=disk_util,
-                                                                                       bek_util=bek_util,
-                                                                                       status_prefix=status_prefix)
-            else:
-                encryption_result_phase = encrypt_inplace_with_seperate_header_file(passphrase_file=passphrase_file,
-                                                                                    device_item=device_item,
-                                                                                    disk_util=disk_util,
-                                                                                    bek_util=bek_util,
-                                                                                    status_prefix=status_prefix)
+            encryption_result_phase = encrypt_inplace_without_seperate_header_file(passphrase_file=passphrase_file,
+                                                                                   device_item=device_item,
+                                                                                   disk_util=disk_util,
+                                                                                   bek_util=bek_util,
+                                                                                   status_prefix=status_prefix)
                 
             if encryption_result_phase == CommonVariables.EncryptionPhaseDone:
                 continue


### PR DESCRIPTION
	1) We now stamp the VHDs which are encrypted instead of the OS disk
	2) We now don't do detached LUKS headers 
	3) We store the relevant line of azure_crypt_mount on a hidden folder on the encrypted device
        4)We scan all attached devices when the extension is run and try to see if there any encrypted devices that are not in the azure_crypt_mount. If there are such devices we extract the lines from them and add them to the azure_crypt_mount file.