### PR TITLE
Fix waagent import error on CoreOS[DualPass]

### DIFF
--- a/VMEncryption/extension_shim.sh
+++ b/VMEncryption/extension_shim.sh
@@ -115,5 +115,12 @@ else
     fi
 fi
 
+${PYTHON} main/Utils/WAAgentUtil.py
+
+if [ $? -ne 0 ]; then
+    echo "Cannot locate waagent. Please verify if this Distro is supported by Azure Disk Encryption"
+    exit 52 # Missing Dependency
+fi
+
 ${PYTHON} ${COMMAND} ${operation} 2>&1
 # DONE

--- a/VMEncryption/main/Utils/WAAgentUtil.py
+++ b/VMEncryption/main/Utils/WAAgentUtil.py
@@ -29,11 +29,12 @@ def searchWAAgent():
     agentPath = '/usr/sbin/waagent'
     if os.path.isfile(agentPath):
         return agentPath
-    user_paths = os.environ['PYTHONPATH'].split(os.pathsep)
-    for user_path in user_paths:
-        agentPath = os.path.join(user_path, 'waagent')
-        if os.path.isfile(agentPath):
-            return agentPath
+    if 'PYTHONPATH' in os.environ:
+        user_paths = os.environ['PYTHONPATH'].split(os.pathsep)
+        for user_path in user_paths:
+            agentPath = os.path.join(user_path, 'waagent')
+            if os.path.isfile(agentPath):
+                return agentPath
     return None
 
 agentPath = searchWAAgent()


### PR DESCRIPTION
waagent binary is in different location on CoreOs. This is causing import error and making extension fail before it can report that CoreOs is supported. Accounting for waagent location on CoreOs so that extension can execute as expected.