### PR TITLE
Auto Unlock for ADE on new VMs [Dual Pass]

### DIFF
--- a/VMEncryption/main/Common.py
+++ b/VMEncryption/main/Common.py
@@ -42,6 +42,7 @@ class CommonVariables:
     azure_symlinks_dir = '/dev/disk/azure'
     disk_by_id_root = '/dev/disk/by-id'
     disk_by_uuid_root = '/dev/disk/by-uuid'
+    encryption_key_mount_point = '/mnt/azure_bek_disk/'
 
     """
     parameter key names

--- a/VMEncryption/main/Common.py
+++ b/VMEncryption/main/Common.py
@@ -43,6 +43,7 @@ class CommonVariables:
     disk_by_id_root = '/dev/disk/by-id'
     disk_by_uuid_root = '/dev/disk/by-uuid'
     encryption_key_mount_point = '/mnt/azure_bek_disk/'
+    bek_fstab_line_template = 'LABEL=BEK\\040VOLUME {0} auto defaults,discard,nofail,nobootwait 0 0\n'
 
     """
     parameter key names

--- a/VMEncryption/main/Common.py
+++ b/VMEncryption/main/Common.py
@@ -43,7 +43,9 @@ class CommonVariables:
     disk_by_id_root = '/dev/disk/by-id'
     disk_by_uuid_root = '/dev/disk/by-uuid'
     encryption_key_mount_point = '/mnt/azure_bek_disk/'
-    bek_fstab_line_template = 'LABEL=BEK\\040VOLUME {0} auto defaults,discard,nofail,nobootwait 0 0\n'
+    bek_fstab_line_template = 'LABEL=BEK\\040VOLUME {0} auto defaults,discard,nofail 0 0\n'
+    bek_fstab_line_template_ubuntu_14 = 'LABEL=BEK\\040VOLUME {0} auto defaults,discard,nobootwait 0 0\n'
+    etc_defaults_cryptdisks_line = '\nCRYPTDISKS_MOUNT="$CRYPTDISKS_MOUNT {0}"\n'
 
     """
     parameter key names

--- a/VMEncryption/main/DiskUtil.py
+++ b/VMEncryption/main/DiskUtil.py
@@ -683,7 +683,7 @@ class DiskUtil(object):
             mount_filesystem_result = self.mount_filesystem(os.path.join(CommonVariables.dev_mapper_root, crypt_item.mapper_name), crypt_item.mount_point, crypt_item.file_system)
             self.logger.log("mount file system result:{0}".format(mount_filesystem_result))
         else:
-            logger.log(msg=('mount_point is None so trying an auto mount for the item {0}'.format(crypt_item)), level=CommonVariables.WarningLevel)
+            self.logger.log(msg=('mount_point is None so trying an auto mount for the item {0}'.format(crypt_item)), level=CommonVariables.WarningLevel)
             mount_filesystem_result = self.mount_auto(os.path.join(CommonVariables.dev_mapper_root, crypt_item.mapper_name))
 
     def swapoff(self):

--- a/VMEncryption/main/DiskUtil.py
+++ b/VMEncryption/main/DiskUtil.py
@@ -92,43 +92,85 @@ class DiskUtil(object):
         self.logger.log("touching file, executing: {0}".format(mkdir_cmd))
         return self.command_executor.Execute(mkdir_cmd)
 
+    def parse_crypttab_line(self, line):
+        crypttab_parts = line.strip().split()
+
+        if len(crypttab_parts) < 3: # Line should have enough content
+            return None
+
+        if crypttab_parts[0].startswith("#"): # Line should not be a comment
+            return None
+
+        crypt_item = CryptItem()
+        crypt_item.mapper_name = crypttab_parts[0]
+        crypt_item.dev_path = crypttab_parts[1]
+        keyfile_path = crypttab_parts[2]
+        if CommonVariables.encryption_key_mount_point not in keyfile_path and self.encryption_environment.cleartext_key_base_path not in keyfile_path:
+            return None # if the key_file path doesn't have the encryption key file name, its probably not for us to mess with
+        if self.encryption_environment.cleartext_key_base_path in keyfile_path:
+            crypt_item.uses_cleartext_key = True
+        crypttab_option_string = crypttab_parts[3]
+        crypttab_options = crypttab_option_string.split(',')
+        for option in crypttab_options:
+            option_pair = option.split("=")
+            if len(option_pair) == 2:
+                key = option_pair[0].strip()
+                value = option_pair[1].strip()
+                if key == "header":
+                    crypt_item.luks_header_path = value
+        return crypt_item
+
+    def parse_azure_crypt_mount_line(self, line):
+
+        crypt_item = CryptItem()
+
+        crypt_mount_item_properties = line.strip().split()
+
+        crypt_item.mapper_name = crypt_mount_item_properties[0]
+        crypt_item.dev_path = crypt_mount_item_properties[1]
+        crypt_item.luks_header_path = crypt_mount_item_properties[2] if crypt_mount_item_properties[2] and crypt_mount_item_properties[2] != "None" else None
+        crypt_item.mount_point = crypt_mount_item_properties[3]
+        crypt_item.file_system = crypt_mount_item_properties[4]
+        crypt_item.uses_cleartext_key = True if crypt_mount_item_properties[5] == "True" else False
+        crypt_item.current_luks_slot = int(crypt_mount_item_properties[6]) if len(crypt_mount_item_properties) > 6 else -1
+
+        return crypt_item
+
     def get_crypt_items(self):
         crypt_items = []
         rootfs_crypt_item_found = False
 
-        if not os.path.exists(self.encryption_environment.azure_crypt_mount_config_path):
-            self.logger.log("{0} does not exist".format(self.encryption_environment.azure_crypt_mount_config_path))
-        else:
-            with open(self.encryption_environment.azure_crypt_mount_config_path,'r') as f:
+        if self.should_use_azure_crypt_mount():
+            with open(self.encryption_environment.azure_crypt_mount_config_path, 'r') as f:
                 for line in f:
                     if not line.strip():
                         continue
 
-                    crypt_mount_item_properties = line.strip().split()
+                    crypt_item = self.parse_azure_crypt_mount_line(line)
 
-                    crypt_item = CryptItem()
-                    crypt_item.mapper_name = crypt_mount_item_properties[0]
-                    crypt_item.dev_path = crypt_mount_item_properties[1]
-
-                    header_file_path = None
-                    if crypt_mount_item_properties[2] and crypt_mount_item_properties[2] != "None":
-                        header_file_path = crypt_mount_item_properties[2]
-
-                    crypt_item.luks_header_path = header_file_path
-                    crypt_item.mount_point = crypt_mount_item_properties[3]
-
-                    if crypt_item.mount_point == "/":
+                    if crypt_item.mount_point == "/" or crypt_item.mapper_name == CommonVariables.osmapper_name :
                         rootfs_crypt_item_found = True
 
-                    crypt_item.file_system = crypt_mount_item_properties[4]
-                    crypt_item.uses_cleartext_key = True if crypt_mount_item_properties[5] == "True" else False
-
-                    try:
-                        crypt_item.current_luks_slot = int(crypt_mount_item_properties[6])
-                    except IndexError:
-                        crypt_item.current_luks_slot = -1
-
                     crypt_items.append(crypt_item)
+        else:
+            self.logger.log("Using crypttab instead of azure_crypt_mount file.")
+            crypttab_path = "/etc/crypttab"
+            if not os.path.exists(crypttab_path):
+                self.logger.log("{0} does not exist".format(crypttab_path))
+            else:
+                with open(crypttab_path, 'r') as f:
+                    for line in f:
+                        if not line.strip():
+                            continue
+
+                        crypt_item = self.parse_crypttab_line(line)
+                        if crypt_item is None:
+                            continue
+
+                        if crypt_item.mapper_name == CommonVariables.osmapper_name :
+                            rootfs_crypt_item_found = True
+
+                        crypt_items.append(crypt_item)
 
         encryption_status = json.loads(self.get_encryption_status())
 
@@ -171,7 +213,46 @@ class DiskUtil(object):
 
         return crypt_items
 
-    def add_crypt_item(self, crypt_item):
+    def should_use_azure_crypt_mount(self):
+        if not os.path.exists(self.encryption_environment.azure_crypt_mount_config_path):
+            return False
+
+        non_os_entry_found = False
+        with open(self.encryption_environment.azure_crypt_mount_config_path, 'r') as f:
+            for line in f:
+                if not line.strip():
+                    continue
+
+                parsed_crypt_item = self.parse_azure_crypt_mount_line(line)
+                if parsed_crypt_item.mapper_name != CommonVariables.osmapper_name:
+                    non_os_entry_found = True
+
+        # if there is a non_os_entry found we should use azure_crypt_mount. Otherwise we shouldn't
+        return non_os_entry_found
+
+    def add_crypt_item(self, crypt_item, key_file_path):
+        if self.should_use_azure_crypt_mount():
+            return self.add_crypt_item_to_azure_crypt_mount(crypt_item)
+        else:
+            return self.add_crypt_item_to_crypttab(crypt_item, key_file_path)
+
+    def add_crypt_item_to_crypttab(self, crypt_item, key_file):
+
+        if key_file is None and crypt_item.uses_cleartext_key:
+            line_key_file = self.encryption_environment.cleartext_key_base_path + mapper_name
+        else:
+            line_key_file = key_file
+
+        crypttab_line = "\n{0} {1} {2} luks,nofail".format(crypt_item.mapper_name, crypt_item.dev_path, line_key_file)
+        if crypt_item.luks_header_path:
+            crypttab_line += ",header=" + crypt_item.luks_header_path
+
+        with open("/etc/crypttab", "a") as wf:
+            wf.write(crypttab_line + "\n")
+
+        return True
+
+    def add_crypt_item_to_azure_crypt_mount(self, crypt_item):
         """
         TODO we should judge that the second time.
         format is like this:
@@ -208,31 +289,41 @@ class DiskUtil(object):
             return False
 
     def remove_crypt_item(self, crypt_item):
-        if not os.path.exists(self.encryption_environment.azure_crypt_mount_config_path):
-            return False
-
         try:
-            mount_lines = []
+            if os.path.exists(self.encryption_environment.azure_crypt_mount_config_path):
+                crypt_file_path = self.encryption_environment.azure_crypt_mount_config_path
+                crypt_line_parser = self.parse_azure_crypt_mount_line
+            elif os.path.exists("/etc/crypttab"):
+                crypt_file_path = "/etc/crypttab"
+                crypt_line_parser = self.parse_crypttab_line
+            else:
+                return True
 
-            with open(self.encryption_environment.azure_crypt_mount_config_path, 'r') as f:
-                mount_lines = f.readlines()
+            filtered_mount_lines = []
+            with open(crypt_file_path, 'r') as f:
+                for line in f:
+                    if not line.strip():
+                        continue
 
-            filtered_mount_lines = filter(lambda line: not crypt_item.mapper_name in line, mount_lines)
+                    parsed_crypt_item = crypt_line_parser(line)
+                    if parsed_crypt_item.mapper_name == crypt_item.mapper_name:
+                        self.logger.log("Removing crypt mount entry: {0}".format(line))
+                        continue
+
+                    filtered_mount_lines.append(line)
 
             with open(self.encryption_environment.azure_crypt_mount_config_path, 'w') as wf:
-                wf.write('\n')
-                wf.write('\n'.join(filtered_mount_lines))
-                wf.write('\n')
+                wf.write(''.join(filtered_mount_lines))
 
             return True
 
-        except Exception:
+        except Exception as e:
             return False
 
-    def update_crypt_item(self, crypt_item):
+    def update_crypt_item(self, crypt_item, key_file_path):
         self.logger.log("Updating entry for crypt item {0}".format(crypt_item))
         self.remove_crypt_item(crypt_item)
-        self.add_crypt_item(crypt_item)
+        self.add_crypt_item(crypt_item, key_file_path)
 
     def create_luks_header(self, mapper_name):
         luks_header_file_path = self.encryption_environment.luks_header_base_path + mapper_name
@@ -415,6 +506,71 @@ class DiskUtil(object):
         with open("/etc/fstab",'w') as wf:
             wf.write(new_mount_content)
 
+
+    def is_bek_in_fstab_file(self, lines):
+        for line in lines:
+            fstab_parts = line.strip().split()
+            if len(fstab_parts) < 2: # Line should have enough content
+                continue
+            if fstab_parts[0].startswith("#"): # Line should not be a comment
+                continue
+            fstab_mount_point = fstab_parts[1]
+            if fstab_mount_point == CommonVariables.encryption_key_mount_point:
+                return True
+        return False
+
+    def modify_fstab_entry_encrypt(self, mount_point, mapper_path):
+        self.logger.log("modify_fstab_entry_encrypt called with mount_point={0}, mapper_path={1}".format(mount_point, mapper_path))
+
+        if not mount_point:
+            self.logger.log("modify_fstab_entry_encrypt: mount_point is empty")
+            return
+
+        shutil.copy2('/etc/fstab', '/etc/fstab.backup.' + str(str(uuid.uuid4())))
+
+        with open('/etc/fstab', 'r') as f:
+            lines = f.readlines()
+
+        relevant_line = None
+        for i in range(len(lines)):
+            line = lines[i]
+            fstab_parts = line.strip().split()
+
+            if len(fstab_parts) < 2: # Line should have enough content
+                continue
+
+            if fstab_parts[0].startswith("#"): # Line should not be a comment
+                continue
+
+            fstab_device = fstab_parts[0]
+            fstab_mount_point = fstab_parts[1]
+
+            if fstab_mount_point != mount_point: # Not the line we are looking for
+                continue
+
+            self.logger.log("Found the relevant fstab line: " + line)
+            relevant_line = line
+
+            if self.should_use_azure_crypt_mount():
+                # in this case we just remove the line
+                lines.pop(i)
+                break
+            else:
+                new_line = relevant_line.replace(fstab_device, mapper_path)
+                self.logger.log("Replacing that line with: " + new_line)
+                lines[i] = new_line
+                break
+
+        if not self.is_bek_in_fstab_file(lines):
+            lines.append('LABEL=BEK\\040VOLUME {0} auto defaults,discard,nofail 0 0\n'.format(CommonVariables.encryption_key_mount_point))
+
+        with open('/etc/fstab', 'w') as f:
+            f.writelines(lines)
+
+        if relevant_line is not None:
+            with open('/etc/fstab.azure.backup', 'a+') as f:
+                f.write(relevant_line)
+
     def remove_mount_info(self, mount_point):
         if not mount_point:
             self.logger.log("remove_mount_info: mount_point is empty")
@@ -458,8 +614,8 @@ class DiskUtil(object):
 
         shutil.copy2('/etc/fstab', '/etc/fstab.backup.' + str(str(uuid.uuid4())))
 
-        filtered_contents = []
-        removed_lines = []
+        lines_to_keep_in_backup_fstab = []
+        lines_to_put_back_to_fstab = []
 
         with open('/etc/fstab.azure.backup', 'r') as f:
             for line in f.readlines():
@@ -468,21 +624,30 @@ class DiskUtil(object):
 
                 if re.search(pattern, line):
                     self.logger.log("removing fstab.azure.backup line: {0}".format(line))
-                    removed_lines.append(line)
+                    lines_to_put_back_to_fstab.append(line)
                     continue
 
-                filtered_contents.append(line)
+                lines_to_keep_in_backup_fstab.append(line)
 
         with open('/etc/fstab.azure.backup', 'w') as f:
-            f.write('\n')
-            f.write('\n'.join(filtered_contents))
+            f.write('\n'.join(lines_to_keep_in_backup_fstab))
             f.write('\n')
 
         self.logger.log("fstab.azure.backup updated successfully")
 
-        with open('/etc/fstab', 'a+') as f:
-            f.write('\n')
-            f.write('\n'.join(removed_lines))
+        lines_that_remain_in_fstab = []
+        with open('/etc/fstab', 'r') as f:
+            for line in f.readlines():
+                line = line.strip()
+                pattern = '\s' + re.escape(mount_point) + '\s'
+                if re.search(pattern, line):
+                    # This line should not remain in the fstab.
+                    self.logger.log("removing fstab line: {0}".format(line))
+                    continue
+                lines_that_remain_in_fstab.append(line)
+
+        with open('/etc/fstab', 'w') as f:
+            f.write('\n'.join(lines_that_remain_in_fstab + lines_to_put_back_to_fstab))
             f.write('\n')
 
         self.logger.log("fstab updated successfully")
@@ -602,7 +767,8 @@ class DiskUtil(object):
 
             if volume_type == CommonVariables.VolumeTypeOS.lower() or \
                 volume_type == CommonVariables.VolumeTypeAll.lower():
-                encryption_status["os"] = "EncryptionInProgress"
+                if not os_drive_encrypted:
+                    encryption_status["os"] = "EncryptionInProgress"
         elif os.path.exists(osmapper_path) and not os_drive_encrypted:
             encryption_status["os"] = "VMRestartPending"
 

--- a/VMEncryption/main/DiskUtil.py
+++ b/VMEncryption/main/DiskUtil.py
@@ -560,7 +560,7 @@ class DiskUtil(object):
                 break
 
         if not self.is_bek_in_fstab_file(lines):
-            lines.append('LABEL=BEK\\040VOLUME {0} auto defaults,discard,nofail 0 0\n'.format(CommonVariables.encryption_key_mount_point))
+            lines.append(CommonVariables.bek_fstab_line_template.format(CommonVariables.encryption_key_mount_point))
 
         with open('/etc/fstab', 'w') as f:
             f.writelines(lines)
@@ -830,6 +830,12 @@ class DiskUtil(object):
         azure_name_table = self.get_block_device_to_azure_udev_table()
         if sdx_realpath in azure_name_table:
             return azure_name_table[sdx_realpath]
+
+        # A mapper path is also pretty good (especially for raid or lvm)
+        for mapper_name in os.listdir(CommonVariables.dev_mapper_root):
+            mapper_path = os.path.join(CommonVariables.dev_mapper_root, mapper_name)
+            if os.path.realpath(mapper_path) == sdx_realpath:
+                return mapper_path
 
         # Then try matching a uuid symlink. Those are probably the best
         for disk_by_uuid in os.listdir(CommonVariables.disk_by_uuid_root):

--- a/VMEncryption/main/DiskUtil.py
+++ b/VMEncryption/main/DiskUtil.py
@@ -569,6 +569,20 @@ class DiskUtil(object):
             with open('/etc/fstab.azure.backup', 'a+') as f:
                 f.write(relevant_line)
 
+    def get_fstab_bek_line(self):
+        if self.distro_patcher.distro_info[0].lower() == 'ubuntu' and self.distro_patcher.distro_info[1] == '14':
+            return CommonVariables.bek_fstab_line_template_ubuntu_14.format(CommonVariables.encryption_key_mount_point)
+        else:
+            return CommonVariables.bek_fstab_line_template.format(CommonVariables.encryption_key_mount_point)
+
+    def add_bek_to_default_cryptdisks(self):
+        if os.path.exists("/etc/default/cryptdisks"):
+            with open("/etc/default/cryptdisks", 'r') as f:
+                lines = f.readlines()
+            if not any(["azure_bek_disk" in line for line in lines]):
+                with open("/etc/default/cryptdisks", 'a') as f:
+                    f.write(CommonVariables.etc_defaults_cryptdisks_line.format(CommonVariables.encryption_key_mount_point))
+
     def remove_mount_info(self, mount_point):
         if not mount_point:
             self.logger.log("remove_mount_info: mount_point is empty")

--- a/VMEncryption/main/ResourceDiskUtil.py
+++ b/VMEncryption/main/ResourceDiskUtil.py
@@ -121,7 +121,10 @@ class ResourceDiskUtil(object):
     def _unmount_resource_disk(self):
         """ unmount resource disk """
         self.disk_util.umount(self.RD_MOUNT_POINT)
+        self.disk_util.umount(CommonVariables.encryption_key_mount_point)
         self.disk_util.umount('/mnt')
+        self.disk_util.make_sure_path_exists(CommonVariables.encryption_key_mount_point)
+        self.disk_util.mount_bek_volume("BEK VOLUME", CommonVariables.encryption_key_mount_point, "fmask=077")
 
     def _is_plain_mounted(self):
         """ return true if mount point is mounted from a non-crypt layer """

--- a/VMEncryption/main/ResourceDiskUtil.py
+++ b/VMEncryption/main/ResourceDiskUtil.py
@@ -259,7 +259,7 @@ class ResourceDiskUtil(object):
             lines.append(CommonVariables.bek_fstab_line_template.format(CommonVariables.encryption_key_mount_point))
 
         if not any([line.startswith(self.RD_MAPPER_PATH) for line in lines]):
-            lines.append('{0} {1} auto defaults,discard,nofail 0 0\n'.format(self.RD_MAPPER_PATH, self.RD_MOUNT_POINT))
+            lines.append('{0} {1} auto defaults,discard,nofail,nobootwait 0 0\n'.format(self.RD_MAPPER_PATH, self.RD_MOUNT_POINT))
 
         with open('/etc/fstab', 'w') as f:
             f.writelines(lines)

--- a/VMEncryption/main/ResourceDiskUtil.py
+++ b/VMEncryption/main/ResourceDiskUtil.py
@@ -146,7 +146,7 @@ class ResourceDiskUtil(object):
         """
         device_items = self.disk_util.get_device_items(self.RD_DEV_PATH)
         device_mappers = []
-        mapper_device_types = ["raid0","raid1","raid5","raid10","lvm"]
+        mapper_device_types = ["raid0", "raid1", "raid5", "raid10", "lvm", "crypt"]
         for device_item in device_items:
             # fstype should be crypto_LUKS
             dev_path = self.disk_util.get_device_path(device_item.name)

--- a/VMEncryption/main/ResourceDiskUtil.py
+++ b/VMEncryption/main/ResourceDiskUtil.py
@@ -252,9 +252,11 @@ class ResourceDiskUtil(object):
         with open("/etc/fstab") as f:
             lines = f.readlines()
 
-        if self.disk_util.is_bek_in_fstab_file(lines):
+        if not self.disk_util.is_bek_in_fstab_file(lines):
             lines.append('LABEL=BEK\\040VOLUME {0} auto defaults,discard,nofail 0 0\n'.format(CommonVariables.encryption_key_mount_point))
-        lines.append('{0} {1} auto defaults,discard,nofail 0 0\n'.format(self.RD_MAPPER_PATH, self.RD_MOUNT_POINT))
+
+        if not any([line.startswith(self.RD_MAPPER_PATH) for line in lines]):
+            lines.append('{0} {1} auto defaults,discard,nofail 0 0\n'.format(self.RD_MAPPER_PATH, self.RD_MOUNT_POINT))
 
         with open('/etc/fstab', 'w') as f:
             f.writelines(lines)
@@ -278,6 +280,7 @@ class ResourceDiskUtil(object):
             crypt_item.dev_path = self.RD_DEV_PATH
             crypt_item.mapper_name = self.RD_MAPPER_NAME
             crypt_item.uses_cleartext_key = False
+            self.disk_util.remove_crypt_item(crypt_item) # Remove old item in case it was already there
             self.disk_util.add_crypt_item_to_crypttab(crypt_item, self.passphrase_filename)
             self.add_to_fstab()
         return True

--- a/VMEncryption/main/ResourceDiskUtil.py
+++ b/VMEncryption/main/ResourceDiskUtil.py
@@ -37,12 +37,13 @@ class ResourceDiskUtil(object):
     RD_MAPPER_NAME = 'resourceencrypt'
     RD_MAPPER_PATH = os.path.join(CommonVariables.dev_mapper_root, RD_MAPPER_NAME)
 
-    def __init__(self, logger, disk_util, passphrase_filename, public_settings):
+    def __init__(self, logger, disk_util, passphrase_filename, public_settings, distro_info):
         self.logger = logger
         self.executor = CommandExecutor(self.logger)
         self.disk_util = disk_util
         self.passphrase_filename = passphrase_filename  # WARNING: This may be null, in which case we mount the resource disk if its unencrypted and do nothing if it is.
         self.public_settings = public_settings
+        self.distro_info = distro_info
 
     def _is_encrypt_format_all(self):
         """ return true if current encryption operation is EncryptFormatAll """
@@ -256,10 +257,14 @@ class ResourceDiskUtil(object):
             lines = f.readlines()
 
         if not self.disk_util.is_bek_in_fstab_file(lines):
-            lines.append(CommonVariables.bek_fstab_line_template.format(CommonVariables.encryption_key_mount_point))
+            lines.append(self.disk_util.get_fstab_bek_line())
+            self.disk_util.add_bek_to_default_cryptdisks()
 
         if not any([line.startswith(self.RD_MAPPER_PATH) for line in lines]):
-            lines.append('{0} {1} auto defaults,discard,nofail,nobootwait 0 0\n'.format(self.RD_MAPPER_PATH, self.RD_MOUNT_POINT))
+            if self.distro_info[0].lower() == 'ubuntu' and self.distro_info[1].startswith('14'):
+                lines.append('{0} {1} auto defaults,discard,nobootwait 0 0\n'.format(self.RD_MAPPER_PATH, self.RD_MOUNT_POINT))
+            else:
+                lines.append('{0} {1} auto defaults,discard,nofail 0 0\n'.format(self.RD_MAPPER_PATH, self.RD_MOUNT_POINT))
 
         with open('/etc/fstab', 'w') as f:
             f.writelines(lines)

--- a/VMEncryption/main/ResourceDiskUtil.py
+++ b/VMEncryption/main/ResourceDiskUtil.py
@@ -256,7 +256,7 @@ class ResourceDiskUtil(object):
             lines = f.readlines()
 
         if not self.disk_util.is_bek_in_fstab_file(lines):
-            lines.append('LABEL=BEK\\040VOLUME {0} auto defaults,discard,nofail 0 0\n'.format(CommonVariables.encryption_key_mount_point))
+            lines.append(CommonVariables.bek_fstab_line_template.format(CommonVariables.encryption_key_mount_point))
 
         if not any([line.startswith(self.RD_MAPPER_PATH) for line in lines]):
             lines.append('{0} {1} auto defaults,discard,nofail 0 0\n'.format(self.RD_MAPPER_PATH, self.RD_MOUNT_POINT))

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -416,7 +416,7 @@ def mount_encrypted_disks(disk_util, bek_util, passphrase_file, encryption_confi
     # mount encrypted resource disk
     volume_type = encryption_config.get_volume_type().lower()
     if volume_type == CommonVariables.VolumeTypeData.lower() or volume_type == CommonVariables.VolumeTypeAll.lower():
-        resource_disk_util = ResourceDiskUtil(logger, disk_util, passphrase_file, get_public_settings())
+        resource_disk_util = ResourceDiskUtil(logger, disk_util, passphrase_file, get_public_settings(), DistroPatcher.distro_info)
         resource_disk_util.automount()
         logger.log("mounted encrypted resource disk")
 

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -372,9 +372,9 @@ def update():
     hutil.do_parse_context('Update')
     logger.log("Installing pre-requisites")
     DistroPatcher.update_prereq()
-    # during update to new extension version, sweep configuration settings files from the prior 
+    # during update to new extension version, sweep configuration settings files from the prior
     # version into the new configuration settings directory that will be used by the new extension
-    hutil.restore_old_configs() 
+    hutil.restore_old_configs()
     hutil.do_exit(0, 'Update', CommonVariables.extension_success_status, '0', 'Update Succeeded')
 
 
@@ -441,10 +441,7 @@ def mount_encrypted_disks(disk_util, bek_util, passphrase_file, encryption_confi
 
             logger.log("luks open result is {0}".format(luks_open_result))
 
-        if str(crypt_item.mount_point) != 'None':
-            disk_util.mount_crypt_item(crypt_item, passphrase_file)
-        else:
-            logger.log(msg=('mount_point is None so skipping mount for the item {0}'.format(crypt_item)), level=CommonVariables.WarningLevel)
+        disk_util.mount_crypt_item(crypt_item, passphrase_file)
 
     if DistroPatcher.distro_info[0].lower() == 'centos' and DistroPatcher.distro_info[1].startswith('7.0'):
         if se_linux_status is not None and se_linux_status.lower() == 'enforcing':
@@ -632,7 +629,6 @@ def enable_encryption():
                        level=CommonVariables.WarningLevel)
             hutil.redo_last_status()
             exit_without_status_report()
-    
 
     ps = subprocess.Popen(["ps", "aux"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     ps_stdout, ps_stderr = ps.communicate()
@@ -1841,7 +1837,7 @@ def daemon_decrypt():
         else:
             raise Exception("command {0} not supported.".format(decryption_marker.get_current_command()))
 
-        if failed_item != None:
+        if failed_item is not None:
             hutil.do_exit(exit_code=CommonVariables.encryption_failed,
                           operation='Disable',
                           status=CommonVariables.extension_error_status,

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -1263,6 +1263,8 @@ def decrypt_inplace_copy_data(passphrase_file,
                 if mount_point and mount_point != "None":
                     logger.log(msg="restoring entry for unencrypted drive from fstab", level=CommonVariables.InfoLevel)
                     disk_util.restore_mount_info(ongoing_item_config.get_mount_point())
+                elif crypt_item.mapper_name:
+                    disk_util.restore_mount_info(crypt_item.mapper_name)
                 else:
                     logger.log(msg=crypt_item.dev_path + " was not in fstab when encryption was enabled, no need to restore",
                                level=CommonVariables.InfoLevel)
@@ -1531,7 +1533,7 @@ def disable_encryption_all_in_place(passphrase_file, decryption_marker, disk_uti
         if decryption_result_phase == CommonVariables.DecryptionPhaseDone:
             disk_util.luks_close(crypt_item.mapper_name)
             disk_util.remove_crypt_item(crypt_item)
-            disk_util.mount_all()
+            #disk_util.mount_all()
 
             continue
         else:

--- a/VMEncryption/test/test_resource_disk_util.py
+++ b/VMEncryption/test/test_resource_disk_util.py
@@ -33,7 +33,7 @@ class TestResourceDiskUtil(unittest.TestCase):
         self.mock_disk_util = mock.create_autospec(DiskUtil)
         self.mock_passhprase_filename = "mock_passphrase_filename"
         mock_public_settings = {}
-        self.resource_disk = ResourceDiskUtil(self.logger, self.mock_disk_util, self.mock_passhprase_filename, mock_public_settings)
+        self.resource_disk = ResourceDiskUtil(self.logger, self.mock_disk_util, self.mock_passhprase_filename, mock_public_settings, ["ubuntu", "16"])
 
     def _test_resource_disk_partition_dependant_method(self, method, mock_partition_exists, mock_execute):
         """


### PR DESCRIPTION
- Add a parser crypttab
- Add a post-reimage restore mechanism for crypttab
- Add methods to judge which unlock mechanism to use (old azure_crypt_mount vs crypttab)
- Unmount BEK VOLUME when it is needed to unmount RD (and then remount it again).
- Lint handle.py a little