### PR TITLE
ADE SP - add python-six for CentOS 6.8 compatibility

### DIFF
--- a/VMEncryption/main/patch/centosPatching.py
+++ b/VMEncryption/main/patch/centosPatching.py
@@ -97,6 +97,7 @@ class centosPatching(redhatPatching):
                     'pyparted']
 
         if self.distro_info[1].startswith("6."):
+            packages.add('python-six')
             packages.remove('cryptsetup')
             packages.remove('procps-ng')
             packages.remove('util-linux')


### PR DESCRIPTION
adds python-six for CentOS 6.8 compatibility, required by transitions