### PR TITLE
Fix update encryption settings flow

### DIFF
--- a/VMEncryption/main/BekUtil.py
+++ b/VMEncryption/main/BekUtil.py
@@ -54,6 +54,10 @@ class BekUtil(object):
 
             with open(os.path.join(self.bek_filesystem_mount_point, bek_filename), "w") as f:
                 f.write(passphrase)
+            for bek_file in os.listdir(self.bek_filesystem_mount_point):
+                if bek_filename in bek_file and bek_filename != bek_file:
+                    with open(os.path.join(self.bek_filesystem_mount_point, bek_file), "w") as f:
+                        f.write(passphrase)
         except Exception as e:
             message = "Failed to store BEK in BEK VOLUME with error: {0}".format(str(e))
             self.logger.log(message)

--- a/VMEncryption/main/DiskUtil.py
+++ b/VMEncryption/main/DiskUtil.py
@@ -390,12 +390,9 @@ class DiskUtil(object):
         <target name> <source device> <key file> <options>
         """
         try:
-            if not crypt_item.luks_header_path:
-                crypt_item.luks_header_path = "None"
-
             mount_content_item = (crypt_item.mapper_name + " " +
                                   crypt_item.dev_path + " " +
-                                  crypt_item.luks_header_path + " " +
+                                  str(crypt_item.luks_header_path) + " " +
                                   crypt_item.mount_point + " " +
                                   crypt_item.file_system + " " +
                                   str(crypt_item.uses_cleartext_key) + " " +


### PR DESCRIPTION
1. Remove new luks keys if update operation fails.
2. Remove reboot from singlepass update settings flow.
3. Commit encryption parameters after encryption settings are stamped.
4. Keep all passphrase files in sync when updating passphrase.
5. Fix multiple wireserver requests send by Linux extension.