### PR TITLE
Auto Unlock for ADE on new VMs

### DIFF
--- a/VMEncryption/main/Common.py
+++ b/VMEncryption/main/Common.py
@@ -32,8 +32,9 @@ class CommonVariables:
     """
     encryption_key_file_name = 'LinuxPassPhraseFileName'
     encryption_key_mount_point = '/mnt/azure_bek_disk'
-    bek_fstab_line_template = 'LABEL=BEK\\040VOLUME {0} auto defaults,discard,nofail,nobootwait 0 0\n'
-    etc_defaults_cryptdisks_line = '\nCRYPTDISKS_MOUNT="$CRYPTDISKS_MOUNT /mnt/azure_bek_disk"\n'
+    bek_fstab_line_template = 'LABEL=BEK\\040VOLUME {0} auto defaults,discard,nofail 0 0\n'
+    bek_fstab_line_template_ubuntu_14 = 'LABEL=BEK\\040VOLUME {0} auto defaults,discard,nobootwait 0 0\n'
+    etc_defaults_cryptdisks_line = '\nCRYPTDISKS_MOUNT="$CRYPTDISKS_MOUNT {0}"\n'
     encryption_algorithms = ['RSA-OAEP', 'RSA-OAEP-256', 'RSA1_5']
     default_encryption_algorithm = 'RSA-OAEP'
     encryption_settings_file_name_pattern = 'settings_{0}.json'

--- a/VMEncryption/main/Common.py
+++ b/VMEncryption/main/Common.py
@@ -32,6 +32,8 @@ class CommonVariables:
     """
     encryption_key_file_name = 'LinuxPassPhraseFileName'
     encryption_key_mount_point = '/mnt/azure_bek_disk'
+    bek_fstab_line_template = 'LABEL=BEK\\040VOLUME {0} auto defaults,discard,nofail,nobootwait 0 0\n'
+    etc_defaults_cryptdisks_line = '\nCRYPTDISKS_MOUNT="$CRYPTDISKS_MOUNT /mnt/azure_bek_disk"\n'
     encryption_algorithms = ['RSA-OAEP', 'RSA-OAEP-256', 'RSA1_5']
     default_encryption_algorithm = 'RSA-OAEP'
     encryption_settings_file_name_pattern = 'settings_{0}.json'

--- a/VMEncryption/main/DiskUtil.py
+++ b/VMEncryption/main/DiskUtil.py
@@ -352,7 +352,7 @@ class DiskUtil(object):
             key_file = self.encryption_environment.cleartext_key_base_path + crypt_item.mapper_name
         else:
             # get the scsi and lun number for the dev_path of this crypt_item
-            scsi_lun_numbers = self.get_azure_data_disk_controller_and_lun_numbers([os.path.realpah(crypt_item.dev_path)])
+            scsi_lun_numbers = self.get_azure_data_disk_controller_and_lun_numbers([os.path.realpath(crypt_item.dev_path)])
             if len(scsi_lun_numbers) == 0:
                 # The default in case we didn't get any scsi/lun numbers
                 key_file = os.path.join(CommonVariables.encryption_key_mount_point, self.encryption_environment.default_bek_filename)
@@ -372,7 +372,7 @@ class DiskUtil(object):
             self.make_sure_path_exists(backup_folder)
             with open(backup_file, "w") as wf:
                 wf.write(crypttab_line)
-            self.logger.log("Added crypttab item {0} to {1}".format(mapper_name, backup_file))
+            self.logger.log("Added crypttab item {0} to {1}".format(crypt_item.mapper_name, backup_file))
         return True
 
     def add_crypt_item_to_azure_crypt_mount(self, crypt_item, backup_folder=None):
@@ -673,10 +673,11 @@ class DiskUtil(object):
                 break
 
         if not bek_line_found:
-            lines.append('LABEL=BEK\040\VOLUME {0} auto defaults,discard,nofail 0 0'.format(CommonVariables.encryption_key_mount_point))
+            lines.append('LABEL=BEK\\040VOLUME {0} auto defaults,discard,nofail 0 0'.format(CommonVariables.encryption_key_mount_point))
 
         with open('/etc/fstab', 'w') as f:
             f.writelines(lines)
+            f.write('\n')
 
         if relevant_line is not None:
             with open('/etc/fstab.azure.backup', 'a+') as f:
@@ -890,8 +891,8 @@ class DiskUtil(object):
                     encryption_status["data"] = "EncryptionInProgress"
 
             if volume_type == CommonVariables.VolumeTypeOS.lower() or \
-                volume_type == CommonVariables.VolumeTypeAll.lower():
-                 if not os_drive_encrypted:
+               volume_type == CommonVariables.VolumeTypeAll.lower():
+                if not os_drive_encrypted:
                     encryption_status["os"] = "EncryptionInProgress"
         elif os.path.exists(self.get_osmapper_path()) and not os_drive_encrypted:
             encryption_status["os"] = "VMRestartPending"

--- a/VMEncryption/main/DiskUtil.py
+++ b/VMEncryption/main/DiskUtil.py
@@ -242,11 +242,8 @@ class DiskUtil(object):
 
         crypt_items = []
         rootfs_crypt_item_found = False
-        non_root_crypt_item_found_in_azure_crypt_mount = False
 
-        if not os.path.exists(self.encryption_environment.azure_crypt_mount_config_path):
-            self.logger.log("{0} does not exist".format(self.encryption_environment.azure_crypt_mount_config_path))
-        else:
+        if self.should_use_azure_crypt_mount():
             with open(self.encryption_environment.azure_crypt_mount_config_path, 'r') as f:
                 for line in f:
                     if not line.strip():
@@ -256,12 +253,9 @@ class DiskUtil(object):
 
                     if crypt_item.mount_point == "/" or crypt_item.mapper_name == CommonVariables.osmapper_name :
                         rootfs_crypt_item_found = True
-                    else:
-                        non_root_crypt_item_found_in_azure_crypt_mount = True
 
                     crypt_items.append(crypt_item)
-
-        if not non_root_crypt_item_found_in_azure_crypt_mount:
+        else:
             self.logger.log("Using crypttab instead of azure_crypt_mount file.")
             crypttab_path = "/etc/crypttab"
             if not os.path.exists(crypttab_path):

--- a/VMEncryption/main/DiskUtil.py
+++ b/VMEncryption/main/DiskUtil.py
@@ -686,7 +686,7 @@ class DiskUtil(object):
                 break
 
         if not self.is_bek_in_fstab_file(lines):
-            lines.append(CommonVariables.bek_fstab_line_template.format(CommonVariables.encryption_key_mount_point))
+            lines.append(self.get_fstab_bek_line())
             self.add_bek_to_default_cryptdisks()
 
         with open('/etc/fstab', 'w') as f:
@@ -696,13 +696,19 @@ class DiskUtil(object):
             with open('/etc/fstab.azure.backup', 'a+') as f:
                 f.write(relevant_line)
 
+    def get_fstab_bek_line(self):
+        if self.distro_patcher.distro_info[0].lower() == 'ubuntu' and self.distro_patcher.distro_info[1] == '14':
+            return CommonVariables.bek_fstab_line_template_ubuntu_14.format(CommonVariables.encryption_key_mount_point)
+        else:
+            return CommonVariables.bek_fstab_line_template.format(CommonVariables.encryption_key_mount_point)
+
     def add_bek_to_default_cryptdisks(self):
-        if os.path.exists("/etc/defaults/cryptdisks"):
-            with open("/etc/defaults/cryptdisks", 'r') as f:
+        if os.path.exists("/etc/default/cryptdisks"):
+            with open("/etc/default/cryptdisks", 'r') as f:
                 lines = f.readlines()
             if not any(["azure_bek_disk" in line for line in lines]):
-                with open("/etc/defaults/cryptdisks", 'a') as f:
-                    f.write(CommonVariables.etc_defaults_cryptdisks_line)
+                with open("/etc/default/cryptdisks", 'a') as f:
+                    f.write(CommonVariables.etc_defaults_cryptdisks_line.format(CommonVariables.encryption_key_mount_point))
 
     def remove_mount_info(self, mount_point):
         if not mount_point:

--- a/VMEncryption/main/DiskUtil.py
+++ b/VMEncryption/main/DiskUtil.py
@@ -639,6 +639,7 @@ class DiskUtil(object):
             lines = f.readlines()
 
         relevant_line = None
+        bek_line_found = False
         for i in range(len(lines)):
             line = lines[i]
             fstab_parts = line.strip().split()
@@ -651,6 +652,9 @@ class DiskUtil(object):
 
             fstab_device = fstab_parts[0]
             fstab_mount_point = fstab_parts[1]
+
+            if fstab_mount_point == CommonVariables.encryption_key_mount_point:
+                bek_line_found = True
 
             if fstab_mount_point != mount_point: # Not the line we are looking for
                 continue
@@ -667,6 +671,9 @@ class DiskUtil(object):
                 self.logger.log("Replacing that line with: " + new_line)
                 lines[i] = new_line
                 break
+
+        if not bek_line_found:
+            lines.append('LABEL=BEK\040\VOLUME {0} auto defaults,discard,nofail 0 0'.format(CommonVariables.encryption_key_mount_point))
 
         with open('/etc/fstab', 'w') as f:
             f.writelines(lines)

--- a/VMEncryption/main/DiskUtil.py
+++ b/VMEncryption/main/DiskUtil.py
@@ -843,8 +843,8 @@ class DiskUtil(object):
 
     def umount_all_crypt_items(self):
         for crypt_item in self.get_crypt_items():
-            self.logger.log("Unmounting {0}".format(crypt_item.mount_point))
-            self.umount(crypt_item.mount_point)
+            self.logger.log("Unmounting {0}".format(os.path.join(CommonVariables.dev_mapper_root, crypt_item.mapper_name)))
+            self.umount(os.path.join(CommonVariables.dev_mapper_root, crypt_item.mapper_name))
 
     def mount_all(self):
         mount_all_cmd = self.distro_patcher.mount_path + ' -a'

--- a/VMEncryption/main/EncryptionSettingsUtil.py
+++ b/VMEncryption/main/EncryptionSettingsUtil.py
@@ -311,6 +311,8 @@ class EncryptionSettingsUtil(object):
                     }]
                 }
 
+        protectors_null = [{"Name": "nullProtector.bek", "Base64Key": ""}]
+
         data_disks_settings_data = [controller_id_and_lun_to_settings_data(scsi_controller, lun_number)
                                     for (scsi_controller, lun_number) in data_disk_controller_ids_and_luns]
 
@@ -318,6 +320,7 @@ class EncryptionSettingsUtil(object):
                 "DiskEncryptionOperation": "DisableEncryption",
                 "Disks": data_disks_settings_data,
                 "KekAlgorithm": "",
+                "Protectors": protectors_null,
                 "KekUrl": "",
                 "KekVaultResourceId": "",
                 "KeyVaultResourceId": "",

--- a/VMEncryption/main/ResourceDiskUtil.py
+++ b/VMEncryption/main/ResourceDiskUtil.py
@@ -257,7 +257,7 @@ class ResourceDiskUtil(object):
             lines = f.readlines()
 
         if not self.disk_util.is_bek_in_fstab_file(lines):
-            lines.append(self.get_fstab_bek_line())
+            lines.append(self.disk_util.get_fstab_bek_line())
             self.disk_util.add_bek_to_default_cryptdisks()
 
         if not any([line.startswith(self.RD_MAPPER_PATH) for line in lines]):

--- a/VMEncryption/main/ResourceDiskUtil.py
+++ b/VMEncryption/main/ResourceDiskUtil.py
@@ -121,7 +121,10 @@ class ResourceDiskUtil(object):
     def _unmount_resource_disk(self):
         """ unmount resource disk """
         self.disk_util.umount(self.RD_MOUNT_POINT)
+        self.disk_util.umount(CommonVariables.encryption_key_mount_point)
         self.disk_util.umount('/mnt')
+        self.disk_util.make_sure_path_exists(CommonVariables.encryption_key_mount_point)
+        self.disk_util.mount_by_label("BEK VOLUME", CommonVariables.encryption_key_mount_point, "fmask=077")
 
     def _is_plain_mounted(self):
         """ return true if mount point is mounted from a non-crypt layer """
@@ -146,7 +149,7 @@ class ResourceDiskUtil(object):
         """
         device_items = self.disk_util.get_device_items(self.RD_DEV_PATH)
         device_mappers = []
-        mapper_device_types = ["raid0","raid1","raid5","raid10","lvm"]
+        mapper_device_types = ["raid0", "raid1", "raid5", "raid10", "lvm", "crypt"]
         for device_item in device_items:
             # fstype should be crypto_LUKS
             dev_path = self.disk_util.get_device_path(device_item.name)
@@ -252,9 +255,12 @@ class ResourceDiskUtil(object):
         with open("/etc/fstab") as f:
             lines = f.readlines()
 
-        if self.disk_util.is_bek_in_fstab_file(lines):
-            lines.append('LABEL=BEK\\040VOLUME {0} auto defaults,discard,nofail 0 0\n'.format(CommonVariables.encryption_key_mount_point))
-        lines.append('{0} {1} auto defaults,discard,nofail 0 0\n'.format(self.RD_MAPPER_PATH, self.RD_MOUNT_POINT))
+        if not self.disk_util.is_bek_in_fstab_file(lines):
+            lines.append(CommonVariables.bek_fstab_line_template.format(CommonVariables.encryption_key_mount_point))
+            self.add_bek_to_default_cryptdisks()
+
+        if not any([line.startswith(self.RD_MAPPER_PATH) for line in lines]):
+            lines.append('{0} {1} auto defaults,discard,nofail,nobootwait 0 0\n'.format(self.RD_MAPPER_PATH, self.RD_MOUNT_POINT))
 
         with open('/etc/fstab', 'w') as f:
             f.writelines(lines)
@@ -278,6 +284,7 @@ class ResourceDiskUtil(object):
             crypt_item.dev_path = self.RD_DEV_PATH
             crypt_item.mapper_name = self.RD_MAPPER_NAME
             crypt_item.uses_cleartext_key = False
+            self.disk_util.remove_crypt_item(crypt_item) # Remove old item in case it was already there
             self.disk_util.add_crypt_item_to_crypttab(crypt_item)
             self.add_to_fstab()
         return True

--- a/VMEncryption/main/ResourceDiskUtil.py
+++ b/VMEncryption/main/ResourceDiskUtil.py
@@ -22,7 +22,7 @@ import time
 import os
 
 from CommandExecutor import CommandExecutor
-from Common import CommonVariables
+from Common import CommonVariables, CryptItem
 
 
 class ResourceDiskUtil(object):
@@ -248,6 +248,17 @@ class ResourceDiskUtil(object):
         self._prepare_partition()
         return True
 
+    def add_to_fstab(self):
+        with open("/etc/fstab") as f:
+            lines = f.readlines()
+
+        if self.disk_util.is_bek_in_fstab_file(lines):
+            lines.append('LABEL=BEK\\040VOLUME {0} auto defaults,discard,nofail 0 0\n'.format(CommonVariables.encryption_key_mount_point))
+        lines.append('{0} {1} auto defaults,discard,nofail 0 0\n'.format(self.RD_MAPPER_PATH, self.RD_MOUNT_POINT))
+
+        with open('/etc/fstab', 'w') as f:
+            f.writelines(lines)
+
     def encrypt_format_mount(self):
         if not self.prepare():
             self.logger.log("Failed to prepare VM for Resource Disk Encryption", CommonVariables.ErrorLevel)
@@ -261,6 +272,14 @@ class ResourceDiskUtil(object):
         if not self._mount_resource_disk(self.RD_MAPPER_PATH):
             self.logger.log("Failed to mount after formatting and encrypting the Resource Disk Encryption", CommonVariables.ErrorLevel)
             return False
+        if not self.disk_util.should_use_azure_crypt_mount():
+            self.logger.log("Adding resource disk to the crypttab file")
+            crypt_item = CryptItem()
+            crypt_item.dev_path = self.RD_DEV_PATH
+            crypt_item.mapper_name = self.RD_MAPPER_NAME
+            crypt_item.uses_cleartext_key = False
+            self.disk_util.add_crypt_item_to_crypttab(crypt_item)
+            self.add_to_fstab()
         return True
 
     def automount(self):

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -1219,6 +1219,8 @@ def decrypt_inplace_copy_data(passphrase_file,
                 if mount_point and mount_point != "None":
                     logger.log(msg="restoring entry for unencrypted drive from fstab", level=CommonVariables.InfoLevel)
                     disk_util.restore_mount_info(ongoing_item_config.get_mount_point())
+                elif crypt_item.mapper_name:
+                    disk_util.restore_mount_info(crypt_item.mapper_name)
                 else:
                     logger.log(msg=crypt_item.dev_path + " was not in fstab when encryption was enabled, no need to restore",
                                level=CommonVariables.InfoLevel)
@@ -1491,7 +1493,7 @@ def disable_encryption_all_in_place(passphrase_file, decryption_marker, disk_uti
 
         if decryption_result_phase == CommonVariables.DecryptionPhaseDone:
             disk_util.luks_close(crypt_item.mapper_name)
-            disk_util.mount_all()
+            #disk_util.mount_all()
             backup_folder = os.path.join(crypt_item.mount_point, ".azure_ade_backup_mount_info/") if crypt_item.mount_point else None
             disk_util.remove_crypt_item(crypt_item, backup_folder)
 

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -54,15 +54,15 @@ def install():
     # The extension update handshake is [old:disable][new:update][old:uninstall][new:install]
     # Prior extensions archived their configs in [old:uninstall], not in [old:disable]
     # As such, the first opportunity to restore old configs is in [new:install]
-    # In the future, moving the config archive/restore step to disable/update is preferred 
+    # In the future, moving the config archive/restore step to disable/update is preferred
     hutil.restore_old_configs()
     hutil.do_exit(0, 'Install', CommonVariables.extension_success_status, str(CommonVariables.success), 'Install Succeeded')
 
 def disable():
     hutil.do_parse_context('Disable')
-    # archiving old configs during disable rather than uninstall will allow subsequent versions 
-    # to restore these configs in their update step rather than their install step once all 
-    # released versions of the extension are at this version or above 
+    # archiving old configs during disable rather than uninstall will allow subsequent versions
+    # to restore these configs in their update step rather than their install step once all
+    # released versions of the extension are at this version or above
     hutil.archive_old_configs()
     hutil.do_exit(0, 'Disable', CommonVariables.extension_success_status, '0', 'Disable succeeded')
 
@@ -255,7 +255,7 @@ def update_encryption_settings():
 
     logger.log("Current secret was created in operation #{0}".format(current_secret_seq_num))
     logger.log("The update call is operation #{0}".format(update_call_seq_num))
-    
+
     executor = CommandExecutor(logger)
     executor.Execute("mount /boot")
 
@@ -275,7 +275,7 @@ def update_encryption_settings():
             temp_keyfile = tempfile.NamedTemporaryFile(delete=False)
             temp_keyfile.write(extension_parameter.passphrase)
             temp_keyfile.close()
-            
+
             disk_util.consolidate_azure_crypt_mount(existing_passphrase_file)
             for crypt_item in disk_util.get_crypt_items():
                 if not crypt_item:
@@ -366,7 +366,7 @@ def update_encryption_settings():
 
                 keyslots = disk_util.luks_dump_keyslots(crypt_item.dev_path, crypt_item.luks_header_path)
                 logger.log("Keyslots before removal: {0}".format(keyslots))
-                
+
                 luks_remove_result = disk_util.luks_remove_key(passphrase_file=encryption_environment.bek_backup_path,
                                                                dev_path=crypt_item.dev_path,
                                                                header_file=crypt_item.luks_header_path)
@@ -375,7 +375,7 @@ def update_encryption_settings():
                 keyslots = disk_util.luks_dump_keyslots(crypt_item.dev_path, crypt_item.luks_header_path)
                 logger.log("Keyslots after removal: {0}".format(keyslots))
 
-            logger.log("Old key successfully removed from all encrypted devices") 
+            logger.log("Old key successfully removed from all encrypted devices")
             hutil.save_seq()
             extension_parameter.commit()
             os.unlink(encryption_environment.bek_backup_path)
@@ -464,10 +464,7 @@ def mount_encrypted_disks(disk_util, bek_util, passphrase_file, encryption_confi
                                                    uses_cleartext_key=crypt_item.uses_cleartext_key)
             logger.log("luks open result is {0}".format(luks_open_result))
 
-        if str(crypt_item.mount_point) != 'None':
-            disk_util.mount_crypt_item(crypt_item, passphrase_file)
-        else:
-            logger.log(msg=('mount_point is None so skipping mount for the item {0}'.format(crypt_item)), level=CommonVariables.WarningLevel)
+        disk_util.mount_crypt_item(crypt_item, passphrase_file)
 
     if DistroPatcher.distro_info[0].lower() == 'centos' and DistroPatcher.distro_info[1].startswith('7.0'):
         if se_linux_status is not None and se_linux_status.lower() == 'enforcing':
@@ -478,7 +475,7 @@ def main():
     global hutil, DistroPatcher, logger, encryption_environment
     HandlerUtil.LoggerInit('/var/log/waagent.log','/dev/stdout')
     HandlerUtil.waagent.Log("{0} started to handle.".format(CommonVariables.extension_name))
-    
+
     hutil = HandlerUtil.HandlerUtility(HandlerUtil.waagent.Log, HandlerUtil.waagent.Error, CommonVariables.extension_name)
     logger = BackupLogger(hutil)
     DistroPatcher = GetDistroPatcher(logger)
@@ -630,7 +627,7 @@ def enable_encryption():
     """
     disk_util = DiskUtil(hutil=hutil, patching=DistroPatcher, logger=logger, encryption_environment=encryption_environment)
     bek_util = BekUtil(disk_util, logger)
-    
+
     existing_passphrase_file = None
     encryption_config = EncryptionConfig(encryption_environment=encryption_environment, logger=logger)
     config_path_result = disk_util.make_sure_path_exists(encryption_environment.encryption_config_path)
@@ -667,13 +664,13 @@ def enable_encryption():
 
     try:
         extension_parameter = ExtensionParameter(hutil, logger, DistroPatcher, encryption_environment, get_protected_settings(), get_public_settings())
-        
+
         encryption_marker = EncryptionMarkConfig(logger, encryption_environment)
         if encryption_marker.config_file_exists():
             # verify the encryption mark
             logger.log(msg="encryption mark is there, starting daemon.", level=CommonVariables.InfoLevel)
             start_daemon('EnableEncryption')
-        else:            
+        else:
             encryption_config = EncryptionConfig(encryption_environment, logger)
 
             exit_status = None
@@ -699,7 +696,7 @@ def enable_encryption():
                 start_daemon('EnableEncryption')
             else:
                 # prepare to create secret, place on key volume, and request key vault update via wire protocol
-                
+
                 # validate parameters
                 if extension_parameter.command not in [CommonVariables.EnableEncryption, CommonVariables.EnableEncryptionFormat, CommonVariables.EnableEncryptionFormatAll]:
                     encryption_config.clear_config()
@@ -718,7 +715,7 @@ def enable_encryption():
 
                     bek_util.store_bek_passphrase(encryption_config, extension_parameter.passphrase)
                     extension_parameter.commit()
-   
+
                 encryption_marker = mark_encryption(command=extension_parameter.command,
                                                     volume_type=extension_parameter.VolumeType,
                                                     disk_format_query=extension_parameter.DiskFormatQuery)
@@ -743,7 +740,7 @@ def enable_encryption_format(passphrase, encryption_format_items, disk_util, for
 
     for encryption_item in encryption_format_items:
         dev_path_in_query = None
-        
+
         if encryption_item.has_key("scsi") and encryption_item["scsi"] != '':
             dev_path_in_query = disk_util.query_dev_sdx_path_by_scsi_id(encryption_item["scsi"])
         if encryption_item.has_key("dev_path") and encryption_item["dev_path"] != '':
@@ -841,7 +838,7 @@ def encrypt_inplace_without_separate_header_file(passphrase_file,
                                                  ongoing_item_config=None):
     """
     if ongoing_item_config is not None, then this is a resume case.
-    this function will return the phase 
+    this function will return the phase
     """
     logger.log("encrypt_inplace_without_seperate_header_file")
     current_phase = CommonVariables.EncryptionPhaseBackupHeader
@@ -881,7 +878,7 @@ def encrypt_inplace_without_separate_header_file(passphrase_file,
         if current_phase == CommonVariables.EncryptionPhaseBackupHeader:
             logger.log(msg="the current phase is " + str(CommonVariables.EncryptionPhaseBackupHeader),
                        level=CommonVariables.InfoLevel)
-            
+
             if not ongoing_item_config.get_file_system().lower() in ["ext2", "ext3", "ext4"]:
                 logger.log(msg="we only support ext file systems for centos 6.5/6.6/6.7 and redhat 6.7",
                            level=CommonVariables.WarningLevel)
@@ -1260,7 +1257,7 @@ def decrypt_inplace_without_separate_header_file(passphrase_file,
                    level=CommonVariables.ErrorLevel)
         logger.log(msg="mapper_device_item {0}".format(mapper_device_item),
                    level=CommonVariables.ErrorLevel)
-        
+
         return None
 
     return decrypt_inplace_copy_data(passphrase_file,
@@ -1287,7 +1284,7 @@ def decrypt_inplace_with_separate_header_file(passphrase_file,
                    level=CommonVariables.ErrorLevel)
         logger.log(msg="mapper_device_item {0}".format(mapper_device_item),
                    level=CommonVariables.ErrorLevel)
-        
+
         return
 
     return decrypt_inplace_copy_data(passphrase_file,
@@ -1328,7 +1325,7 @@ def encrypt_format_device_items(passphrase, device_items, disk_util, force=False
     Returns None if all items are successfully format-encrypted
     Otherwise returns the device item which failed.
     """
-    
+
     #use the new udev names for formatting and later on for cryptmounting
     dev_path_reference_table = disk_util.get_block_device_to_azure_udev_table()
 
@@ -1423,7 +1420,7 @@ def enable_encryption_all_in_place(passphrase_file, encryption_marker, disk_util
                                                                                    disk_util=disk_util,
                                                                                    bek_util=bek_util,
                                                                                    status_prefix=status_prefix)
-                
+
             if encryption_result_phase == CommonVariables.EncryptionPhaseDone:
                 continue
             else:
@@ -1455,7 +1452,7 @@ def disable_encryption_all_in_place(passphrase_file, decryption_marker, disk_uti
 
         def raw_device_item_match(device_item):
             sdx_device_name = os.path.join("/dev/", device_item.name)
-            return os.path.realpath(sdx_device_name) == os.path.realpath(crypt_item.dev_path) 
+            return os.path.realpath(sdx_device_name) == os.path.realpath(crypt_item.dev_path)
 
         def mapped_device_item_match(device_item):
             return crypt_item.mapper_name == device_item.name
@@ -1473,7 +1470,7 @@ def disable_encryption_all_in_place(passphrase_file, decryption_marker, disk_uti
 
         decryption_result_phase = None
 
-        
+
         status_prefix = "Decrypting data volume {0}/{1}".format(crypt_item_num + 1,
                                                                 len(crypt_items))
 
@@ -1491,7 +1488,7 @@ def disable_encryption_all_in_place(passphrase_file, decryption_marker, disk_uti
                                                                                    mapper_device_item=mapper_device_item,
                                                                                    disk_util=disk_util,
                                                                                    status_prefix=status_prefix)
-        
+
         if decryption_result_phase == CommonVariables.DecryptionPhaseDone:
             disk_util.luks_close(crypt_item.mapper_name)
             disk_util.mount_all()
@@ -1512,7 +1509,7 @@ def daemon_encrypt():
     encryption_marker = EncryptionMarkConfig(logger, encryption_environment)
     if encryption_marker.config_file_exists():
         logger.log("encryption is marked.")
-        
+
     """
     search for the bek volume, then mount it:)
     """
@@ -1598,7 +1595,7 @@ def daemon_encrypt():
                                                             encryption_environment=encryption_environment)
         elif (((distro_name == 'centos' and distro_version == '7.3.1611') or
                (distro_name == 'centos' and distro_version.startswith('7.4')) or
-               (distro_name == 'centos' and distro_version.startswith('7.5')) or 
+               (distro_name == 'centos' and distro_version.startswith('7.5')) or
                (distro_name == 'centos' and distro_version.startswith('7.6'))) and
               (disk_util.is_os_disk_lvm() or os.path.exists('/volumes.lvm'))):
             from oscrypto.rhel_72_lvm import RHEL72LVMEncryptionStateMachine
@@ -1702,7 +1699,7 @@ def daemon_encrypt_data_volumes(encryption_marker, encryption_config, disk_util,
                        level=CommonVariables.ErrorLevel)
         """
         TODO: resuming the encryption for rebooting suddenly scenario
-        we need the special handling is because the half done device can be a error state: say, the file system header missing.so it could be 
+        we need the special handling is because the half done device can be a error state: say, the file system header missing.so it could be
         identified.
         """
         ongoing_item_config = OnGoingItemConfig(encryption_environment=encryption_environment, logger=logger)
@@ -1795,7 +1792,7 @@ def daemon_encrypt_data_volumes(encryption_marker, encryption_config, disk_util,
 
 def daemon_decrypt():
     decryption_marker = DecryptionMarkConfig(logger, encryption_environment)
-    
+
     if not decryption_marker.config_file_exists():
         logger.log("decryption is not marked.")
         return
@@ -1831,8 +1828,8 @@ def daemon_decrypt():
                                                           disk_util=disk_util)
         else:
             raise Exception("command {0} not supported.".format(decryption_marker.get_current_command()))
-        
-        if failed_item != None:
+
+        if failed_item is not None:
             hutil.do_exit(exit_code=CommonVariables.encryption_failed,
                           operation='Disable',
                           status=CommonVariables.extension_error_status,
@@ -1858,7 +1855,7 @@ def daemon():
         return
 
     logger.log("daemon lock acquired sucessfully.")
-    
+
     logger.log("waiting for 1 minute before continuing the daemon")
     time.sleep(60)
 
@@ -1872,10 +1869,10 @@ def daemon():
             daemon_decrypt()
         except Exception as e:
             error_msg = ("Failed to disable the extension with error: {0}, stack trace: {1}".format(e, traceback.format_exc()))
-                
+
             logger.log(msg=error_msg,
                         level=CommonVariables.ErrorLevel)
-                
+
             hutil.do_exit(exit_code=CommonVariables.encryption_failed,
                           operation='Disable',
                           status=CommonVariables.extension_error_status,
@@ -1885,7 +1882,7 @@ def daemon():
             lock.release_lock()
             logger.log("returned to daemon")
             logger.log("exiting daemon")
-                
+
             return
 
     # try encrypt, in absence of decryption marker
@@ -1925,7 +1922,7 @@ def start_daemon(operation):
     #throw broken pipe exception when parent process exit.
     devnull = open(os.devnull, 'w')
     child = subprocess.Popen(args, stdout=devnull, stderr=devnull)
-    
+
     encryption_config = EncryptionConfig(encryption_environment, logger)
     if encryption_config.config_file_exists():
         if are_disks_stamped_with_current_config(encryption_config):

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -433,7 +433,7 @@ def toggle_se_linux_for_centos7(disable):
 def mount_encrypted_disks(disk_util, bek_util, passphrase_file, encryption_config):
 
     # mount encrypted resource disk
-    resource_disk_util = ResourceDiskUtil(logger, disk_util, passphrase_file, get_public_settings())
+    resource_disk_util = ResourceDiskUtil(logger, disk_util, passphrase_file, get_public_settings(), DistroPatcher.distro_info)
     if encryption_config.config_file_exists():
         volume_type = encryption_config.get_volume_type().lower()
         if volume_type == CommonVariables.VolumeTypeData.lower() or volume_type == CommonVariables.VolumeTypeAll.lower():

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -201,7 +201,7 @@ def stamp_disks_with_settings(items_to_encrypt, encryption_config):
             for tag in volume.get("SecretTags", []):
                 if tag.get("Name") == 'DiskEncryptionKeyFileName':
                     if tag.get("Value") is not None:
-                        filenames.append(str(["Value"]))
+                        filenames.append(str(tag["Value"]))
 
     for filename in filenames:
         shutil.copy(current_passphrase_file, os.path.join(CommonVariables.encryption_key_mount_point, filename))

--- a/VMEncryption/test/test_resource_disk_util.py
+++ b/VMEncryption/test/test_resource_disk_util.py
@@ -33,7 +33,7 @@ class TestResourceDiskUtil(unittest.TestCase):
         self.mock_disk_util = mock.create_autospec(DiskUtil)
         self.mock_passhprase_filename = "mock_passphrase_filename"
         mock_public_settings = {}
-        self.resource_disk = ResourceDiskUtil(self.logger, self.mock_disk_util, self.mock_passhprase_filename, mock_public_settings)
+        self.resource_disk = ResourceDiskUtil(self.logger, self.mock_disk_util, self.mock_passhprase_filename, mock_public_settings, ["ubuntu", "16"])
 
     def _test_resource_disk_partition_dependant_method(self, method, mock_partition_exists, mock_execute):
         """


### PR DESCRIPTION
- Add a parser `crypttab`
- Add a post-reimage restore mechanism for `crypttab`
- Add methods to judge which unlock mechanism to use (old `azure_crypt_mount` vs `crypttab`)
- Unmount `BEK VOLUME` when it is needed to unmount `RD` (and then remount it again).
- Lint `handle.py` a little