### PR TITLE
Account for LUKS header size more than 2MB

### DIFF
--- a/VMEncryption/main/Common.py
+++ b/VMEncryption/main/Common.py
@@ -61,7 +61,7 @@ class CommonVariables:
     disk/file system related
     """
     sector_size = 512
-    luks_header_size = 4096 * 512
+    luks_header_size = 20480 * 512
     default_block_size = 52428800
     min_filesystem_size_support = 52428800 * 3
     default_file_system = 'ext4'


### PR DESCRIPTION
Resize filesystem by 10 MB. Luks format will take only the required space by header.