### PR TITLE
ADE SP Jan QOS

### DIFF
--- a/VMEncryption/MANIFEST.in
+++ b/VMEncryption/MANIFEST.in
@@ -1,4 +1,4 @@
-include HandlerManifest.json manifest.xml
+include HandlerManifest.json manifest.xml extension_shim.sh
 recursive-include main/oscrypto/91ade *.sh
 recursive-include main/oscrypto/91ade *.rules
 recursive-include main/oscrypto/rhel_68/encryptpatches *.patch

--- a/VMEncryption/extension_shim.sh
+++ b/VMEncryption/extension_shim.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+# Keeping the default command
+COMMAND=""
+PYTHON=""
+
+USAGE="$(basename "$0") [-h] [-i|--install] [-u|--uninstall] [-d|--disable] [-e|--enable] [-p|--update] [-m|--daemon]
+
+Program to find the installed python on the box and invoke a Python extension script using Python 2.7.
+
+where:
+    -h|--help       show this help text
+    -i|--install    install the extension
+    -u|--uninstall  uninstall the extension
+    -d|--disable    disable the extension
+    -e|--enable     enable the extension
+    -p|--update     update the extension
+    -m|--daemon     invoke daemon option
+    -c|--command    command to run
+
+example:
+# Install usage
+$ bash extension_shim.sh -i
+python ./main/handle.py -install
+
+# Custom executable python file
+$ bash extension_shim.sh -c ""hello.py"" -i
+python hello.py -install
+
+# Custom executable python file with arguments
+$ bash extension_shim.sh -c ""hello.py --install""
+python hello.py --install
+"
+
+function find_python(){
+    local python_exec_command=$1
+
+    # Check if there is python defined.
+    if command -v python >/dev/null 2>&1 ; then
+        eval ${python_exec_command}="python"
+    fi
+}
+
+# Transform long options to short ones for getopts support (getopts doesn't support long args)
+for arg in "$@"; do
+  shift
+  case "$arg" in
+    "--help")       set -- "$@" "-h" ;;
+    "--install")    set -- "$@" "-i" ;;
+    "--update")     set -- "$@" "-p" ;;
+    "--enable")     set -- "$@" "-e" ;;
+    "--disable")    set -- "$@" "-d" ;;
+    "--uninstall")  set -- "$@" "-u" ;;
+    "--daemon")     set -- "$@" "-m" ;;
+    *)              set -- "$@" "$arg"
+  esac
+done
+
+if [ -z "$arg" ]
+then
+   echo "$USAGE" >&2
+   exit 1
+fi
+
+# Get the arguments
+while getopts "iudephc:?" o; do
+    case "${o}" in
+        h|\?)
+            echo "$USAGE"
+            exit 0
+            ;;
+        i)
+            operation="-install"
+            ;;
+        u)
+            operation="-uninstall"
+            ;;
+        d)
+            operation="-disable"
+            ;;
+        e)
+            operation="-enable"
+            ;;
+        p)
+            operation="-update"
+            ;;
+        m)
+            operation="-daemon"
+            ;;
+        c)
+            COMMAND="$OPTARG"
+            ;;
+        *)
+            echo "$USAGE" >&2
+            exit 1
+            ;;
+    esac
+done
+
+shift "$((OPTIND-1))"
+
+# If find_python is not able to find a python installed, $PYTHON will be null.
+find_python PYTHON
+
+if [ -z "$PYTHON" ]; then
+   echo "No Python interpreter found on the box" >&2
+   exit 51 # Not Supported
+else
+    PYTHON_VER=`${PYTHON} --version 2>&1`
+    if [[ "$PYTHON_VER" =~ "Python 2.6" ]] || [[ "$PYTHON_VER" =~ "Python 2.7" ]]; then
+        echo $PYTHON_VER
+    else
+        echo "Expected Python 2.7, found $PYTHON_VER" >&2
+        exit 51 # Not Supported
+    fi
+fi
+
+${PYTHON} ${COMMAND} ${operation} 2>&1
+# DONE

--- a/VMEncryption/main/Common.py
+++ b/VMEncryption/main/Common.py
@@ -20,11 +20,12 @@
 class CommonVariables:
     utils_path_name = 'Utils'
     extension_name = 'AzureDiskEncryptionForLinux'
-    extension_version = '1.1.0.22'
+    extension_version = '1.1.0.23'
     extension_type = extension_name
     extension_media_link = 'https://amextpaas.blob.core.windows.net/prod/' + extension_name + '-' + str(extension_version) + '.zip'
     extension_label = 'Azure Disk Encryption For Linux VMSS'
     extension_description = extension_label
+    extension_shim_filename = "extension_shim.sh"
 
     """
     wire protocol message format

--- a/VMEncryption/main/Utils/HandlerUtil.py
+++ b/VMEncryption/main/Utils/HandlerUtil.py
@@ -437,23 +437,23 @@ class HandlerUtility:
                     shutil.copy2(src, dest)
 
     def restore_old_configs(self):
-        if not os.path.exists(self.config_archive_folder):
-            return
+        # restores all archived settings files carried over from prior extension versions 
+        # use cp for faster performance than iterating over each file using shutil.copy2() 
+        # use --preserve=timestamps to ensure that _get_current_seq_no() can sort by timestamp
+        if os.path.exists(self.config_archive_folder) and os.path.exists(self._context._config_dir):
+            try:
+                src = self.config_archive_folder + '/*.settings'
+                dst = self._context._config_dir
+                cmd = "cp {0} {1} --preserve=timestamps".format(src,dst)
+                subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
+            except subprocess.CalledProcessError as e:
+                self.log("restore_old_configs error (settings): {0}".format(e))
 
-        for root, dirs, files in os.walk(self.config_archive_folder):
-            for file in files:
-                if file.endswith('.settings'):
-                    src = os.path.join(root, file)
-                    dest = os.path.join(self._context._config_dir, file)
-
-                    self.log("Copying {0} to {1}".format(src, dest))
-
-                    shutil.copy2(src, dest)
-
-                if file == 'mrseq':
-                    src = os.path.join(root, file)
-                    dest = os.path.join(os.path.join(self._context._config_dir, '..'), file)
-
-                    self.log("Copying {0} to {1}".format(src, dest))
-
-                    shutil.copy2(src, dest)
+            try:
+                src = os.path.join(self.config_archive_folder,'mrseq')
+                if os.path.exists(src):
+                    dst = os.path.join(self._context._config_dir,'..')
+                    cmd = "cp {0} {1} --preserve=timestamps".format(src,dst)
+                    subprocess.check_output(cmd,stderr=subprocess.STDOUT,shell=True)
+            except subprocess.CalledProcessError as e:
+                self.log("restore_old_configs error (mrseq): {0}".format(e))

--- a/VMEncryption/main/check_util.py
+++ b/VMEncryption/main/check_util.py
@@ -201,10 +201,9 @@ class CheckUtil(object):
         # first, check if the root OS volume type is LVM
         if ( encryption_operation and volume_type and 
              os.system("lsblk -o TYPE,MOUNTPOINT | grep lvm | grep -q '/$'") == 0):
-            # next, check that all required logical volume names exist
+            # next, check that all required logical volume names exist (swaplv not required)
             lvlist = ['rootvg-tmplv',
                       'rootvg-usrlv',
-                      'rootvg-swaplv',
                       'rootvg-optlv',
                       'rootvg-homelv',
                       'rootvg-varlv',

--- a/VMEncryption/main/check_util.py
+++ b/VMEncryption/main/check_util.py
@@ -74,25 +74,6 @@ class CheckUtil(object):
                     detected = True
         return detected
 
-    def is_invalid_lvm_os(self):
-        """ if an lvm os disk is present, check the lv names """
-        detected = False
-        # run checks only when the root OS volume type is LVM
-        if os.system("lsblk -o TYPE,MOUNTPOINT | grep lvm | grep -q '/$'") == 0:
-            # LVM OS volume detected, check that required logical volume names exist
-            lvlist = ['rootvg-tmplv',
-                      'rootvg-usrlv',
-                      'rootvg-swaplv',
-                      'rootvg-optlv',
-                      'rootvg-homelv',
-                      'rootvg-varlv',
-                      'rootvg-rootlv']
-            for lvname in lvlist:
-                if not os.system("lsblk -o NAME | grep -q '" + lvname + "'") == 0:
-                    self.logger.log('WARNING: LVM OS scheme is missing LV [' + lvname + ']')
-                    detected = True
-        return detected
-
     def check_kv_url(self, test_url, message):
         """basic sanity check of the key vault url"""
 
@@ -198,11 +179,48 @@ class CheckUtil(object):
         if not volume_type.lower() in map(lambda x: x.lower(), supported_types) :
             raise Exception("Unknown Volume Type: {0}, has to be one of {1}".format(volume_type, supported_types))
 
+    def validate_lvm_os(self, public_settings):
+        encryption_operation = public_settings.get(CommonVariables.EncryptionEncryptionOperationKey)
+        if not encryption_operation:
+            self.logger.log("LVM OS validation skipped (no encryption operation)")
+            return
+        elif encryption_operation.lower() == CommonVariables.QueryEncryptionStatus.lower():
+            self.logger.log("LVM OS validation skipped (Encryption Operation: QueryEncryptionStatus)")
+            return
+
+        volume_type = public_settings.get(CommonVariables.VolumeTypeKey)
+        if not volume_type:
+            self.logger.log("LVM OS validation skipped (no volume type)")
+            return
+        elif volume_type.lower() == CommonVariables.VolumeTypeData.lower():
+            self.logger.log("LVM OS validation skipped (Volume Type: DATA)")
+            return
+
+        #  run lvm check if volume type, encryption operation were specified and OS type is LVM
+        detected = False
+        # first, check if the root OS volume type is LVM
+        if ( encryption_operation and volume_type and 
+             os.system("lsblk -o TYPE,MOUNTPOINT | grep lvm | grep -q '/$'") == 0):
+            # next, check that all required logical volume names exist
+            lvlist = ['rootvg-tmplv',
+                      'rootvg-usrlv',
+                      'rootvg-swaplv',
+                      'rootvg-optlv',
+                      'rootvg-homelv',
+                      'rootvg-varlv',
+                      'rootvg-rootlv']
+            for lvname in lvlist:
+                if not os.system("lsblk -o NAME | grep -q '" + lvname + "'") == 0:
+                    self.logger.log('LVM OS scheme is missing LV [' + lvname + ']')
+                    detected = True
+        if detected:
+            raise Exception("LVM OS disk layout does not satisfy prerequisites ( see https://aka.ms/adelvm )")
+
     def precheck_for_fatal_failures(self, public_settings):
         """ run all fatal prechecks, they should throw an exception if anything is wrong """
         self.validate_key_vault_params(public_settings)
         self.validate_volume_type(public_settings)
-
+        self.validate_lvm_os(public_settings)
 
     def is_non_fatal_precheck_failure(self):
         """ run all prechecks """
@@ -216,7 +234,4 @@ class CheckUtil(object):
         if self.is_unsupported_mount_scheme():
             detected = True
             self.logger.log("PRECHECK: Unsupported mount scheme detected")
-        if self.is_invalid_lvm_os():
-            detected = True
-            self.logger.log("PRECHECK: Invalid LVM OS scheme detected")
         return detected

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -61,16 +61,23 @@ from MetadataUtil import MetadataUtil
 
 def install():
     hutil.do_parse_context('Install')
+    # The extension update handshake is [old:disable][new:update][old:uninstall][new:install]
+    # Prior extensions archived their configs in [old:uninstall], not in [old:disable]
+    # As such, the first opportunity to restore old configs is in [new:install]
+    # In the future, moving the config archive/restore step to disable/update is preferred 
     hutil.restore_old_configs()
     hutil.do_exit(0, 'Install', CommonVariables.extension_success_status, str(CommonVariables.success), 'Install Succeeded')
 
 def disable():
     hutil.do_parse_context('Disable')
+    # archiving old configs during disable rather than uninstall will allow subsequent versions 
+    # to restore these configs in their update step rather than their install step once all 
+    # released versions of the extension are at this version or above 
+    hutil.archive_old_configs()
     hutil.do_exit(0, 'Disable', CommonVariables.extension_success_status, '0', 'Disable succeeded')
 
 def uninstall():
     hutil.do_parse_context('Uninstall')
-    hutil.archive_old_configs()
     hutil.do_exit(0, 'Uninstall', CommonVariables.extension_success_status, '0', 'Uninstall succeeded')
 
 def disable_encryption():
@@ -160,7 +167,7 @@ def disable_encryption():
         message = "Failed to disable the extension with error: {0}, stack trace: {1}".format(e, traceback.format_exc())
 
         logger.log(msg=message, level=CommonVariables.ErrorLevel)
-        hutil.do_exit(exit_code=0,
+        hutil.do_exit(exit_code=CommonVariables.unknown_error,
                       operation='DisableEncryption',
                       status=CommonVariables.extension_error_status,
                       code=str(CommonVariables.unknown_error),
@@ -370,7 +377,7 @@ def update_encryption_settings():
     except Exception as e:
         message = "Failed to update encryption settings with error: {0}, stack trace: {1}".format(e, traceback.format_exc())
         logger.log(msg=message, level=CommonVariables.ErrorLevel)
-        hutil.do_exit(exit_code=0,
+        hutil.do_exit(exit_code=CommonVariables.unknown_error,
                       operation='UpdateEncryptionSettings',
                       status=CommonVariables.extension_error_status,
                       code=str(CommonVariables.unknown_error),
@@ -481,7 +488,7 @@ def main():
             install()
         elif re.match("^([-/]*)(enable)", a):
             if DistroPatcher is None:
-                hutil.do_exit(exit_code=0,
+                hutil.do_exit(exit_code=CommonVariables.os_not_supported,
                             operation='Enable',
                             status=CommonVariables.extension_error_status,
                             code=(CommonVariables.os_not_supported),
@@ -530,7 +537,7 @@ def enable():
             logger.log("PRECHECK: Fatal Exception thrown during precheck")
             logger.log(traceback.format_exc())
             msg = str(e)
-            hutil.do_exit(exit_code=0,
+            hutil.do_exit(exit_code=CommonVariables.configuration_error,
                           operation='Enable',
                           status=CommonVariables.extension_error_status,
                           code=(CommonVariables.configuration_error),
@@ -581,10 +588,10 @@ def enable():
         else:
             msg = "Encryption operation {0} is not supported".format(encryption_operation)
             logger.log(msg)
-            hutil.do_exit(exit_code=0,
+            hutil.do_exit(exit_code=CommonVariables.configuration_error,
                           operation='Enable',
                           status=CommonVariables.extension_error_status,
-                          code=(CommonVariables.unknown_error),
+                          code=(CommonVariables.configuration_error),
                           message=msg)
 
 def enable_encryption():
@@ -688,17 +695,17 @@ def enable_encryption():
                             logger.log("Unsupported volume type specified and BEK volume does not exist, clearing encryption config")
                             encryption_config.clear_config()
 
-                    hutil.do_exit(exit_code=0,
+                    hutil.do_exit(exit_code=CommonVariables.configuration_error,
                                   operation='EnableEncryption',
                                   status=CommonVariables.extension_error_status,
-                                  code=str(CommonVariables.volue_type_not_support),
+                                  code=str(CommonVariables.configuration_error),
                                   message='VolumeType "{0}" is not supported'.format(extension_parameter.VolumeType))
 
                 if extension_parameter.command not in [CommonVariables.EnableEncryption, CommonVariables.EnableEncryptionFormat, CommonVariables.EnableEncryptionFormatAll]:
-                    hutil.do_exit(exit_code=0,
+                    hutil.do_exit(exit_code=CommonVariables.configuration_error,
                                   operation='EnableEncryption',
                                   status=CommonVariables.extension_error_status,
-                                  code=str(CommonVariables.command_not_support),
+                                  code=str(CommonVariables.configuration_error),
                                   message='Command "{0}" is not supported'.format(extension_parameter.command))
 
                 # generate passphrase and passphrase file if needed
@@ -718,7 +725,7 @@ def enable_encryption():
     except Exception as e:
         message = "Failed to enable the extension with error: {0}, stack trace: {1}".format(e, traceback.format_exc())
         logger.log(msg=message, level=CommonVariables.ErrorLevel)
-        hutil.do_exit(exit_code=0,
+        hutil.do_exit(exit_code=CommonVariables.unknown_error,
                       operation='EnableEncryption',
                       status=CommonVariables.extension_error_status,
                       code=str(CommonVariables.unknown_error),
@@ -1520,7 +1527,7 @@ def daemon_encrypt():
         bek_passphrase_file = bek_util.get_bek_passphrase_file(encryption_config)
 
     if bek_passphrase_file is None:
-        hutil.do_exit(exit_code=0,
+        hutil.do_exit(exit_code=CommonVariables.passphrase_file_not_found,
                       operation='EnableEncryption',
                       status=CommonVariables.extension_error_status,
                       code=CommonVariables.passphrase_file_not_found,
@@ -1552,7 +1559,7 @@ def daemon_encrypt():
         except Exception as e:
             message = "Failed to encrypt data volumes with error: {0}, stack trace: {1}".format(e, traceback.format_exc())
             logger.log(msg=message, level=CommonVariables.ErrorLevel)
-            hutil.do_exit(exit_code=0,
+            hutil.do_exit(exit_code=CommonVariables.encryption_failed,
                           operation='EnableEncryptionDataVolumes',
                           status=CommonVariables.extension_error_status,
                           code=CommonVariables.encryption_failed,
@@ -1630,7 +1637,7 @@ def daemon_encrypt():
             message = "OS volume encryption is not supported on {0} {1}".format(distro_name,
                                                                                 distro_version)
             logger.log(msg=message, level=CommonVariables.ErrorLevel)
-            hutil.do_exit(exit_code=0,
+            hutil.do_exit(exit_code=CommonVariables.encryption_failed,
                           operation='EnableEncryptionOSVolume',
                           status=CommonVariables.extension_error_status,
                           code=CommonVariables.encryption_failed,
@@ -1652,7 +1659,7 @@ def daemon_encrypt():
                                                                                                                  traceback.format_exc(),
                                                                                                                  os_encryption.state)
             logger.log(msg=message, level=CommonVariables.ErrorLevel)
-            hutil.do_exit(exit_code=0,
+            hutil.do_exit(exit_code=CommonVariables.encryption_failed,
                           operation='EnableEncryptionOSVolume',
                           status=CommonVariables.extension_error_status,
                           code=CommonVariables.encryption_failed,
@@ -1816,7 +1823,7 @@ def daemon_decrypt():
             raise Exception("command {0} not supported.".format(decryption_marker.get_current_command()))
         
         if failed_item != None:
-            hutil.do_exit(exit_code=0,
+            hutil.do_exit(exit_code=CommonVariables.encryption_failed,
                           operation='Disable',
                           status=CommonVariables.extension_error_status,
                           code=CommonVariables.encryption_failed,
@@ -1859,7 +1866,7 @@ def daemon():
             logger.log(msg=error_msg,
                         level=CommonVariables.ErrorLevel)
                 
-            hutil.do_exit(exit_code=0,
+            hutil.do_exit(exit_code=CommonVariables.encryption_failed,
                           operation='Disable',
                           status=CommonVariables.extension_error_status,
                           code=str(CommonVariables.encryption_failed),
@@ -1879,7 +1886,7 @@ def daemon():
         error_msg = ("Failed to enable the extension with error: {0}, stack trace: {1}".format(e, traceback.format_exc()))
         logger.log(msg=error_msg,
                     level=CommonVariables.ErrorLevel)
-        hutil.do_exit(exit_code=0,
+        hutil.do_exit(exit_code=CommonVariables.encryption_failed,
                         operation='Enable',
                         status=CommonVariables.extension_error_status,
                         code=str(CommonVariables.encryption_failed),
@@ -1896,14 +1903,16 @@ def daemon():
         logger.log("exiting daemon")
 
 def start_daemon(operation):
-    args = [os.path.join(os.getcwd(), __file__), "-daemon"]
-    logger.log("start_daemon with args: {0}".format(args))
     #This process will start a new background process by calling
-    #    handle.py -daemon
+    #    extension_shim.sh -c handle.py -daemon
     #to run the script and will exit itself immediatelly.
+    shim_path = os.path.join(os.getcwd(), CommonVariables.extension_shim_filename)
+    shim_opts = '-c ' + os.path.join(os.getcwd(), __file__) + ' -daemon'
+    args = [shim_path, shim_opts]
+    logger.log("start_daemon with args: {0}".format(args))
 
     #Redirect stdout and stderr to /dev/null.  Otherwise daemon process will
-    #throw Broke pipe exeception when parent process exit.
+    #throw broken pipe exception when parent process exit.
     devnull = open(os.devnull, 'w')
     child = subprocess.Popen(args, stdout=devnull, stderr=devnull)
     
@@ -1922,7 +1931,7 @@ def start_daemon(operation):
                           code=str(CommonVariables.success),
                           message="")
     else:
-        hutil.do_exit(exit_code=0,
+        hutil.do_exit(exit_code=CommonVariables.encryption_failed,
                       operation=operation,
                       status=CommonVariables.extension_error_status,
                       code=str(CommonVariables.encryption_failed),

--- a/VMEncryption/main/oscrypto/centos_68/encryptstates/StripdownState.py
+++ b/VMEncryption/main/oscrypto/centos_68/encryptstates/StripdownState.py
@@ -79,7 +79,7 @@ class StripdownState(OSEncryptionState):
                 f.write("service waagent restart\n")
             self.command_executor.Execute('at -f /restart-wala.sh now + 1 minutes', True)
 
-            self.context.hutil.do_exit(exit_code=0,
+            self.context.hutil.do_exit(CommonVariables.encryption_failed,
                                        operation='EnableEncryptionOSVolume',
                                        status=CommonVariables.extension_error_status,
                                        code=CommonVariables.encryption_failed,

--- a/VMEncryption/main/oscrypto/rhel_68/encryptstates/StripdownState.py
+++ b/VMEncryption/main/oscrypto/rhel_68/encryptstates/StripdownState.py
@@ -79,7 +79,7 @@ class StripdownState(OSEncryptionState):
                 f.write("service waagent restart\n")
             self.command_executor.Execute('at -f /restart-wala.sh now + 1 minutes', True)
 
-            self.context.hutil.do_exit(exit_code=0,
+            self.context.hutil.do_exit(exit_code=CommonVariables.encryption_failed,
                                        operation='EnableEncryptionOSVolume',
                                        status=CommonVariables.extension_error_status,
                                        code=CommonVariables.encryption_failed,

--- a/VMEncryption/main/oscrypto/ubuntu_1404/encryptstates/StripdownState.py
+++ b/VMEncryption/main/oscrypto/ubuntu_1404/encryptstates/StripdownState.py
@@ -80,7 +80,7 @@ class StripdownState(OSEncryptionState):
                 f.write("service walinuxagent restart\n")
             self.command_executor.Execute('at -f /restart-wala.sh now + 1 minutes', True)
 
-            self.context.hutil.do_exit(exit_code=0,
+            self.context.hutil.do_exit(exit_code=CommonVariables.encryption_failed,
                                        operation='EnableEncryptionOSVolume',
                                        status=CommonVariables.extension_error_status,
                                        code=CommonVariables.encryption_failed,

--- a/VMEncryption/main/oscrypto/ubuntu_1604/encryptstates/StripdownState.py
+++ b/VMEncryption/main/oscrypto/ubuntu_1604/encryptstates/StripdownState.py
@@ -76,7 +76,7 @@ class StripdownState(OSEncryptionState):
             # the restarted process shall see the marker and advance the state machine
             self.command_executor.ExecuteInBash('sleep 30 && systemctl start walinuxagent &', True)
 
-            self.context.hutil.do_exit(exit_code=0,
+            self.context.hutil.do_exit(exit_code=CommonVariables.encryption_failed,
                                        operation='EnableEncryptionOSVolume',
                                        status=CommonVariables.extension_error_status,
                                        code=CommonVariables.encryption_failed,

--- a/VMEncryption/setup.py
+++ b/VMEncryption/setup.py
@@ -81,11 +81,11 @@ manifest_obj = [{
   "name": CommonVariables.extension_name,
   "version": "1.0",
   "handlerManifest": {
-    "installCommand": main_entry + " -install",
-    "uninstallCommand": main_entry + " -uninstall",
-    "updateCommand": main_entry + " -update",
-    "enableCommand": main_entry + " -enable",
-    "disableCommand": main_entry + " -disable",
+    "installCommand": "extension_shim.sh -c {0} --install".format(main_entry),
+    "uninstallCommand": "extension_shim.sh -c {0} --uninstall".format(main_entry),
+    "updateCommand": "extension_shim.sh -c {0} --update".format(main_entry),
+    "enableCommand": "extension_shim.sh -c {0} --enable".format(main_entry),
+    "disableCommand": "extension_shim.sh -c {0} --disable".format(main_entry),
     "rebootAfterInstall": False,
     "reportHeartbeat": False
   }

--- a/VMEncryption/test/test_check_util.py
+++ b/VMEncryption/test/test_check_util.py
@@ -136,17 +136,61 @@ class TestCheckUtil(unittest.TestCase):
         with mock.patch("__builtin__.open", mock.mock_open(read_data=proc_mounts_output)) as mock_open:
             self.assertFalse(self.cutil.is_unsupported_mount_scheme())
 
+    # Skip LVM OS validation when OS volume is not being targeted
+    def test_skip_lvm_os_check_if_data_only_enable(self):
+        # skip lvm detection if data only 
+        self.cutil.validate_lvm_os({Common.CommonVariables.VolumeTypeKey: "DATA", Common.CommonVariables.EncryptionEncryptionOperationKey: Common.CommonVariables.EnableEncryption})
+
+    def test_skip_lvm_os_check_if_data_only_ef(self):
+        # skip lvm detection if data only 
+        self.cutil.validate_lvm_os({Common.CommonVariables.VolumeTypeKey: "DATA", Common.CommonVariables.EncryptionEncryptionOperationKey: Common.CommonVariables.EnableEncryptionFormat})
+
+    def test_skip_lvm_os_check_if_data_only_efa(self):
+        # skip lvm detection if data only 
+        self.cutil.validate_lvm_os({Common.CommonVariables.VolumeTypeKey: "DATA", Common.CommonVariables.EncryptionEncryptionOperationKey: Common.CommonVariables.EnableEncryptionFormatAll})
+
+    def test_skip_lvm_os_check_if_data_only_disable(self):
+        # skip lvm detection if data only 
+        self.cutil.validate_lvm_os({Common.CommonVariables.VolumeTypeKey: "DATA", Common.CommonVariables.EncryptionEncryptionOperationKey: Common.CommonVariables.DisableEncryption})
+
+    def test_skip_lvm_os_check_if_query(self):
+        # skip lvm detection if query status operation is invoked without volume type
+        self.cutil.validate_lvm_os({Common.CommonVariables.EncryptionEncryptionOperationKey: Common.CommonVariables.QueryEncryptionStatus})
+
+    def test_skip_lvm_no_encryption_operation(self):
+        # skip lvm detection if no encryption operation 
+        self.cutil.validate_lvm_os({Common.CommonVariables.VolumeTypeKey: "ALL"})
+
+    def test_skip_lvm_no_volume_type(self):
+        # skip lvm detection if no volume type specified
+        self.cutil.validate_lvm_os({Common.CommonVariables.EncryptionEncryptionOperationKey: Common.CommonVariables.EnableEncryptionFormatAll})
+
+    @mock.patch("os.system", return_value=-1)
+    def test_no_lvm_no_config(self, os_system):
+        # simulate no LVM OS, no config 
+        self.cutil.validate_lvm_os({})
+
     @mock.patch("os.system", return_value=0)
-    def test_lvm_os_lvm_present(self, os_system):
-        # if there is LVM
-        self.assertFalse(self.cutil.is_invalid_lvm_os())
+    def test_lvm_no_config(self, os_system):
+        # simulate valid LVM OS, no config
+        self.cutil.validate_lvm_os({})
+
+    @mock.patch("os.system", side_effect=[0, -1])
+    def test_invalid_lvm_no_config(self, os_system):
+        # simulate invalid LVM naming scheme, but no config setting to encrypt OS
+        self.cutil.validate_lvm_os({})
 
     @mock.patch("os.system", return_value=-1)
     def test_lvm_os_lvm_absent(self, os_system):
-        # if there is no LVM
-        self.assertFalse(self.cutil.is_invalid_lvm_os())
+        # using patched return value of -1, simulate no LVM OS 
+        self.cutil.validate_lvm_os({Common.CommonVariables.VolumeTypeKey: "ALL", Common.CommonVariables.EncryptionEncryptionOperationKey: Common.CommonVariables.EnableEncryption})
 
-    @mock.patch("os.system", side_effect=[0, -1, 0, 0, 0, 0, 0, 0])
-    def test_lvm_os_lvm_faulty(self, os_system):
-        # if there is faulty LVM
-        self.assertTrue(self.cutil.is_invalid_lvm_os())
+    @mock.patch("os.system", return_value=0)
+    def test_lvm_os_valid(self, os_system):
+        # simulate a valid LVM OS and a valid naming scheme by always returning 0
+        self.cutil.validate_lvm_os({Common.CommonVariables.VolumeTypeKey: "ALL", Common.CommonVariables.EncryptionEncryptionOperationKey: Common.CommonVariables.EnableEncryption})
+
+    @mock.patch("os.system", side_effect=[0, -1])
+    def test_lvm_os_lv_missing_expected_name(self, os_system):
+        # using patched side effects, first simulate LVM OS present, then simulate not finding the expected LV name 
+        self.assertRaises(Exception, self.cutil.validate_lvm_os, {Common.CommonVariables.VolumeTypeKey: "ALL", Common.CommonVariables.EncryptionEncryptionOperationKey: Common.CommonVariables.EnableEncryption})


### PR DESCRIPTION
- add extension shim for early exit if python 2.7 is unavailable on target system
- move archive to disable so future versions can restore in update
- improve restore performance by replacing slower shutil.copy2 with cp wildcard copy
- update various exit points with telemetry specific exit codes
- reduce enable failures by failing early on lvm os validation instead of warning