### PR TITLE
Fix for issue #942

### DIFF
--- a/OmsAgent/omsagent.py
+++ b/OmsAgent/omsagent.py
@@ -495,24 +495,15 @@ def enable():
             os.chown(etc_final_path, uid, gid)
 
             # octal numbers are represented differently in python 3
-            if sys.version_info >= (3,):
-                os.chmod(etc_final_path, 0o750)
-            else:    
-                os.chmod(etc_final_path, 0750)
+            os.chmod(etc_final_path, 0o750)
 
             for root, dirs, files in os.walk(etc_final_path):
                 for d in dirs:
                     os.chown(os.path.join(root, d), uid, gid)
-                    if sys.version_info >= (3,):
-                        os.chmod(os.path.join(root, d), 0o750)
-                    else:    
-                        os.chmod(os.path.join(root, d), 0750)                
+                    os.chmod(os.path.join(root, d), 0o750)
                 for f in files:
                     os.chown(os.path.join(root, f), uid, gid)                  
-                    if sys.version_info >= (3,):
-                        os.chmod(os.path.join(root, f), 0o640)
-                    else:    
-                        os.chmod(os.path.join(root, f), 0640)                           
+                    os.chmod(os.path.join(root, f), 0o640)
     except:
         hutil_log_info('Failed to set permissions for OMS directories, could potentially have issues uploading.')
 


### PR DESCRIPTION
I have tested `os.chmod("/tmp/test", 0o750)` with *python2* and *python3* and this syntax works with both version, therefore removing the `if..then` that distiguish between the two versions.

This fixes issue https://github.com/Azure/azure-linux-extensions/issues/942


