### PR TITLE
Add DSC operation status files for telemetry

### DIFF
--- a/OmsAgent/watcherutil.py
+++ b/OmsAgent/watcherutil.py
@@ -110,7 +110,10 @@ class Watcher:
         status_files = [
                 "/var/opt/microsoft/omsagent/log/ODSIngestion.status",
                 "/var/opt/microsoft/omsagent/log/ODSIngestionBlob.status",
-                "/var/opt/microsoft/omsagent/log/ODSIngestionAPI.status"
+                "/var/opt/microsoft/omsagent/log/ODSIngestionAPI.status",
+                "/var/opt/microsoft/omsconfig/status/dscperformrequiredconfigurationchecks",
+                "/var/opt/microsoft/omsconfig/status/dscperforminventory",
+                "/var/opt/microsoft/omsconfig/status/dscsetdsclocalconfigurationmanager"
             ]
         for sf in status_files:
             if os.path.isfile(sf):


### PR DESCRIPTION
This PR adds the 3 current DSC operation status files for collections by the OMS Agent extension telemetry.
The 3 DSC operations are:
- PerformRequiredConfigurationChecks
- PerformInventory
- SetDscLocalConfigurationManager

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/azure-linux-extensions/608)
<!-- Reviewable:end -->
