### PR TITLE
Using Purge to uninstall with dpkg and adding checks for MCS vars

### DIFF
--- a/AzureMonitorAgent/HandlerManifest.json
+++ b/AzureMonitorAgent/HandlerManifest.json
@@ -1,7 +1,7 @@
 [
   {
     "name":  "AzureMonitorLinuxAgent",
-    "version": "1.5",
+    "version": "0.4",
     "handlerManifest": {
       "installCommand": "agent.py -install",
       "uninstallCommand": "agent.py -uninstall",

--- a/AzureMonitorAgent/README.md
+++ b/AzureMonitorAgent/README.md
@@ -1,7 +1,7 @@
 # AzureMonitorLinuxAgent Extension
 Allow the owner of the Azure Virtual Machines to install the Azure Monitor Linux Agent
 
-The extension is currently in test versions 0.*
+The extension is currently in Canary. The test versions naming scheme is 0.* . The latest version is 0.4
 
 You can read the User Guide below.
 * [Learn more: Azure Virtual Machine Extensions](https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-extensions-features/)
@@ -19,7 +19,13 @@ You can deploy it using Azure CLI
  
 ### 1.1. Using Azure CLI Resource Manager
 
-You can deploy the OmsAgent Extension by running:
+You can view the availability of the Azure Monitor Linux Agent extension versions in each region by running:
+
+```
+az vm extension image list-versions -l <region> --name AzureMonitorLinuxAgent -p Microsoft.Azure.Monitor
+```
+
+You can deploy the Azure Monitor Linux Agent Extension by running:
 ```
 az vm extension set --name AzureMonitorLinuxAgent --publisher Microsoft.Azure.Monitor --version <version> --resource-group <My Resource Group> --vm-name <My VM Name>
 ```

--- a/AzureMonitorAgent/README.md
+++ b/AzureMonitorAgent/README.md
@@ -1,0 +1,51 @@
+# AzureMonitorLinuxAgent Extension
+Allow the owner of the Azure Virtual Machines to install the Azure Monitor Linux Agent
+
+The extension is currently in test versions 0.*
+
+You can read the User Guide below.
+* [Learn more: Azure Virtual Machine Extensions](https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-extensions-features/)
+
+Azure Monitor Linux Agent Extension can:
+* Install the agent and pull configs from MCS
+
+# User Guide
+
+## 1. Deploying the Extension to a VM
+
+You can deploy it using Azure CLI
+
+
+ 
+### 1.1. Using [**Azure CLI**][azure-cli]
+
+#### 1.1.1 Resource Manager
+
+You can deploy the OmsAgent Extension by running:
+```
+az vm extension set \
+  --resource-group myResourceGroup \
+  --vm-name myVM \
+  --name AzureMonitorLinuxAgent \
+  --publisher Microsoft.Azure.Monitor \
+  --version <version> \
+```
+
+
+## Supported Linux Distributions
+* CentOS Linux 5,6, and 7 (x86/x64)
+* Oracle Linux 5,6, and 7 (x86/x64)
+* Red Hat Enterprise Linux Server 5,6 and 7 (x86/x64)
+* Debian GNU/Linux 6, 7, and 8 (x86/x64)
+* Ubuntu 12.04 LTS, 14.04 LTS, 15.04, 15.10, 16.04 LTS (x86/x64)
+* SUSE Linux Enteprise Server 11 and 12 (x86/x64)
+
+## Troubleshooting
+
+* The status of the extension is reported back to Azure so that user can
+see the status on Azure Portal
+* All the extension installation and config files are unzipped into - 
+`/var/lib/waagent/Microsoft.Azure.Monitor.AzureMonitorLinuxAgent-<version>/packages/`
+and the tail of the output is logged into the log directory specified
+in HandlerEnvironment.json and reported back to Azure
+* The operation log of the extension is `/var/log/azure/Microsoft.Azure.Monitor.AzureMonitorLinuxAgent-<version>/extension.log` file.

--- a/AzureMonitorAgent/README.md
+++ b/AzureMonitorAgent/README.md
@@ -31,12 +31,12 @@ az vm extension set \
 
 
 ## Supported Linux Distributions 
- Currently Tested only on -
+ Currently Manually tested only on -
 * CentOS Linux 6, and 7 (x64)
 * Red Hat Enterprise Linux Server 6 and 7 (x64)
 * Ubuntu 16.04 LTS, 18.04 LTS(x64)
 
-Will Add more distros once they  manually tested
+Will Add more distros once they are tested
 
 ## Troubleshooting
 

--- a/AzureMonitorAgent/README.md
+++ b/AzureMonitorAgent/README.md
@@ -21,13 +21,10 @@ You can deploy it using Azure CLI
 
 You can deploy the OmsAgent Extension by running:
 ```
-az vm extension set \
-  --resource-group myResourceGroup \
-  --vm-name myVM \
-  --name AzureMonitorLinuxAgent \
-  --publisher Microsoft.Azure.Monitor \
-  --version <version> \
+az vm extension set --name AzureMonitorLinuxAgent --publisher Microsoft.Azure.Monitor --version <version> --resource-group <My Resource Group> --vm-name <My VM Name>
 ```
+
+To update the version of the esisting installation of Azure Monitor Linux Agent extension on a VM, please add "--force-update" flag to the above command. (Currenty Waagent only supports this way of upgrading. Will update once we have more info from them.)
 
 
 ## Supported Linux Distributions 

--- a/AzureMonitorAgent/README.md
+++ b/AzureMonitorAgent/README.md
@@ -17,9 +17,7 @@ You can deploy it using Azure CLI
 
 
  
-### 1.1. Using [**Azure CLI**][azure-cli]
-
-#### 1.1.1 Resource Manager
+### 1.1. Using Azure CLI Resource Manager
 
 You can deploy the OmsAgent Extension by running:
 ```
@@ -32,13 +30,13 @@ az vm extension set \
 ```
 
 
-## Supported Linux Distributions
-* CentOS Linux 5,6, and 7 (x86/x64)
-* Oracle Linux 5,6, and 7 (x86/x64)
-* Red Hat Enterprise Linux Server 5,6 and 7 (x86/x64)
-* Debian GNU/Linux 6, 7, and 8 (x86/x64)
-* Ubuntu 12.04 LTS, 14.04 LTS, 15.04, 15.10, 16.04 LTS (x86/x64)
-* SUSE Linux Enteprise Server 11 and 12 (x86/x64)
+## Supported Linux Distributions 
+ Currently Tested only on -
+* CentOS Linux 6, and 7 (x64)
+* Red Hat Enterprise Linux Server 6 and 7 (x64)
+* Ubuntu 16.04 LTS, 18.04 LTS(x64)
+
+Will Add more distros once they  manually tested
 
 ## Troubleshooting
 

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -205,11 +205,15 @@ def install():
 
     try:
         if os.path.isfile("/etc/default/mdsd"):
-            with open("/etc/default/mdsd", "a") as f:
-                f.write("\n")
-                f.write("export ENABLE_MCS=true\n")
-                f.write("export MCS_ENDPOINT=mcs.azure.com\n")
-                f.write("export AZURE_ENDPOINT=https://management.azure.com/\n")
+            with open("/etc/default/mdsd", "r+") as f:
+                data = f.read()
+                if "ENABLE_MCS=true" not in data:
+                    f.write("\n")
+                    f.write("export ENABLE_MCS=true\n")
+                if "MCS_ENDPOINT=mcs.azure.com" not in data:
+                    f.write("export MCS_ENDPOINT=mcs.azure.com\n")
+                if "AZURE_ENDPOINT=https://management.azure.com/" not in data:
+                    f.write("export AZURE_ENDPOINT=https://management.azure.com/\n")
         else:
             log_and_exit("install", MissingorInvalidParameterErrorCode, "Could not find the file - /etc/default/mdsd" )        
     except:
@@ -230,7 +234,7 @@ def uninstall():
     """
     find_package_manager("Uninstall")
     if PackageManager == "dpkg":
-        OneAgentUninstallCommand = "dpkg -r azure-mdsd"
+        OneAgentUninstallCommand = "dpkg -P azure-mdsd"
     elif PackageManager == "rpm":
         OneAgentUninstallCommand = "rpm -e azure-mdsd"
     else:

--- a/AzureMonitorAgent/manifest.xml
+++ b/AzureMonitorAgent/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.Azure.Monitor</ProviderNameSpace>
   <Type>AzureMonitorLinuxAgent</Type>
-  <Version>1.5</Version>
+  <Version>0.4</Version>
   <Label>Microsoft Azure Monitoring Agent for Linux</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>


### PR DESCRIPTION
By default, the -r/--remove flag in dpkg doesn't remove the config files (for ex. /etc/default/mdsd ) And we want the file to be replaced with the new installation. 
Thus adding the -P (--purge) flag to completely remove the configs related to mdsd so that the new version can create a fresh copy

Also adding checks before adding the MCS export vars statements (In case of Debian systems, if --install operation is ran multiple times, it will keep appending to the same file, Doesn't happen in RedHat systems as rpm prevents from installing the same package)