### PR TITLE
ADE SP use 2.6 compatible dictionary syntax

### DIFF
--- a/VMEncryption/main/DiskUtil.py
+++ b/VMEncryption/main/DiskUtil.py
@@ -905,7 +905,7 @@ class DiskUtil(object):
 
         mount_items = self.get_mount_items()
         device_items = self.get_device_items(None)
-        device_items_dict = {device_item.mount_point: device_item for device_item in device_items}
+        device_items_dict = dict([(device_item.mount_point,device_item) for device_item in device_items])
 
         os_drive_encrypted = False
         data_drives_found = False

--- a/VMEncryption/main/DiskUtil.py
+++ b/VMEncryption/main/DiskUtil.py
@@ -905,7 +905,7 @@ class DiskUtil(object):
 
         mount_items = self.get_mount_items()
         device_items = self.get_device_items(None)
-        device_items_dict = dict([(device_item.mount_point,device_item) for device_item in device_items])
+        device_items_dict = dict([(device_item.mount_point, device_item) for device_item in device_items])
 
         os_drive_encrypted = False
         data_drives_found = False


### PR DESCRIPTION
- use Python 2.6 compatible dictionary syntax in DiskUtil for CentOS 6.8 backcompat