### PR TITLE
Check if OS encryption is supported for Distro,Version and Kernel

### DIFF
--- a/VMEncryption/main/SupportedOS.json
+++ b/VMEncryption/main/SupportedOS.json
@@ -1,0 +1,54 @@
+{
+  "redhat": [
+        {
+          "Version" : "7.6"
+        },
+        {
+          "Version" : "7.5"
+        },
+        {
+          "Version" : "7.4"
+        },
+        {
+          "Version" : "7.3"
+        },
+        {
+          "Version" : "7.2"
+        },
+        {
+          "Version" : "6.8"
+        }
+    ],
+    "Ubuntu" : [
+        {
+          "Version" : "16.04"
+        },
+        {
+          "Version" : "18.04"
+        },
+        {
+          "Version" : "14.04",
+          "Kernel": "4.15"
+        }
+    ],
+    "centos" : [
+        {
+          "Version" : "7.5"
+        },
+        {
+          "Version" : "7.4"
+        },
+        {
+          "Version" : "7.3.1611"
+        },
+        {
+          "Version" : "7.2.1511"
+        },
+        {
+          "Version" : "6.9"
+        },
+        {
+          "Version" : "6.8"
+        }
+    ]
+}

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -546,7 +546,7 @@ def enable():
 
         # run fatal prechecks, report error if exceptions are caught
         try:
-            cutil.precheck_for_fatal_failures(public_settings, encryption_status)
+            cutil.precheck_for_fatal_failures(public_settings, encryption_status, DistroPatcher)
         except Exception as e:
             logger.log("PRECHECK: Fatal Exception thrown during precheck")
             logger.log(traceback.format_exc())

--- a/VMEncryption/main/patch/AbstractPatching.py
+++ b/VMEncryption/main/patch/AbstractPatching.py
@@ -52,6 +52,7 @@ class AbstractPatching(object):
         self.openssl_path = '/usr/bin/openssl'
         self.resize2fs_path = '/sbin/resize2fs'
         self.umount_path = '/usr/bin/umount'
+        self.kernel_version = platform.release()
 
     def install_cryptsetup(self):
         pass

--- a/VMEncryption/setup.py
+++ b/VMEncryption/setup.py
@@ -32,6 +32,7 @@ import os
 import subprocess
 from distutils.core import setup
 from zipfile import ZipFile
+from shutil import copy2
 
 from main.Common import CommonVariables
 
@@ -190,5 +191,7 @@ def zip(src, dst):
     zf.close()
 
 final_folder_path = target_zip_file_location + target_folder_name
+# Manually add SupportedOS.json file as setup seems to only copy py file
+copy2(main_folder+'/SupportedOS.json', final_folder_path+'/'+main_folder )
 zip(final_folder_path, target_zip_file_path)
 


### PR DESCRIPTION
Added a new json file that contains Distro, Version and Kernel information for supported OS encryption.
This file will be referred before starting a new enable operation.