### PR TITLE
Shorten DSC operation names for OMS Agent telemetry

### DIFF
--- a/OmsAgent/watcherutil.py
+++ b/OmsAgent/watcherutil.py
@@ -111,9 +111,9 @@ class Watcher:
                 "/var/opt/microsoft/omsagent/log/ODSIngestion.status",
                 "/var/opt/microsoft/omsagent/log/ODSIngestionBlob.status",
                 "/var/opt/microsoft/omsagent/log/ODSIngestionAPI.status",
-                "/var/opt/microsoft/omsconfig/status/dscperformrequiredconfigurationchecks",
+                "/var/opt/microsoft/omsconfig/status/dscperformconsistency",
                 "/var/opt/microsoft/omsconfig/status/dscperforminventory",
-                "/var/opt/microsoft/omsconfig/status/dscsetdsclocalconfigurationmanager"
+                "/var/opt/microsoft/omsconfig/status/dscsetlcm"
             ]
         for sf in status_files:
             if os.path.isfile(sf):


### PR DESCRIPTION
This is in conjunction with the DSC PR: https://github.com/Microsoft/PowerShell-DSC-for-Linux/pull/418

Since the operation names have been shortened, this changes the status file names as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/azure-linux-extensions/616)
<!-- Reviewable:end -->
