### PR TITLE
Check if OS encryption is supported for Distro,Version and Kernel

### DIFF
--- a/VMEncryption/main/SupportedOS.json
+++ b/VMEncryption/main/SupportedOS.json
@@ -1,0 +1,54 @@
+{
+  "redhat": [
+        {
+          "Version" : "7.6"
+        },
+        {
+          "Version" : "7.5"
+        },
+        {
+          "Version" : "7.4"
+        },
+        {
+          "Version" : "7.3"
+        },
+        {
+          "Version" : "7.2"
+        },
+        {
+          "Version" : "6.8"
+        }
+    ],
+    "Ubuntu" : [
+        {
+          "Version" : "16.04"
+        },
+        {
+          "Version" : "18.04"
+        },
+        {
+          "Version" : "14.04",
+          "Kernel": "4.15"
+        }
+    ],
+    "centos" : [
+        {
+          "Version" : "7.5"
+        },
+        {
+          "Version" : "7.4"
+        },
+        {
+          "Version" : "7.3.1611"
+        },
+        {
+          "Version" : "7.2.1511"
+        },
+        {
+          "Version" : "6.9"
+        },
+        {
+          "Version" : "6.8"
+        }
+    ]
+}

--- a/VMEncryption/main/check_util.py
+++ b/VMEncryption/main/check_util.py
@@ -22,8 +22,10 @@ import os
 import os.path
 import urlparse
 import re
+import json
 from Common import CommonVariables
 from CommandExecutor import CommandExecutor
+from distutils.version import LooseVersion
 
 class CheckUtil(object):
     """Checks compatibility for disk encryption"""
@@ -221,7 +223,36 @@ class CheckUtil(object):
             if self.is_insufficient_memory():
                 raise Exception("Not enough memory for enabling encryption on OS volume. 8 GB memory is recommended.")
 
-    def precheck_for_fatal_failures(self, public_settings, encryption_status):
+    def is_supported_os(self, public_settings, DistroPatcher, encryption_status):
+        encryption_operation = public_settings.get(CommonVariables.EncryptionEncryptionOperationKey)
+        if encryption_operation in [CommonVariables.QueryEncryptionStatus]:
+            self.logger.log("Query encryption operation detected. Skipping OS encryption validation check.")
+            return
+        volume_type = public_settings.get(CommonVariables.VolumeTypeKey)
+        # If volume type is data allow the operation (At this point we are sure a patch file for the distro exist)
+        if volume_type.lower() == CommonVariables.VolumeTypeData.lower():
+            self.logger.log("Volume Type is DATA. Skipping OS encryption validation check.")
+            return
+        # If OS volume is already encrypted just return (Should not break already encryted VM's)
+        if encryption_status["os"] != "NotEncrypted":
+            self.logger.log("OS volume already encrypted. Skipping OS encryption validation check.")
+            return
+        distro_name = DistroPatcher.distro_info[0]
+        distro_version = DistroPatcher.distro_info[1]
+        supported_os_file = os.path.join(os.getcwd(), 'main/SupportedOS.json')
+        with open(supported_os_file) as json_file:
+            data = json.load(json_file)
+            if distro_name in data:
+                versions = data[distro_name]
+                for version in versions:
+                    if distro_version.startswith(version['Version']):
+                        if 'Kernel' in version and LooseVersion(DistroPatcher.kernel_version) < LooseVersion(version['Kernel']):
+                            raise Exception('Kernel version {0} is not supported. Upgrade to kernel version {1}'.format(DistroPatcher.kernel_version, version['Kernel']))
+                        else:
+                            return
+            raise Exception('Distro {0} {1} is not supported for OS encryption'.format(distro_name, distro_version))
+
+    def precheck_for_fatal_failures(self, public_settings, encryption_status, DistroPatcher):
         """ run all fatal prechecks, they should throw an exception if anything is wrong """
         self.validate_key_vault_params(public_settings)
         self.validate_volume_type(public_settings)
@@ -229,6 +260,7 @@ class CheckUtil(object):
         self.validate_vfat()
         self.validate_aad(public_settings)
         self.validate_memory_os_encryption(public_settings, encryption_status)
+        self.is_supported_os(public_settings, DistroPatcher, encryption_status)
 
     def is_non_fatal_precheck_failure(self):
         """ run all prechecks """

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -513,7 +513,7 @@ def enable():
 
         # run fatal prechecks, report error if exceptions are caught
         try:
-            cutil.precheck_for_fatal_failures(public_settings, encryption_status)
+            cutil.precheck_for_fatal_failures(public_settings, encryption_status, DistroPatcher)
         except Exception as e:
             logger.log("PRECHECK: Fatal Exception thrown during precheck")
             logger.log(traceback.format_exc())

--- a/VMEncryption/main/patch/AbstractPatching.py
+++ b/VMEncryption/main/patch/AbstractPatching.py
@@ -52,6 +52,7 @@ class AbstractPatching(object):
         self.openssl_path = '/usr/bin/openssl'
         self.resize2fs_path = '/sbin/resize2fs'
         self.umount_path = '/usr/bin/umount'
+        self.kernel_version = platform.release()
 
     def install_adal(self):
         pass

--- a/VMEncryption/setup.py
+++ b/VMEncryption/setup.py
@@ -34,6 +34,7 @@ import os
 import subprocess
 from distutils.core import setup
 from zipfile import ZipFile
+from shutil import copy2
 
 from main.Common import CommonVariables
 
@@ -192,5 +193,7 @@ def zip(src, dst):
     zf.close()
 
 final_folder_path = target_zip_file_location + target_folder_name
+# Manually add SupportedOS.json file as setup seems to only copy py file
+copy2(main_folder+'/SupportedOS.json', final_folder_path+'/'+main_folder )
 zip(final_folder_path, target_zip_file_path)
 

--- a/VMEncryption/test/test_check_util.py
+++ b/VMEncryption/test/test_check_util.py
@@ -6,6 +6,12 @@ from main import Common
 from StringIO import StringIO
 import console_logger
 
+class MockDistroPatcher:
+    def __init__(self, name, version, kernel):
+        self.distro_info = [None] * 2
+        self.distro_info[0] = name
+        self.distro_info[1] = version
+        self.kernel_version = kernel
 
 class TestCheckUtil(unittest.TestCase):
     """ unit tests for functions in the check_util module """
@@ -68,26 +74,27 @@ class TestCheckUtil(unittest.TestCase):
 
     @mock.patch('main.CommandExecutor.CommandExecutor.Execute', return_value=0)
     def test_fatal_checks(self, mock_exec):
+        mock_distro_patcher = MockDistroPatcher('Ubuntu', '14.04', '4.15')
         self.cutil.precheck_for_fatal_failures({
             Common.CommonVariables.EncryptionEncryptionOperationKey: Common.CommonVariables.QueryEncryptionStatus
-            }, { "os": "NotEncrypted" })
+            }, { "os": "NotEncrypted" }, mock_distro_patcher)
         self.cutil.precheck_for_fatal_failures({
             Common.CommonVariables.VolumeTypeKey: "DATA",
             Common.CommonVariables.EncryptionEncryptionOperationKey: Common.CommonVariables.DisableEncryption
-            }, { "os": "NotEncrypted" })
+            }, { "os": "NotEncrypted" }, mock_distro_patcher)
         self.cutil.precheck_for_fatal_failures({
             Common.CommonVariables.VolumeTypeKey: "ALL",
             Common.CommonVariables.KeyVaultURLKey: "https://vaultname.vault.azure.net/",
             Common.CommonVariables.AADClientIDKey: "00000000-0000-0000-0000-000000000000",
             Common.CommonVariables.EncryptionEncryptionOperationKey: Common.CommonVariables.EnableEncryption
-            }, { "os": "NotEncrypted" })
+            }, { "os": "NotEncrypted" }, mock_distro_patcher)
         self.cutil.precheck_for_fatal_failures({
             Common.CommonVariables.VolumeTypeKey: "ALL",
             Common.CommonVariables.KeyVaultURLKey: "https://vaultname.vault.azure.net/",
             Common.CommonVariables.KeyEncryptionKeyURLKey: "https://vaultname.vault.azure.net/keys/keyname/ver",
             Common.CommonVariables.AADClientIDKey: "00000000-0000-0000-0000-000000000000",
             Common.CommonVariables.EncryptionEncryptionOperationKey: Common.CommonVariables.EnableEncryptionFormat
-            }, { "os": "NotEncrypted" })
+            }, { "os": "NotEncrypted" }, mock_distro_patcher)
         self.cutil.precheck_for_fatal_failures({
             Common.CommonVariables.VolumeTypeKey: "ALL",
             Common.CommonVariables.KeyVaultURLKey: "https://vaultname.vault.azure.net/",
@@ -95,7 +102,7 @@ class TestCheckUtil(unittest.TestCase):
             Common.CommonVariables.KeyEncryptionAlgorithmKey: 'rsa-OAEP-256',
             Common.CommonVariables.AADClientIDKey: "00000000-0000-0000-0000-000000000000",
             Common.CommonVariables.EncryptionEncryptionOperationKey: Common.CommonVariables.EnableEncryptionFormatAll
-            }, { "os": "NotEncrypted" })
+            }, { "os": "NotEncrypted" }, mock_distro_patcher)
         self.assertRaises(Exception, self.cutil.precheck_for_fatal_failures, {})
         self.assertRaises(Exception, self.cutil.precheck_for_fatal_failures, {
             Common.CommonVariables.VolumeTypeKey: "ALL",
@@ -104,12 +111,12 @@ class TestCheckUtil(unittest.TestCase):
             Common.CommonVariables.KeyEncryptionAlgorithmKey: 'rsa-OAEP-256',
             Common.CommonVariables.AADClientIDKey: "INVALIDKEY",
             Common.CommonVariables.EncryptionEncryptionOperationKey: Common.CommonVariables.EnableEncryptionFormatAll
-            })
+            }, mock_distro_patcher)
         self.assertRaises(Exception, self.cutil.precheck_for_fatal_failures, {
             Common.CommonVariables.VolumeTypeKey: "123",
             Common.CommonVariables.AADClientIDKey: "00000000-0000-0000-0000-000000000000",
             Common.CommonVariables.EncryptionEncryptionOperationKey: Common.CommonVariables.EnableEncryption
-            }, { "os": "NotEncrypted" })
+            }, { "os": "NotEncrypted" }, mock_distro_patcher)
         self.assertRaises(Exception, self.cutil.precheck_for_fatal_failures, {
             Common.CommonVariables.VolumeTypeKey: "ALL",
             Common.CommonVariables.KeyVaultURLKey: "https://vaultname.vault.azure.net/",
@@ -117,7 +124,11 @@ class TestCheckUtil(unittest.TestCase):
             Common.CommonVariables.KeyEncryptionAlgorithmKey: 'rsa-OAEP-25600',
             Common.CommonVariables.AADClientIDKey: "00000000-0000-0000-0000-000000000000",
             Common.CommonVariables.EncryptionEncryptionOperationKey: Common.CommonVariables.EnableEncryptionFormatAll
-            }, { "os": "NotEncrypted" })
+            }, { "os": "NotEncrypted" }, mock_distro_patcher)
+        mock_distro_patcher = MockDistroPatcher('Ubuntu', '14.04', '4.4')
+        self.assertRaises(Exception, self.cutil.precheck_for_fatal_failures, {
+            Common.CommonVariables.VolumeTypeKey: "ALL"
+            }, { "os": "NotEncrypted" }, mock_distro_patcher)
 
     def test_mount_scheme(self):
         proc_mounts_output = """
@@ -267,49 +278,95 @@ class TestCheckUtil(unittest.TestCase):
         self.assertRaises(Exception, self.cutil.validate_memory_os_encryption, {
             Common.CommonVariables.VolumeTypeKey: "ALL",
             Common.CommonVariables.KeyVaultURLKey: "https://vaultname.vault.azure.net/",
-            Common.CommonVariables.KeyVaultResourceIdKey: "/subscriptions/subid/resourceGroups/rgname/providers/Microsoft.KeyVault/vaults/vaultname",
             Common.CommonVariables.KeyEncryptionKeyURLKey: "https://vaultname.vault.azure.net/keys/keyname/ver",
-            Common.CommonVariables.KekVaultResourceIdKey: "/subscriptions/subid/resourceGroups/rgname/providers/Microsoft.KeyVault/vaults/vaultname",
             Common.CommonVariables.KeyEncryptionAlgorithmKey: 'rsa-OAEP-25600',
+            Common.CommonVariables.AADClientIDKey: "00000000-0000-0000-0000-000000000000",
             Common.CommonVariables.EncryptionEncryptionOperationKey: Common.CommonVariables.EnableEncryptionFormatAll
             }, { "os": "NotEncrypted" })
         try:
             self.cutil.validate_memory_os_encryption( {
             Common.CommonVariables.VolumeTypeKey: "ALL",
             Common.CommonVariables.KeyVaultURLKey: "https://vaultname.vault.azure.net/",
-            Common.CommonVariables.KeyVaultResourceIdKey: "/subscriptions/subid/resourceGroups/rgname/providers/Microsoft.KeyVault/vaults/vaultname",
             Common.CommonVariables.KeyEncryptionKeyURLKey: "https://vaultname.vault.azure.net/keys/keyname/ver",
-            Common.CommonVariables.KekVaultResourceIdKey: "/subscriptions/subid/resourceGroups/rgname/providers/Microsoft.KeyVault/vaults/vaultname",
             Common.CommonVariables.KeyEncryptionAlgorithmKey: 'rsa-OAEP-25600',
+            Common.CommonVariables.AADClientIDKey: "00000000-0000-0000-0000-000000000000",
             Common.CommonVariables.EncryptionEncryptionOperationKey: Common.CommonVariables.EnableEncryptionFormatAll
             }, { "os": "Encrypted" })
         except Exception:
-            self.fail("validate_memory_os_encryption threw unexpected exception")
+            self.fail("validate_memory_os_encryption threw unexpected exception\nException message was:\n" + str(e))
         try:
             output = "8000000"
             os_popen.return_value = self.get_mock_filestream(output)
             self.cutil.validate_memory_os_encryption( {
             Common.CommonVariables.VolumeTypeKey: "ALL",
             Common.CommonVariables.KeyVaultURLKey: "https://vaultname.vault.azure.net/",
-            Common.CommonVariables.KeyVaultResourceIdKey: "/subscriptions/subid/resourceGroups/rgname/providers/Microsoft.KeyVault/vaults/vaultname",
             Common.CommonVariables.KeyEncryptionKeyURLKey: "https://vaultname.vault.azure.net/keys/keyname/ver",
-            Common.CommonVariables.KekVaultResourceIdKey: "/subscriptions/subid/resourceGroups/rgname/providers/Microsoft.KeyVault/vaults/vaultname",
             Common.CommonVariables.KeyEncryptionAlgorithmKey: 'rsa-OAEP-25600',
+            Common.CommonVariables.AADClientIDKey: "00000000-0000-0000-0000-000000000000",
             Common.CommonVariables.EncryptionEncryptionOperationKey: Common.CommonVariables.EnableEncryptionFormatAll
             }, { "os": "Encrypted" })
         except Exception:
-            self.fail("validate_memory_os_encryption threw unexpected exception")
+            self.fail("validate_memory_os_encryption threw unexpected exception\nException message was:\n" + str(e))
         try:
             output = "8000000"
             os_popen.return_value = self.get_mock_filestream(output)
             self.cutil.validate_memory_os_encryption( {
             Common.CommonVariables.VolumeTypeKey: "ALL",
             Common.CommonVariables.KeyVaultURLKey: "https://vaultname.vault.azure.net/",
-            Common.CommonVariables.KeyVaultResourceIdKey: "/subscriptions/subid/resourceGroups/rgname/providers/Microsoft.KeyVault/vaults/vaultname",
             Common.CommonVariables.KeyEncryptionKeyURLKey: "https://vaultname.vault.azure.net/keys/keyname/ver",
-            Common.CommonVariables.KekVaultResourceIdKey: "/subscriptions/subid/resourceGroups/rgname/providers/Microsoft.KeyVault/vaults/vaultname",
             Common.CommonVariables.KeyEncryptionAlgorithmKey: 'rsa-OAEP-25600',
+            Common.CommonVariables.AADClientIDKey: "00000000-0000-0000-0000-000000000000",
             Common.CommonVariables.EncryptionEncryptionOperationKey: Common.CommonVariables.EnableEncryptionFormatAll
             }, { "os": "NotEncrypted" })
         except Exception:
-            self.fail("validate_memory_os_encryption threw unexpected exception")
+            self.fail("validate_memory_os_encryption threw unexpected exception\nException message was:\n" + str(e))
+
+    def test_supported_os(self):
+        # test exception is raised for Ubuntu 14.04 kernel version
+        self.assertRaises(Exception, self.cutil.is_supported_os, {
+            Common.CommonVariables.VolumeTypeKey: "ALL"
+            }, MockDistroPatcher('Ubuntu', '14.04', '4.4'), {"os" : "NotEncrypted"})
+        # test exception is not raised for Ubuntu 14.04 kernel version 4.15
+        try:
+            self.cutil.is_supported_os( {
+            Common.CommonVariables.VolumeTypeKey: "ALL"
+            }, MockDistroPatcher('Ubuntu', '14.04', '4.15'), {"os" : "NotEncrypted"})
+        except Exception as e:
+            self.fail("is_unsupported_os threw unexpected exception.\nException message was:\n" + str(e))
+        # test exception is not raised for already encrypted OS volume
+        try:
+            self.cutil.is_supported_os( {
+            Common.CommonVariables.VolumeTypeKey: "ALL"
+            }, MockDistroPatcher('Ubuntu', '14.04', '4.4'), {"os" : "Encrypted"})
+        except Exception as e:
+            self.fail("is_unsupported_os threw unexpected exception.\nException message was:\n" + str(e))
+        # test exception is raised for unsupported OS
+        self.assertRaises(Exception, self.cutil.is_supported_os, {
+            Common.CommonVariables.VolumeTypeKey: "ALL"
+            }, MockDistroPatcher('Ubuntu', '12.04', ''), {"os" : "NotEncrypted"})
+        self.assertRaises(Exception, self.cutil.is_supported_os, {
+            Common.CommonVariables.VolumeTypeKey: "ALL"
+            }, MockDistroPatcher('redhat', '6.7', ''), {"os" : "NotEncrypted"})
+        self.assertRaises(Exception, self.cutil.is_supported_os, {
+            Common.CommonVariables.VolumeTypeKey: "ALL"
+            }, MockDistroPatcher('centos', '7.9', ''), {"os" : "NotEncrypted"})
+        # test exception is not raised for supported OS
+        try:
+            self.cutil.is_supported_os( {
+            Common.CommonVariables.VolumeTypeKey: "ALL"
+            }, MockDistroPatcher('Ubuntu', '18.04', ''), {"os" : "NotEncrypted"})
+        except Exception as e:
+            self.fail("is_unsupported_os threw unexpected exception.\nException message was:\n" + str(e))
+        try:
+            self.cutil.is_supported_os( {
+            Common.CommonVariables.VolumeTypeKey: "ALL"
+            }, MockDistroPatcher('centos', '7.2.1511', ''), {"os" : "NotEncrypted"})
+        except Exception as e:
+            self.fail("is_unsupported_os threw unexpected exception.\nException message was:\n" + str(e))
+        # test exception is not raised for DATA volume
+        try:
+            self.cutil.is_supported_os( {
+            Common.CommonVariables.VolumeTypeKey: "DATA"
+            }, MockDistroPatcher('SuSE', '12.4', ''), {"os" : "NotEncrypted"})
+        except Exception as e:
+            self.fail("is_unsupported_os threw unexpected exception.\nException message was:\n" + str(e))


### PR DESCRIPTION
Added a new json file that contains Distro, Version and Kernel information for supported OS encryption.
This file will be referred before starting a new enable operation.