### PR TITLE
Automatically restart VM after dual pass encryption completes.

### DIFF
--- a/VMEncryption/main/oscrypto/OSEncryptionStateMachine.py
+++ b/VMEncryption/main/oscrypto/OSEncryptionStateMachine.py
@@ -93,3 +93,6 @@ class OSEncryptionStateMachine(object):
     def start_encryption(self):
         self.skip_encryption()
         self.log_machine_state()
+
+    def _reboot(self):
+        self.command_executor.Execute('reboot')

--- a/VMEncryption/main/oscrypto/centos_68/CentOS68EncryptionStateMachine.py
+++ b/VMEncryption/main/oscrypto/centos_68/CentOS68EncryptionStateMachine.py
@@ -211,3 +211,5 @@ class CentOS68EncryptionStateMachine(OSEncryptionStateMachine):
         
         self.stop_machine()
         self.log_machine_state()
+
+        self._reboot()

--- a/VMEncryption/main/oscrypto/rhel_68/RHEL68EncryptionStateMachine.py
+++ b/VMEncryption/main/oscrypto/rhel_68/RHEL68EncryptionStateMachine.py
@@ -200,3 +200,5 @@ class RHEL68EncryptionStateMachine(OSEncryptionStateMachine):
         
         self.stop_machine()
         self.log_machine_state()
+
+        self._reboot()

--- a/VMEncryption/main/oscrypto/rhel_72/RHEL72EncryptionStateMachine.py
+++ b/VMEncryption/main/oscrypto/rhel_72/RHEL72EncryptionStateMachine.py
@@ -199,3 +199,5 @@ class RHEL72EncryptionStateMachine(OSEncryptionStateMachine):
         
         self.stop_machine()
         self.log_machine_state()
+
+        self._reboot()

--- a/VMEncryption/main/oscrypto/rhel_72_lvm/RHEL72LVMEncryptionStateMachine.py
+++ b/VMEncryption/main/oscrypto/rhel_72_lvm/RHEL72LVMEncryptionStateMachine.py
@@ -201,3 +201,5 @@ class RHEL72LVMEncryptionStateMachine(OSEncryptionStateMachine):
         
         self.stop_machine()
         self.log_machine_state()
+
+        self._reboot()

--- a/VMEncryption/main/oscrypto/ubuntu_1404/Ubuntu1404EncryptionStateMachine.py
+++ b/VMEncryption/main/oscrypto/ubuntu_1404/Ubuntu1404EncryptionStateMachine.py
@@ -199,3 +199,5 @@ class Ubuntu1404EncryptionStateMachine(OSEncryptionStateMachine):
         
         self.stop_machine()
         self.log_machine_state()
+
+        self._reboot()

--- a/VMEncryption/main/oscrypto/ubuntu_1604/Ubuntu1604EncryptionStateMachine.py
+++ b/VMEncryption/main/oscrypto/ubuntu_1604/Ubuntu1604EncryptionStateMachine.py
@@ -199,3 +199,5 @@ class Ubuntu1604EncryptionStateMachine(OSEncryptionStateMachine):
         
         self.stop_machine()
         self.log_machine_state()
+
+        self._reboot()


### PR DESCRIPTION
Some distros like RHEL & CentOS are not able send VMRestartPending
status to the portal. This seems to occur due to agent not working
properly in pivot root env. As a result, the extension is not
completing as customer don't know to restart the VM due to lack
of notification.
In this fix a rebbot is added at the end of encryption. This
will remove the need of manual restart by the customer.