### PR TITLE
Add omsconfig host telemetry file path

### DIFF
--- a/OmsAgent/watcherutil.py
+++ b/OmsAgent/watcherutil.py
@@ -207,7 +207,8 @@ class Watcher:
                 "/var/opt/microsoft/omsagent/log/ODSIngestionAPI.status",
                 "/var/opt/microsoft/omsconfig/status/dscperformconsistency",
                 "/var/opt/microsoft/omsconfig/status/dscperforminventory",
-                "/var/opt/microsoft/omsconfig/status/dscsetlcm"
+                "/var/opt/microsoft/omsconfig/status/dscsetlcm",
+                "/var/opt/microsoft/omsconfig/status/omsconfighost"
             ]            
         for sf in status_files:
             if os.path.isfile(sf):


### PR DESCRIPTION
This file is going to include telemetry messages from the incoming omsconfig host (when OMI dependency is removed from omsconfig).