### PR TITLE
CRI 75202646 - some settings are mandatory

### DIFF
--- a/VMAccess/README.md
+++ b/VMAccess/README.md
@@ -240,10 +240,20 @@ For more details about ARM template, please visit [Authoring Azure Resource Mana
 ## 3. Scenarios
 
 ### 3.1 Resetting the password
+
+in the Public Settings
+```json
+{
+  "check_disk": "false"
+}
+```
+
+in the Protectect Settings
 ```json
 {
   "username": "currentusername",
-  "password": "newpassword"
+  "password": "newpassword",
+  "reset_ssh": "false"
 }
 ```
 


### PR DESCRIPTION
VMAccessForLinux makes a blanket check for reset based on the user setting a password.
If the return of this method is True, the SSH server will be reset.

Source code is here https://github.com/Azure/azure-linux-extensions/blob/master/VMAccess/vmaccess.py#L135 

 

 

And the same goes for check_disk – cf https://github.com/Azure/azure-linux-extensions/blob/master/VMAccess/vmaccess.py#L416