### PR TITLE
fix for python 2.6 break and writing to stdout

### DIFF
--- a/OmsAgent/Fairfax/omsagent_ff.py
+++ b/OmsAgent/Fairfax/omsagent_ff.py
@@ -423,8 +423,9 @@ def enable():
         uid = pwd.getpwnam(AgentUser).pw_uid
         gid = grp.getgrnam(AgentGroup).gr_gid
         os.chown(etc_final_path, uid, gid)
+        
         # octal numbers are represented differently in python 3
-        if sys.version_info.major > 2:
+        if sys.version_info >= (3,):
             os.chmod(etc_final_path, 0o750)
         else:    
             os.chmod(etc_final_path, 0750)
@@ -432,16 +433,16 @@ def enable():
         for root, dirs, files in os.walk(etc_final_path):
             for d in dirs:
                 os.chown(os.path.join(root, d), uid, gid)
-                if sys.version_info.major > 2:
+                if sys.version_info >= (3,):
                     os.chmod(os.path.join(root, d), 0o750)
                 else:    
                     os.chmod(os.path.join(root, d), 0750)                
             for f in files:
                 os.chown(os.path.join(root, f), uid, gid)                  
-                if sys.version_info.major > 2:
+                if sys.version_info >= (3,):
                     os.chmod(os.path.join(root, f), 0o640)
                 else:    
-                    os.chmod(os.path.join(root, f), 0640)                  
+                    os.chmod(os.path.join(root, f), 0640)                           
 
     if exit_code is 0:
         # Create a marker file to denote the workspace that was

--- a/OmsAgent/Mooncake/omsagent_mc.py
+++ b/OmsAgent/Mooncake/omsagent_mc.py
@@ -425,7 +425,7 @@ def enable():
         os.chown(etc_final_path, uid, gid)
         
         # octal numbers are represented differently in python 3
-        if sys.version_info.major > 2:
+        if sys.version_info >= (3,):
             os.chmod(etc_final_path, 0o750)
         else:    
             os.chmod(etc_final_path, 0750)
@@ -433,16 +433,16 @@ def enable():
         for root, dirs, files in os.walk(etc_final_path):
             for d in dirs:
                 os.chown(os.path.join(root, d), uid, gid)
-                if sys.version_info.major > 2:
+                if sys.version_info >= (3,):
                     os.chmod(os.path.join(root, d), 0o750)
                 else:    
                     os.chmod(os.path.join(root, d), 0750)                
             for f in files:
                 os.chown(os.path.join(root, f), uid, gid)                  
-                if sys.version_info.major > 2:
+                if sys.version_info >= (3,):
                     os.chmod(os.path.join(root, f), 0o640)
                 else:    
-                    os.chmod(os.path.join(root, f), 0640)                  
+                    os.chmod(os.path.join(root, f), 0640)                           
 
     if exit_code is 0:
         # Create a marker file to denote the workspace that was

--- a/OmsAgent/omsagent.py
+++ b/OmsAgent/omsagent.py
@@ -427,7 +427,7 @@ def enable():
         os.chown(etc_final_path, uid, gid)
 
         # octal numbers are represented differently in python 3
-        if sys.version_info.major > 2:
+        if sys.version_info >= (3,):
             os.chmod(etc_final_path, 0o750)
         else:    
             os.chmod(etc_final_path, 0750)
@@ -435,13 +435,13 @@ def enable():
         for root, dirs, files in os.walk(etc_final_path):
             for d in dirs:
                 os.chown(os.path.join(root, d), uid, gid)
-                if sys.version_info.major > 2:
+                if sys.version_info >= (3,):
                     os.chmod(os.path.join(root, d), 0o750)
                 else:    
                     os.chmod(os.path.join(root, d), 0750)                
             for f in files:
                 os.chown(os.path.join(root, f), uid, gid)                  
-                if sys.version_info.major > 2:
+                if sys.version_info >= (3,):
                     os.chmod(os.path.join(root, f), 0o640)
                 else:    
                     os.chmod(os.path.join(root, f), 0640)                           
@@ -943,6 +943,16 @@ def run_command_and_log(cmd, check_error = True, log_cmd = True):
         hutil_log_info('Output of command "{0}": \n{1}'.format(cmd, output))
     else:
         hutil_log_info('Output: \n{0}'.format(output))
+
+    # also write output to STDOUT since WA agent uploads that to Azlinux Kusto DB
+    try:
+        if sys.version_info >= (3,):
+            print(output)
+        else:    
+            print output        
+    except:
+        hutil_log_info('Failed to write output to STDOUT')
+
     return exit_code, output
 
 


### PR DESCRIPTION
- sys.version.major is not available in versions <2.7
- output message to stdout which waagent picks up