### PR TITLE
Add centos 7.6 to handled distros for VM encryption.

### DIFF
--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -1601,7 +1601,8 @@ def daemon_encrypt():
                                                             encryption_environment=encryption_environment)
         elif (((distro_name == 'centos' and distro_version == '7.3.1611') or
               (distro_name == 'centos' and distro_version.startswith('7.4')) or
-              (distro_name == 'centos' and distro_version.startswith('7.5'))) and
+              (distro_name == 'centos' and distro_version.startswith('7.5')) or
+              (distro_name == 'centos' and distro_version.startswith('7.6'))) and
               (disk_util.is_os_disk_lvm() or os.path.exists('/volumes.lvm'))):
             from oscrypto.rhel_72_lvm import RHEL72LVMEncryptionStateMachine
             os_encryption = RHEL72LVMEncryptionStateMachine(hutil=hutil,
@@ -1613,6 +1614,7 @@ def daemon_encrypt():
               (distro_name == 'redhat' and distro_version == '7.4') or
               (distro_name == 'redhat' and distro_version == '7.5') or
               (distro_name == 'redhat' and distro_version == '7.6') or
+              (distro_name == 'centos' and distro_version.startswith('7.6')) or
               (distro_name == 'centos' and distro_version.startswith('7.5')) or
               (distro_name == 'centos' and distro_version.startswith('7.4')) or
               (distro_name == 'centos' and distro_version == '7.3.1611') or

--- a/VMEncryption/main/oscrypto/rhel_72/encryptstates/PrereqState.py
+++ b/VMEncryption/main/oscrypto/rhel_72/encryptstates/PrereqState.py
@@ -50,6 +50,7 @@ class PrereqState(OSEncryptionState):
             (distro_info[0] == 'redhat' and distro_info[1] == '7.4') or
             (distro_info[0] == 'redhat' and distro_info[1] == '7.5') or
             (distro_info[0] == 'redhat' and distro_info[1] == '7.6') or
+            (distro_info[0] == 'centos' and distro_info[1].startswith('7.6')) or
             (distro_info[0] == 'centos' and distro_info[1].startswith('7.5')) or
             (distro_info[0] == 'centos' and distro_info[1].startswith('7.4')) or
             (distro_info[0] == 'centos' and distro_info[1] == '7.3.1611') or

--- a/VMEncryption/main/oscrypto/rhel_72_lvm/encryptstates/PrereqState.py
+++ b/VMEncryption/main/oscrypto/rhel_72_lvm/encryptstates/PrereqState.py
@@ -48,6 +48,7 @@ class PrereqState(OSEncryptionState):
         if (((distro_info[0] == 'centos' and distro_info[1] == '7.3.1611') or
              (distro_info[0] == 'centos' and distro_info[1].startswith('7.4')) or
              (distro_info[0] == 'centos' and distro_info[1].startswith('7.5')) or
+             (distro_info[0] == 'centos' and distro_info[1].startswith('7.6')) or
              (distro_info[0] == 'redhat' and distro_info[1] == '7.3') or
              (distro_info[0] == 'redhat' and distro_info[1] == '7.4') or
              (distro_info[0] == 'redhat' and distro_info[1] == '7.5') or


### PR DESCRIPTION
Resolves #778 -- whitelists CentOS 7.6, assuming that it follows same compatibility as RHEL 7.6.  Was able to use patched version successfully against production servers to enable os/data disk encryption.

Wasn't sure if I should bump the extension version number like #753 did or not.  Let me know if you'd like me to add that.