### PR TITLE
Move LAD's out_mdsd buffer path to own directory

### DIFF
--- a/Diagnostic/Utils/lad_logging_config.py
+++ b/Diagnostic/Utils/lad_logging_config.py
@@ -360,7 +360,7 @@ class LadLoggingConfig:
 {tag_regex_cfg_line}    num_threads 1
     buffer_chunk_limit 1000k
     buffer_type file
-    buffer_path /var/opt/microsoft/omsagent/state/out_mdsd*.buffer
+    buffer_path /var/opt/microsoft/omsagent/LAD/state/out_mdsd*.buffer
     buffer_queue_limit 128
     flush_interval 10s
     retry_limit 3

--- a/Diagnostic/tests/test_lad_logging_config.py
+++ b/Diagnostic/tests/test_lad_logging_config.py
@@ -241,7 +241,7 @@ class LadLoggingConfigTest(unittest.TestCase, XmlTestMixin):
 {optional_lines}    num_threads 1
     buffer_chunk_limit 1000k
     buffer_type file
-    buffer_path /var/opt/microsoft/omsagent/state/out_mdsd*.buffer
+    buffer_path /var/opt/microsoft/omsagent/LAD/state/out_mdsd*.buffer
     buffer_queue_limit 128
     flush_interval 10s
     retry_limit 3


### PR DESCRIPTION
The state directory is a symlink to the primary workspace; which is different than LAD workspace. If VM is disjoined from primary workspace; the buffer path will turn invalid.