### PR TITLE
Scrub protected settings from files and logs

### DIFF
--- a/Utils/HandlerUtil.py
+++ b/Utils/HandlerUtil.py
@@ -151,8 +151,8 @@ class HandlerUtility:
 
     @staticmethod
     def redact_protected_settings(content):
-        redacted_tmp = re.sub('"protectedSettings":\s*"[^"]+=="', '"protectedSettings:": "*** REDACTED ***"', content)
-        redacted = re.sub('"protectedSettingsCertThumbprint":\s*"[^"]+"', '"protectedSettingsCertThumbprint:": "*** REDACTED ***"', redacted_tmp)
+        redacted_tmp = re.sub('"protectedSettings":\s*"[^"]+=="', '"protectedSettings": "*** REDACTED ***"', content)
+        redacted = re.sub('"protectedSettingsCertThumbprint":\s*"[^"]+"', '"protectedSettingsCertThumbprint": "*** REDACTED ***"', redacted_tmp)
         return redacted
 
     def _parse_config(self, ctxt):

--- a/Utils/HandlerUtil.py
+++ b/Utils/HandlerUtil.py
@@ -59,6 +59,7 @@ import imp
 import base64
 import json
 import time
+import re
 
 from xml.etree import ElementTree
 from os.path import join
@@ -148,15 +149,21 @@ class HandlerUtility:
     def error(self, message):
         self._error(self._get_log_prefix() + message)
 
+    @staticmethod
+    def redact_protected_settings(content):
+        redacted_tmp = re.sub('"protectedSettings":\s*"[^"]+=="', '"protectedSettings:": "*** REDACTED ***"', content)
+        redacted = re.sub('"protectedSettingsCertThumbprint":\s*"[^"]+"', '"protectedSettingsCertThumbprint:": "*** REDACTED ***"', redacted_tmp)
+        return redacted
+
     def _parse_config(self, ctxt):
         config = None
         try:
             config=json.loads(ctxt)
         except:
-            self.error('JSON exception decoding ' + ctxt)
+            self.error('JSON exception decoding ' + HandlerUtility.redact_protected_settings(ctxt))
 
         if config is None:
-            self.error("JSON error processing settings file:" + ctxt)
+            self.error("JSON error processing settings file:" + HandlerUtility.redact_protected_settings(ctxt))
         else:
             handlerSettings = config['runtimeSettings'][0]['handlerSettings']
             if 'protectedSettings' in handlerSettings and \
@@ -177,7 +184,7 @@ class HandlerUtility:
                 try:
                     jctxt=json.loads(cleartxt)
                 except:
-                    self.error('JSON exception decoding ' + cleartxt)
+                    self.error('JSON exception decoding ' + HandlerUtility.redact_protected_settings(cleartxt))
                 handlerSettings['protectedSettings']=jctxt
                 self.log('Config decoded correctly.')
         return config
@@ -238,7 +245,7 @@ class HandlerUtility:
             self.error(error_msg)
             return None
 
-        self.log("JSON config: " + ctxt)
+        self.log("JSON config: " + HandlerUtility.redact_protected_settings(ctxt))
         self._context._config = self._parse_config(ctxt)
         return self._context
 
@@ -264,14 +271,17 @@ class HandlerUtility:
         self._set_most_recent_seq(self._context._seq_no)
         self.log("set most recent sequence number to " + self._context._seq_no)
 
-    def exit_if_enabled(self):
-        self.exit_if_seq_smaller()
+    def exit_if_enabled(self, remove_protected_settings=False):
+        self.exit_if_seq_smaller(remove_protected_settings)
 
-    def exit_if_seq_smaller(self):
+    def exit_if_seq_smaller(self, remove_protected_settings):
         if(self.is_seq_smaller()):
             self.log("Current sequence number, " + self._context._seq_no + ", is not greater than the sequnce number of the most recent executed configuration. Exiting...")
             sys.exit(0)
         self.save_seq()
+
+        if remove_protected_settings:
+            self.scrub_settings_file()
 
     def _get_most_recent_seq(self):
         if(os.path.isfile('mrseq')):
@@ -355,3 +365,8 @@ class HandlerUtility:
             return self.get_handler_settings().get('publicSettings')
         return None
 
+    def scrub_settings_file(self):
+        content = waagent.GetFileContents(self._context._settings_file)
+        redacted = HandlerUtility.redact_protected_settings(content)
+
+        waagent.SetFileContents(self._context._settings_file, redacted)

--- a/Utils/test/test_redacted_settings.py
+++ b/Utils/test/test_redacted_settings.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+#
+# Tests for redacted settings
+#
+# Copyright 2014 Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import Utils.HandlerUtil as Util
+
+
+class TestRedactedProtectedSettings(unittest.TestCase):
+
+    def test_redacted_protected_settings(self):
+        redacted = Util.HandlerUtility.redact_protected_settings(settings_original)
+        self.assertIn('"protectedSettings": "*** REDACTED ***"', redacted)
+        self.assertIn('"protectedSettingsCertThumbprint": "*** REDACTED ***"', redacted)
+
+
+settings_original = """\
+{
+    "runtimeSettings": [{
+        "handlerSettings": {
+            "protectedSettingsCertThumbprint": "9310D2O49D7216D4A1CEDCE9D8A7CE5DBD7FB7BF",
+            "protectedSettings": "MIIC4AYJKoZIhvcNAQcWoIIB0TCDEc0CAQAxggFpMIIBZQIBADBNMDkxNzA1BgoJkiaJk/IsZAEZFidXaW5kb3dzIEF6dXJlIENSUCBDZXJ0aWZpY2F0ZSBHZW5lcmF0b3ICEB8f7DyzHLGjSDLnEWd4YeAwDQYJKoZIhvcNAQEBBQAEggEAiZj2gQtT4MpdTaEH8rUVFB/8Ucc8OxGFWu8VKbIdoHLKp1WcDb7Vlzv6fHLBIccgXGuR1XHTvtlD4QiKpSet341tPPug/R5ZtLSRz1pqtXZdrFcuuSxOa6ib/+la5ukdygcVwkEnmNSQaiipPKyqPH2JsuhmGCdXFiKwCSTrgGE6GyCBtaK9KOf48V/tYXHnDGrS9q5a1gRF5KVI2B26UYSO7V7pXjzYCd/Sp9yGj7Rw3Kqf9Lpix/sPuqWjV6e2XFlD3YxaHSeHVnLI/Bkz2E6Ri8yfPYus52r/mECXPL2YXqY9dGyrlKKIaD9AuzMyvvy1A74a9VBq7zxQQ4adEzBbBgkqhkiG9w0BBwEwFAYIKoZIhvcNAwcECDyEf4mRrmWJgDhW4j2nRNTJU4yXxocQm/PhAr39Um7n0pgI2Cn28AabYtsHWjKqr8Al9LX6bKm8cnmnLjqTntphCw==",
+            "publicSettings": {}
+            }
+     }]
+}
+"""
+
+if __name__ == '__main__':
+    unittest.main()

--- a/VMAccess/vmaccess.py
+++ b/VMAccess/vmaccess.py
@@ -90,7 +90,7 @@ def enable():
             _open_ssh_port()
             hutil.log("Succeeded in check and open ssh port.")
 
-        hutil.exit_if_enabled()
+        hutil.exit_if_enabled(remove_protected_settings=True)
         if _is_sshd_config_modified(protect_settings):
             _backup_sshd_config(SshdConfigPath)
 


### PR DESCRIPTION
For VMAccess, prevent protected settings from appearing in extension logs and config file.