### PR TITLE
Wrong parameter inside VMAccess

### DIFF
--- a/VMAccess/vmaccess.py
+++ b/VMAccess/vmaccess.py
@@ -61,7 +61,7 @@ def main():
 
 def install():
     hutil = Util.HandlerUtility(waagent.Log, waagent.Error)
-    hutil.do_parse_context('Uninstall')
+    hutil.do_parse_context('Install')
     hutil.do_exit(0, 'Install', 'success', '0', 'Install Succeeded')
 
 


### PR DESCRIPTION
Parameter 'Uninstall' was being passed to hutil.do_parse_context()
inside the function install().

Signed-off-by: Eduardo Otubo <otubo@redhat.com>