### PR TITLE
Seperating log to console vs log to file for CSE

### DIFF
--- a/Common/WALinuxAgent-2.0.16/waagent
+++ b/Common/WALinuxAgent-2.0.16/waagent
@@ -2795,7 +2795,7 @@ class Logger(object):
         """
         return (counter < 10) or ((counter < 100) and ((counter % 10) == 0)) or ((counter % 100) == 0)
 
-    def LogToFile(self, message):
+    def WriteToFile(self, message):
         """
         Write 'message' to logfile.
         """
@@ -2815,7 +2815,7 @@ class Logger(object):
             except IOError as e:
                 pass
 
-    def LogToCon(self, message):
+    def WriteToConsole(self, message):
         """
         Write 'message' to /dev/console.
         This supports serial port logging if the /dev/console
@@ -2844,17 +2844,23 @@ class Logger(object):
         """
         self.LogWithPrefix("", message)
 
-    def LogWithPrefix(self, prefix, message):
+    def LogToConsole(self, message):
         """
-        Prefix each line of 'message' with current time+'prefix'.
+        Logs message to console by pre-pending each line of 'message' with current time.
         """
-        t = time.localtime()
-        t = "%04u/%02u/%02u %02u:%02u:%02u " % (t.tm_year, t.tm_mon, t.tm_mday, t.tm_hour, t.tm_min, t.tm_sec)
-        t += prefix
+        log_prefix = self._get_log_prefix("")
         for line in message.split('\n'):
-            line = t + line
-            self.LogToFile(line)
-            self.LogToCon(line)
+            line = log_prefix + line
+            self.WriteToConsole(line)
+
+    def LogToFile(self, message):
+        """
+        Logs message to file by pre-pending each line of 'message' with current time.
+        """
+        log_prefix = self._get_log_prefix("")
+        for line in message.split('\n'):
+            line = log_prefix + line
+            self.WriteToFile(line)
 
     def NoLog(self, message):
         """
@@ -2868,23 +2874,31 @@ class Logger(object):
         """
         self.LogWithPrefixIfVerbose('', message)
 
+    def LogWithPrefix(self, prefix, message):
+        """
+        Prefix each line of 'message' with current time+'prefix'.
+        """
+        log_prefix = self._get_log_prefix(prefix)
+        for line in message.split('\n'):
+            line = log_prefix + line
+            self.WriteToFile(line)
+            self.WriteToConsole(line)
+
     def LogWithPrefixIfVerbose(self, prefix, message):
         """
         Only log 'message' if global Verbose is True.
         Prefix each line of 'message' with current time+'prefix'.
         """
         if self.verbose == True:
-            t = time.localtime()
-            t = "%04u/%02u/%02u %02u:%02u:%02u " % (t.tm_year, t.tm_mon, t.tm_mday, t.tm_hour, t.tm_min, t.tm_sec)
-            t += prefix
+            log_prefix = self._get_log_prefix(prefix)
             for line in message.split('\n'):
-                line = t + line
-                self.LogToFile(line)
-                self.LogToCon(line)
+                line = log_prefix + line
+                self.WriteToFile(line)
+                self.WriteToConsole(line)
 
     def Warn(self, message):
         """
-        Prepend the text "WARNING:" to the prefix for each line in 'message'.
+        Prepend the text "WARNING:" for each line in 'message'.
         """
         self.LogWithPrefix("WARNING:", message)
 
@@ -2901,6 +2915,13 @@ class Logger(object):
         """
         self.LogWithPrefix("ERROR:", message)
 
+    def _get_log_prefix(self, prefix):
+        """
+        Generates the log prefix with timestamp+'prefix'.
+        """
+        t = time.localtime()
+        t = "%04u/%02u/%02u %02u:%02u:%02u " % (t.tm_year, t.tm_mon, t.tm_mday, t.tm_hour, t.tm_min, t.tm_sec)
+        return t + prefix
 
 def LoggerInit(log_file_path, log_con_path, verbose=False):
     """

--- a/Common/WALinuxAgent-2.0.16/waagent
+++ b/Common/WALinuxAgent-2.0.16/waagent
@@ -2927,9 +2927,9 @@ def LoggerInit(log_file_path, log_con_path, verbose=False):
     """
     Create log object and export its methods to global scope.
     """
-    global Log, LogWithPrefix, LogIfVerbose, LogWithPrefixIfVerbose, Error, ErrorWithPrefix, Warn, NoLog, ThrottleLog, myLogger
+    global Log, LogToConsole, LogToFile, LogWithPrefix, LogIfVerbose, LogWithPrefixIfVerbose, Error, ErrorWithPrefix, Warn, NoLog, ThrottleLog, myLogger
     l = Logger(log_file_path, log_con_path, verbose)
-    Log, LogWithPrefix, LogIfVerbose, LogWithPrefixIfVerbose, Error, ErrorWithPrefix, Warn, NoLog, ThrottleLog, myLogger = l.Log, l.LogWithPrefix, l.LogIfVerbose, l.LogWithPrefixIfVerbose, l.Error, l.ErrorWithPrefix, l.Warn, l.NoLog, l.ThrottleLog, l
+    Log, LogToConsole, LogToFile, LogWithPrefix, LogIfVerbose, LogWithPrefixIfVerbose, Error, ErrorWithPrefix, Warn, NoLog, ThrottleLog, myLogger = l.Log, l.LogToConsole, l.LogToFile, l.LogWithPrefix, l.LogIfVerbose, l.LogWithPrefixIfVerbose, l.Error, l.ErrorWithPrefix, l.Warn, l.NoLog, l.ThrottleLog, l
 
 
 def Linux_ioctl_GetInterfaceMac(ifname):

--- a/CustomScript/customscript.py
+++ b/CustomScript/customscript.py
@@ -93,7 +93,7 @@ def dummy_command(operation, status, msg):
 
 
 def parse_context(operation):
-    hutil = Util.HandlerUtility(waagent.Log, waagent.Error, ExtensionShortName)
+    hutil = Util.HandlerUtility(waagent.Log, waagent.Error, ExtensionShortName, console_logger=waagent.LogToConsole, file_logger=waagent.LogToFile)
     hutil.do_parse_context(operation)
     return hutil
 

--- a/CustomScript/manifest.xml
+++ b/CustomScript/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.OSTCExtensions</ProviderNameSpace>
   <Type>CustomScriptForLinux</Type>
-  <Version>1.5.4</Version>
+  <Version>1.5.5</Version>
   <Label>Microsoft Azure Custom Script Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>

--- a/Utils/HandlerUtil.py
+++ b/Utils/HandlerUtil.py
@@ -28,7 +28,7 @@ HandlerEnvironment.json
     "configFolder": "<your config folder location>",
     "statusFolder": "<your status folder location>",
     "heartbeatFile": "<your heartbeat file location>",
-    
+
   }
 }]
 
@@ -51,7 +51,6 @@ Example Status Report:
 
 """
 
-
 import os
 import os.path
 import sys
@@ -69,8 +68,9 @@ DateTimeFormat = "%Y-%m-%dT%H:%M:%SZ"
 
 MANIFEST_XML = "manifest.xml"
 
+
 class HandlerContext:
-    def __init__(self,name):
+    def __init__(self, name):
         self._name = name
         self._version = '0.0'
         self._config_dir = None
@@ -81,13 +81,17 @@ class HandlerContext:
         self._seq_no = -1
         self._status_file = None
         self._settings_file = None
-        self._config = None 
+        self._config = None
         return
 
+
 class HandlerUtility:
-    def __init__(self, log, error, s_name=None, l_name=None, extension_version=None, logFileName = 'extension.log'):
+    def __init__(self, log, error, s_name=None, l_name=None, extension_version=None, logFileName='extension.log',
+                 console_logger=None, file_logger=None):
         self._log = log
-        self._error = error        
+        self._log_to_con = console_logger
+        self._log_to_file = file_logger
+        self._error = error
         self._logFileName = logFileName
         if s_name is None or l_name is None or extension_version is None:
             (l_name, s_name, extension_version) = self._get_extension_info()
@@ -98,7 +102,7 @@ class HandlerUtility:
 
     def get_extension_version(self):
         return self._extension_version
-    
+
     def _get_log_prefix(self):
         return self._log_prefix
 
@@ -130,13 +134,13 @@ class HandlerUtility:
             for file in files:
                 try:
                     cur_seq_no = int(os.path.basename(file).split('.')[0])
-                    if(freshest_time == None):
-                        freshest_time = os.path.getmtime(join(config_folder,file))
+                    if (freshest_time == None):
+                        freshest_time = os.path.getmtime(join(config_folder, file))
                         seq_no = cur_seq_no
                     else:
-                        current_file_m_time = os.path.getmtime(join(config_folder,file))
-                        if(current_file_m_time > freshest_time):
-                            freshest_time=current_file_m_time
+                        current_file_m_time = os.path.getmtime(join(config_folder, file))
+                        if (current_file_m_time > freshest_time):
+                            freshest_time = current_file_m_time
                             seq_no = cur_seq_no
                 except ValueError:
                     continue
@@ -145,13 +149,25 @@ class HandlerUtility:
     def log(self, message):
         self._log(self._get_log_prefix() + message)
 
+    def log_to_console(self, message):
+        if self._log_to_con is not None:
+            self._log_to_con(self._get_log_prefix() + message)
+        else:
+            self.error("Unable to log to console, console log method not set")
+
+    def log_to_file(self, message):
+        if self._log_to_file is not None:
+            self._log_to_file(self._get_log_prefix() + message)
+        else:
+            self.error("Unable to log to file, file log method not set")
+
     def error(self, message):
         self._error(self._get_log_prefix() + message)
 
     def _parse_config(self, ctxt):
         config = None
         try:
-            config=json.loads(ctxt)
+            config = json.loads(ctxt)
         except:
             self.error('JSON exception decoding ' + ctxt)
 
@@ -164,50 +180,50 @@ class HandlerUtility:
                     handlerSettings['protectedSettings'] is not None and \
                     handlerSettings["protectedSettingsCertThumbprint"] is not None:
                 protectedSettings = handlerSettings['protectedSettings']
-                thumb=handlerSettings['protectedSettingsCertThumbprint']
-                cert=waagent.LibDir+'/'+thumb+'.crt'
-                pkey=waagent.LibDir+'/'+thumb+'.prv'
+                thumb = handlerSettings['protectedSettingsCertThumbprint']
+                cert = waagent.LibDir + '/' + thumb + '.crt'
+                pkey = waagent.LibDir + '/' + thumb + '.prv'
                 unencodedSettings = base64.standard_b64decode(protectedSettings)
                 openSSLcmd = "openssl smime -inform DER -decrypt -recip {0} -inkey {1}"
                 cleartxt = waagent.RunSendStdin(openSSLcmd.format(cert, pkey), unencodedSettings)[1]
                 if cleartxt is None:
-                    self.error("OpenSSL decode error using  thumbprint " + thumb )
-                    self.do_exit(1,"Enable",'error','1', 'Failed to decrypt protectedSettings')
-                jctxt=''
+                    self.error("OpenSSL decode error using  thumbprint " + thumb)
+                    self.do_exit(1, "Enable", 'error', '1', 'Failed to decrypt protectedSettings')
+                jctxt = ''
                 try:
-                    jctxt=json.loads(cleartxt)
+                    jctxt = json.loads(cleartxt)
                 except:
                     self.error('JSON exception decoding ' + cleartxt)
-                handlerSettings['protectedSettings']=jctxt
+                handlerSettings['protectedSettings'] = jctxt
                 self.log('Config decoded correctly.')
         return config
 
-    def do_parse_context(self,operation):
+    def do_parse_context(self, operation):
         _context = self.try_parse_context()
         if not _context:
-            self.do_exit(1,operation,'error','1', operation + ' Failed')
+            self.do_exit(1, operation, 'error', '1', operation + ' Failed')
         return _context
-            
+
     def try_parse_context(self):
         self._context = HandlerContext(self._short_name)
-        handler_env=None
-        config=None
-        ctxt=None
-        code=0
+        handler_env = None
+        config = None
+        ctxt = None
+        code = 0
         # get the HandlerEnvironment.json. According to the extension handler spec, it is always in the ./ directory
         self.log('cwd is ' + os.path.realpath(os.path.curdir))
-        handler_env_file='./HandlerEnvironment.json'
+        handler_env_file = './HandlerEnvironment.json'
         if not os.path.isfile(handler_env_file):
             self.error("Unable to locate " + handler_env_file)
             return None
         ctxt = waagent.GetFileContents(handler_env_file)
-        if ctxt == None :
+        if ctxt == None:
             self.error("Unable to read " + handler_env_file)
         try:
-            handler_env=json.loads(ctxt)
+            handler_env = json.loads(ctxt)
         except:
             pass
-        if handler_env == None :
+        if handler_env == None:
             self.log("JSON error processing " + handler_env_file)
             return None
         if type(handler_env) == list:
@@ -215,25 +231,25 @@ class HandlerUtility:
 
         self._context._name = handler_env['name']
         self._context._version = str(handler_env['version'])
-        self._context._config_dir=handler_env['handlerEnvironment']['configFolder']
-        self._context._log_dir= handler_env['handlerEnvironment']['logFolder']
-        
-        self._context._log_file= os.path.join(handler_env['handlerEnvironment']['logFolder'],self._logFileName)
+        self._context._config_dir = handler_env['handlerEnvironment']['configFolder']
+        self._context._log_dir = handler_env['handlerEnvironment']['logFolder']
+
+        self._context._log_file = os.path.join(handler_env['handlerEnvironment']['logFolder'], self._logFileName)
         self._change_log_file()
-        self._context._status_dir=handler_env['handlerEnvironment']['statusFolder']
-        self._context._heartbeat_file=handler_env['handlerEnvironment']['heartbeatFile']
+        self._context._status_dir = handler_env['handlerEnvironment']['statusFolder']
+        self._context._heartbeat_file = handler_env['handlerEnvironment']['heartbeatFile']
         self._context._seq_no = self._get_current_seq_no(self._context._config_dir)
         if self._context._seq_no < 0:
             self.error("Unable to locate a .settings file!")
             return None
         self._context._seq_no = str(self._context._seq_no)
         self.log('sequence number is ' + self._context._seq_no)
-        self._context._status_file= os.path.join(self._context._status_dir, self._context._seq_no +'.status')
+        self._context._status_file = os.path.join(self._context._status_dir, self._context._seq_no + '.status')
         self._context._settings_file = os.path.join(self._context._config_dir, self._context._seq_no + '.settings')
         self.log("setting file path is" + self._context._settings_file)
-        ctxt=None
-        ctxt=waagent.GetFileContents(self._context._settings_file)
-        if ctxt == None :
+        ctxt = None
+        ctxt = waagent.GetFileContents(self._context._settings_file)
+        if ctxt == None:
             error_msg = 'Unable to read ' + self._context._settings_file + '. '
             self.error(error_msg)
             return None
@@ -242,15 +258,14 @@ class HandlerUtility:
         self._context._config = self._parse_config(ctxt)
         return self._context
 
-
     def _change_log_file(self):
         self.log("Change log file to " + self._context._log_file)
-        LoggerInit(self._context._log_file,'/dev/stdout')
+        LoggerInit(self._context._log_file, '/dev/stdout')
         self._log = waagent.Log
         self._error = waagent.Error
 
     def set_verbose_log(self, verbose):
-        if(verbose == "1" or verbose == 1):
+        if (verbose == "1" or verbose == 1):
             self.log("Enable verbose log")
             LoggerInit(self._context._log_file, '/dev/stdout', verbose=True)
         else:
@@ -268,15 +283,16 @@ class HandlerUtility:
         self.exit_if_seq_smaller()
 
     def exit_if_seq_smaller(self):
-        if(self.is_seq_smaller()):
-            self.log("Current sequence number, " + self._context._seq_no + ", is not greater than the sequnce number of the most recent executed configuration. Exiting...")
+        if (self.is_seq_smaller()):
+            self.log(
+                "Current sequence number, " + self._context._seq_no + ", is not greater than the sequnce number of the most recent executed configuration. Exiting...")
             sys.exit(0)
         self.save_seq()
 
     def _get_most_recent_seq(self):
-        if(os.path.isfile('mrseq')):
+        if (os.path.isfile('mrseq')):
             seq = waagent.GetFileContents('mrseq')
-            if(seq):
+            if (seq):
                 return int(seq)
 
         return -1
@@ -287,52 +303,52 @@ class HandlerUtility:
     def get_inused_config_seq(self):
         return self._get_most_recent_seq()
 
-    def set_inused_config_seq(self,seq):
+    def set_inused_config_seq(self, seq):
         self._set_most_recent_seq(seq)
 
-    def _set_most_recent_seq(self,seq):
+    def _set_most_recent_seq(self, seq):
         waagent.SetFileContents('mrseq', str(seq))
 
     def do_status_report(self, operation, status, status_code, message):
         self.log("{0},{1},{2},{3}".format(operation, status, status_code, message))
-        tstamp=time.strftime(DateTimeFormat, time.gmtime())
+        tstamp = time.strftime(DateTimeFormat, time.gmtime())
         stat = [{
-            "version" : self._context._version,
-            "timestampUTC" : tstamp,
-            "status" : {
-                "name" : self._context._name,
-                "operation" : operation,
-                "status" : status,
-                "code" : status_code,
-                "formattedMessage" : {
-                    "lang" : "en-US",
-                    "message" : message
+            "version": self._context._version,
+            "timestampUTC": tstamp,
+            "status": {
+                "name": self._context._name,
+                "operation": operation,
+                "status": status,
+                "code": status_code,
+                "formattedMessage": {
+                    "lang": "en-US",
+                    "message": message
                 }
             }
         }]
         stat_rept = json.dumps(stat)
         if self._context._status_file:
-            tmp = "%s.tmp" %(self._context._status_file)
-            with open(tmp,'w+') as f:
+            tmp = "%s.tmp" % (self._context._status_file)
+            with open(tmp, 'w+') as f:
                 f.write(stat_rept)
             os.rename(tmp, self._context._status_file)
 
-    def do_heartbeat_report(self, heartbeat_file,status,code,message):
+    def do_heartbeat_report(self, heartbeat_file, status, code, message):
         # heartbeat
-        health_report='[{"version":"1.0","heartbeat":{"status":"' + status+ '","code":"'+ code + '","Message":"' + message + '"}}]'
-        if waagent.SetFileContents(heartbeat_file,health_report) == None :
+        health_report = '[{"version":"1.0","heartbeat":{"status":"' + status + '","code":"' + code + '","Message":"' + message + '"}}]'
+        if waagent.SetFileContents(heartbeat_file, health_report) == None:
             self.error('Unable to wite heartbeat info to ' + heartbeat_file)
 
-    def do_exit(self,exit_code,operation,status,code,message):
+    def do_exit(self, exit_code, operation, status, code, message):
         try:
-            self.do_status_report(operation, status,code,message)
+            self.do_status_report(operation, status, code, message)
         except Exception as e:
-            self.log("Can't update status: "+str(e))
+            self.log("Can't update status: " + str(e))
         sys.exit(exit_code)
 
     def get_name(self):
         return self._context._name
-    
+
     def get_seq_no(self):
         return self._context._seq_no
 
@@ -354,4 +370,3 @@ class HandlerUtility:
         if (handlerSettings != None):
             return self.get_handler_settings().get('publicSettings')
         return None
-

--- a/Utils/ScriptUtil.py
+++ b/Utils/ScriptUtil.py
@@ -47,20 +47,20 @@ def run_command(hutil, args, cwd, operation, extension_short_name, version, exit
                                  stderr=err_out)
         time.sleep(1)
         while child.poll() is None:
-            msg_with_cmd_output = LogUtil.get_formatted_log("Command is running...",
-                                            LogUtil.tail(std_out_file), LogUtil.tail(err_out_file))
-            msg_without_cmd_output = "Command is running... Stdout/Stderr omitted from output."
+            msg = "Command is running... "
+            msg_with_cmd_output = LogUtil.get_formatted_log(msg, LogUtil.tail(std_out_file), LogUtil.tail(err_out_file))
+            msg_without_cmd_output = msg + "Stdout/Stderr omitted from output."
+
             hutil.log_to_file(msg_with_cmd_output)
             hutil.log_to_console(msg_without_cmd_output)
-
             hutil.do_status_report(operation, 'transitioning', '0', msg_without_cmd_output)
             time.sleep(interval)
 
         exit_code = child.returncode
         if child.returncode and child.returncode != 0:
-            msg_with_cmd_output = LogUtil.get_formatted_log("Command returned an error.",
-                                            LogUtil.tail(std_out_file), LogUtil.tail(err_out_file))
-            msg_without_cmd_output = "Command returned an error. Stdout/Stderr omitted from output."
+            msg = "Command returned an error (exit_code: %d). " % exit_code
+            msg_with_cmd_output = LogUtil.get_formatted_log(msg, LogUtil.tail(std_out_file), LogUtil.tail(err_out_file))
+            msg_without_cmd_output = msg + "Stdout/Stderr omitted from output."
 
             hutil.error(msg_without_cmd_output)
             waagent.AddExtensionEvent(name=extension_short_name,
@@ -69,12 +69,12 @@ def run_command(hutil, args, cwd, operation, extension_short_name, version, exit
                                       version=version,
                                       message="(01302)" + msg_without_cmd_output)
         else:
-            msg_with_cmd_output = LogUtil.get_formatted_log("Command is finished.",
-                                            LogUtil.tail(std_out_file), LogUtil.tail(err_out_file))
-            msg_without_cmd_output = "Command is finished. Stdout/Stderr omitted from output."
+            msg = "Command is finished (exit_code: %d). " % exit_code
+            msg_with_cmd_output = LogUtil.get_formatted_log(msg, LogUtil.tail(std_out_file), LogUtil.tail(err_out_file))
+            msg_without_cmd_output = msg + "Stdout/Stderr omitted from output."
+
             hutil.log_to_file(msg_with_cmd_output)
             hutil.log_to_console(msg_without_cmd_output)
-
             waagent.AddExtensionEvent(name=extension_short_name,
                                       op=operation,
                                       isSuccess=True,

--- a/Utils/ScriptUtil.py
+++ b/Utils/ScriptUtil.py
@@ -47,9 +47,9 @@ def run_command(hutil, args, cwd, operation, extension_short_name, version, exit
                                  stderr=err_out)
         time.sleep(1)
         while child.poll() is None:
-            msg = "Command is running... "
+            msg = "Command is running..."
             msg_with_cmd_output = LogUtil.get_formatted_log(msg, LogUtil.tail(std_out_file), LogUtil.tail(err_out_file))
-            msg_without_cmd_output = msg + "Stdout/Stderr omitted from output."
+            msg_without_cmd_output = msg + " Stdout/Stderr omitted from output."
 
             hutil.log_to_file(msg_with_cmd_output)
             hutil.log_to_console(msg_without_cmd_output)
@@ -58,9 +58,9 @@ def run_command(hutil, args, cwd, operation, extension_short_name, version, exit
 
         exit_code = child.returncode
         if child.returncode and child.returncode != 0:
-            msg = "Command returned an error (exit_code: %d). " % exit_code
+            msg = "Command returned an error."
             msg_with_cmd_output = LogUtil.get_formatted_log(msg, LogUtil.tail(std_out_file), LogUtil.tail(err_out_file))
-            msg_without_cmd_output = msg + "Stdout/Stderr omitted from output."
+            msg_without_cmd_output = msg + " Stdout/Stderr omitted from output."
 
             hutil.error(msg_without_cmd_output)
             waagent.AddExtensionEvent(name=extension_short_name,
@@ -69,9 +69,9 @@ def run_command(hutil, args, cwd, operation, extension_short_name, version, exit
                                       version=version,
                                       message="(01302)" + msg_without_cmd_output)
         else:
-            msg = "Command is finished (exit_code: %d). " % exit_code
+            msg = "Command is finished."
             msg_with_cmd_output = LogUtil.get_formatted_log(msg, LogUtil.tail(std_out_file), LogUtil.tail(err_out_file))
-            msg_without_cmd_output = msg + "Stdout/Stderr omitted from output."
+            msg_without_cmd_output = msg + " Stdout/Stderr omitted from output."
 
             hutil.log_to_file(msg_with_cmd_output)
             hutil.log_to_console(msg_without_cmd_output)


### PR DESCRIPTION
Seperating log to console vs log to file;
This is for the new requirement for which some extension output should not be logged to console (but only  to file).
This refactor also includes changes to CSE to log script output to file but not to console.