### PR TITLE
Blob storage download fails with parent folder

### DIFF
--- a/DSC/dsc.py
+++ b/DSC/dsc.py
@@ -548,6 +548,10 @@ def download_azure_blob(account_name, account_key, file_uri, download_dir):
         (blob_name, container_name) = parse_blob_uri(file_uri)
         host_base = get_host_base_from_uri(file_uri)
         
+        blob_parent_path = os.path.join(download_dir, os.path.dirname(blob_name))
+        if not os.path.exists(blob_parent_path):
+            os.makedirs(blob_parent_path)
+
         download_path = os.path.join(download_dir, blob_name)
         blob_service = BlobService(account_name, account_key, host_base=host_base)
     except Exception as e:


### PR DESCRIPTION
If the blob_name returned by parse_blob_uri contains a parent folder (IE: DSC/dscExtension.mof), then the get_blob_to_path call will fail due to the the parent path not existing (IE: /var/lib/waagent/Microsoft.OSTCExtensions.DSCForLinux-2.70.0.4/download/4/DSC) when the file is opened.  This change adds a check for the parent path, and creates it if it doesn't exist.