### PR TITLE
Format telemetry event message and success strings for JSON

### DIFF
--- a/OmsAgent/watcherutil.py
+++ b/OmsAgent/watcherutil.py
@@ -104,7 +104,10 @@ class Watcher:
     		]
             }}"""
 
-	return template.format(operation, operation_success, message, duration)
+        operation_success_as_string = str(operation_success).lower()
+        formatted_message = message.replace("\n", "\\n").replace("\t", "\\t").replace('"', '\\"')
+
+        return template.format(operation, operation_success_as_string, formatted_message, duration)
 
     def upload_telemetry(self):
         status_files = [


### PR DESCRIPTION
This will fix DSC telemetry when an error occurs.
All new lines, tab characters, and quotes are now escaped from the message so that the message content will not affect the validity of the telemetry event JSON.
The operation status is also now ensured to be a lower case string since we were having some problems with the uppercase booleans in Python not being compatible with the lower case booleans of JSON.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/azure-linux-extensions/619)
<!-- Reviewable:end -->
