### PR TITLE
ADE DP improve error handling when no settings file present

### DIFF
--- a/VMEncryption/main/Common.py
+++ b/VMEncryption/main/Common.py
@@ -20,7 +20,7 @@
 class CommonVariables:
     utils_path_name = 'Utils'
     extension_name = 'AzureDiskEncryptionForLinux'
-    extension_version = '0.1.0.999340'
+    extension_version = '0.1.0.999341'
     extension_type = extension_name
     extension_media_link = 'https://amextpaas.blob.core.windows.net/prod/' + extension_name + '-' + str(extension_version) + '.zip'
     extension_label = 'Windows Azure VMEncryption Extension for Linux IaaS'

--- a/VMEncryption/main/Utils/HandlerUtil.py
+++ b/VMEncryption/main/Utils/HandlerUtil.py
@@ -175,15 +175,20 @@ class HandlerUtility:
         self._error(self._get_log_prefix() + ': ' + message)
 
     def _parse_config(self, config_txt):
+        # pre : config_txt is a text string containing JSON configuration settings 
+        # post: handlerSettings is initialized with these settings and the config 
+        #       object is returned.  If an error occurs, None is returned. 
+        if not config_txt:
+            self.error('empty config, nothing to parse')
+            return None
+
         config = None
         try:
             config = json.loads(config_txt)
         except:
-            self.error('JSON exception decoding ' + config_txt)
+            self.error('invalid config, could not parse: ' + str(config_txt))
 
-        if config == None:
-            self.error("JSON error processing settings file:" + config_txt)
-        else:
+        if config:
             handlerSettings = config['runtimeSettings'][0]['handlerSettings']
 
             # skip unnecessary decryption of protected settings for query status 
@@ -261,7 +266,7 @@ class HandlerUtility:
         
         # validate that internal preconditions are satisfied and internal variables are initialized
         if self._context._seq_no < 0:
-            self.error("current context sequence number must be initialized and non-negative") 
+            self.error("current context sequence number must be initialized and non-negative")
         if not self._context._config_dir or not os.path.isdir(self._context._config_dir):
             self.error("current context config dir must be initialized and point to a path that exists")
         if not self._context._settings_file or not os.path.exists(self._context._settings_file):
@@ -271,8 +276,8 @@ class HandlerUtility:
         curr_path = self._context._settings_file
         last_path = os.path.join(self.config_archive_folder, "lnq.settings")
         
-        # if an archived nonquery settings file exists, use it if it is newer than current settings
-        if os.path.exists(last_path) and (os.stat(last_path).st_mtime > os.stat(curr_path).st_mtime):
+        # if an archived nonquery settings file exists, use it if no current settings file exists, or it is newer than current settings
+        if os.path.exists(last_path) and ((not os.path.exists(curr_path)) or (os.path.exists(curr_path) and (os.stat(last_path).st_mtime > os.stat(curr_path).st_mtime))):
             return last_path
         else:
             # reverse iterate through numbered settings files in config dir
@@ -308,11 +313,29 @@ class HandlerUtility:
         if nonquery:
             last_config_path = self.get_last_nonquery_config_path()
         else:
-            last_config_path = os.path.join(self._context._config_dir, str(self._context._seq_no) + '.settings') 
+            # retrieve the settings file corresponding to the current sequence number 
+            last_config_path = os.path.join(self._context._config_dir, str(self._context._seq_no) + '.settings')
 
+        # if not found, attempt to fall back to an archived settings file
+        if not os.path.isfile(last_config_path):
+            self.log('settings file not found, checking for archived settings')
+            last_config_path = os.path.join(self.config_archive_folder, "lnq.settings")
+            if not os.path.isfile(last_config_path):
+                self.error('archived settings file not found, unable to get last config')
+                return None
+            
+        # settings file was found, parse config and return config object 
         config_txt = waagent.GetFileContents(last_config_path)
+        if not config_txt:
+            self.error('configuration settings empty, unable to get last config')
+            return None
+            
         config_obj = self._parse_config(config_txt)
-        return config_obj
+        if not config_obj:
+            self.error('failed to parse configuration settings, unable to get last config')
+            return None  
+        else:
+            return config_obj
 
     def get_handler_env(self):
         # load environment variables from HandlerEnvironment.json 

--- a/VMEncryption/test/test_handler_util.py
+++ b/VMEncryption/test/test_handler_util.py
@@ -22,6 +22,7 @@ import unittest
 import os
 import console_logger
 import patch
+import glob
 from Utils import HandlerUtil
 from tempfile import mkstemp
 
@@ -63,7 +64,22 @@ class TestHandlerUtil(unittest.TestCase):
         
     def test_do_parse_context_disable(self):
         self.assertIsNotNone(self.hutil.do_parse_context('Disable'))
-    
+
+    def test_do_parse_context_disable_nosettings(self):
+        # simulate missing settings file by adding .bak extension
+        config_dir = os.path.join(os.getcwd(), 'config')
+        settings_files = glob.glob(os.path.join(config_dir, '*.settings'))
+        for settings_file in settings_files:
+            os.rename(settings_file, settings_file + '.bak')
+        try:
+            # test to simulate disable when no settings are available
+            self.hutil.do_parse_context('Disable')
+            self.hutil.archive_old_configs()
+        finally:
+            # restore settings files back to original name
+            for settings_file in settings_files:
+                os.rename(settings_file + '.bak', settings_file)
+
     def test_do_parse_context_uninstall(self):
         self.assertIsNotNone(self.hutil.do_parse_context('Uninstall'))
 


### PR DESCRIPTION
- equivalent to change recently merged to single pass extension
- adds error handling in the case of no settings file present when parsing context
- adds a unit test around disable to cover this scenario since a failure in disable can block update
