### PR TITLE
Enable debian9 & remove hardcoded extension errors

### DIFF
--- a/OmsAgent/Fairfax/omsagent_ff.py
+++ b/OmsAgent/Fairfax/omsagent_ff.py
@@ -82,6 +82,9 @@ ManagedIdentityExtMissingErrorCode = 41
 ManagedIdentityExtErrorCode = 42
 MetadataAPIErrorCode = 43
 OMSServiceOneClickErrorCode = 44
+MissingorInvalidParameterErrorCode = 11
+UnwantedMultipleConnectionsErrorCode = 10
+CannotConnectToOMSErrorCode = 55
 
 # Configuration
 HUtilObject = None
@@ -359,9 +362,9 @@ def enable():
 def remove_workspace_configuration():
     """
     This is needed to distinguish between extension removal vs extension upgrade.
-    Its a workaround for waagent upgrade routine calling 'remove' on an old version 
-    before calling 'upgrade' on new extension version issue. 
-    In upgrade case, we need workspace configuration to persist when in 
+    Its a workaround for waagent upgrade routine calling 'remove' on an old version
+    before calling 'upgrade' on new extension version issue.
+    In upgrade case, we need workspace configuration to persist when in
     remove case we need all the files be removed.
 
     This method will remove all the files/folders from the workspace path in Etc and Var.
@@ -488,7 +491,7 @@ def is_vm_supported_for_extension():
                        'centos' : ('5', '6', '7'), # CentOS
                        'red hat' : ('5', '6', '7'), # Oracle, RHEL
                        'oracle' : ('5', '6', '7'), # Oracle
-                       'debian' : ('6', '7', '8'), # Debian
+                       'debian' : ('6', '7', '8', '9'), # Debian
                        'ubuntu' : ('12.04', '14.04', '15.04', '15.10',
                                    '16.04', '16.10'), # Ubuntu
                        'suse' : ('11', '12') #SLES
@@ -857,7 +860,7 @@ def run_command_with_retries(cmd, retries, retry_check, final_check = None,
 
 def is_dpkg_locked(exit_code, output):
     """
-    If dpkg is locked, the output will contain a message similar to 'dpkg 
+    If dpkg is locked, the output will contain a message similar to 'dpkg
     status database is locked by another process'
     """
     if exit_code is not 0:
@@ -1125,7 +1128,7 @@ def get_latest_seq_no():
         except:
             pass
         if latest_seq_no < 0:
-            latest_seq_no = 0    
+            latest_seq_no = 0
         SettingsSequenceNumber = latest_seq_no
 
     return SettingsSequenceNumber
@@ -1483,7 +1486,7 @@ class ParameterMissingException(OmsAgentForLinuxException):
     """
     There is a missing parameter for the OmsAgentForLinux Extension
     """
-    error_code = 11
+    error_code = MissingorInvalidParameterErrorCode
     def get_error_message(self, operation):
         return '{0} failed due to a missing parameter: {1}'.format(operation,
                                                                    self)
@@ -1494,7 +1497,7 @@ class InvalidParameterError(OmsAgentForLinuxException):
     There is an invalid parameter for the OmsAgentForLinux Extension
     ex. Workspace ID does not match GUID regex
     """
-    error_code = 11
+    error_code = MissingorInvalidParameterErrorCode
     def get_error_message(self, operation):
         return '{0} failed due to an invalid parameter: {1}'.format(operation,
                                                                     self)
@@ -1505,7 +1508,7 @@ class UnwantedMultipleConnectionsException(OmsAgentForLinuxException):
     This VM is already connected to a different Log Analytics workspace
     and stopOnMultipleConnections is set to true
     """
-    error_code = 10
+    error_code = UnwantedMultipleConnectionsErrorCode
     def get_error_message(self, operation):
         return '{0} failed due to multiple connections: {1}'.format(operation,
                                                                     self)
@@ -1515,7 +1518,7 @@ class CannotConnectToOMSException(OmsAgentForLinuxException):
     """
     The OMSAgent cannot connect to the OMS service
     """
-    error_code = 55 # error code to indicate no internet access
+    error_code = CannotConnectToOMSErrorCode # error code to indicate no internet access
     def get_error_message(self, operation):
         return 'The agent could not connect to the Microsoft Operations ' \
                'Management Suite service. Please check that the system ' \

--- a/OmsAgent/omsagent.py
+++ b/OmsAgent/omsagent.py
@@ -82,6 +82,9 @@ ManagedIdentityExtMissingErrorCode = 41
 ManagedIdentityExtErrorCode = 42
 MetadataAPIErrorCode = 43
 OMSServiceOneClickErrorCode = 44
+MissingorInvalidParameterErrorCode = 11
+UnwantedMultipleConnectionsErrorCode = 10
+CannotConnectToOMSErrorCode = 55
 
 # Configuration
 HUtilObject = None
@@ -489,7 +492,7 @@ def is_vm_supported_for_extension():
                        'centos' : ('5', '6', '7'), # CentOS
                        'red hat' : ('5', '6', '7'), # Oracle, RHEL
                        'oracle' : ('5', '6', '7'), # Oracle
-                       'debian' : ('6', '7', '8'), # Debian
+                       'debian' : ('6', '7', '8', '9'), # Debian
                        'ubuntu' : ('12.04', '14.04', '15.04', '15.10',
                                    '16.04', '16.10'), # Ubuntu
                        'suse' : ('11', '12') #SLES
@@ -1484,7 +1487,7 @@ class ParameterMissingException(OmsAgentForLinuxException):
     """
     There is a missing parameter for the OmsAgentForLinux Extension
     """
-    error_code = 11
+    error_code = MissingorInvalidParameterErrorCode
     def get_error_message(self, operation):
         return '{0} failed due to a missing parameter: {1}'.format(operation,
                                                                    self)
@@ -1495,7 +1498,7 @@ class InvalidParameterError(OmsAgentForLinuxException):
     There is an invalid parameter for the OmsAgentForLinux Extension
     ex. Workspace ID does not match GUID regex
     """
-    error_code = 11
+    error_code = MissingorInvalidParameterErrorCode
     def get_error_message(self, operation):
         return '{0} failed due to an invalid parameter: {1}'.format(operation,
                                                                     self)
@@ -1506,7 +1509,7 @@ class UnwantedMultipleConnectionsException(OmsAgentForLinuxException):
     This VM is already connected to a different Log Analytics workspace
     and stopOnMultipleConnections is set to true
     """
-    error_code = 10
+    error_code = UnwantedMultipleConnectionsErrorCode
     def get_error_message(self, operation):
         return '{0} failed due to multiple connections: {1}'.format(operation,
                                                                     self)
@@ -1516,7 +1519,7 @@ class CannotConnectToOMSException(OmsAgentForLinuxException):
     """
     The OMSAgent cannot connect to the OMS service
     """
-    error_code = 55 # error code to indicate no internet access
+    error_code = CannotConnectToOMSErrorCode # error code to indicate no internet access
     def get_error_message(self, operation):
         return 'The agent could not connect to the Microsoft Operations ' \
                'Management Suite service. Please check that the system ' \


### PR DESCRIPTION
Added Debian 9 to the supported_dists.
Updated the hardcoded error_codes and placed in the header.