### PR TITLE
Remove instrumentation key

### DIFF
--- a/OpenCensusAgent/opencensus-service/exporter/exporterwrapper/converterToApplicationInsights.go
+++ b/OpenCensusAgent/opencensus-service/exporter/exporterwrapper/converterToApplicationInsights.go
@@ -28,7 +28,6 @@ func getHostName() string {
 
 func ConvertOCSpanDataToApplicationInsightsSchema(sd *trace.SpanData) string {
 	envelope := Envelope{
-		IKey: os.Getenv("APPLICATIONINSIGHTS_KEY"),
 		Tags: AzureMonitorContext,
 		Time: FormatTime(sd.StartTime),
 	}
@@ -146,7 +145,6 @@ type Data struct {
 }
 
 type Envelope struct {
-	IKey       string                 `json:"iKey"`
 	Tags       map[string]interface{} `json:"tags"`
 	Name       string                 `json:"name"`
 	Time       string                 `json:"time"`


### PR DESCRIPTION
Developer using this extension to send Open Census data to Application Insights does not need to add  instrumentation key for their resource. The key will be added when the Open Census data passes through the mdsd agent. In the future, "Tags" under Envelope will also be removed for the same reason.

@simathih 