### PR TITLE
Second CDPx build stage which uses Windows build to push artifacts to CloudVault.

### DIFF
--- a/.pipelines/pipeline.user.linux.all_buildtype.ade.yml
+++ b/.pipelines/pipeline.user.linux.all_buildtype.ade.yml
@@ -21,7 +21,5 @@ build:
       fail_on_stderr: true
       artifacts:
         - from: 'VMEncryption'
-          to: 'AzureDiskEncryption'
           include:
             - 'dist/*.zip'
-            - 'dist/**/manifest.xml'

--- a/.pipelines/pipeline.user.windows.all_buildtype.ade.yml
+++ b/.pipelines/pipeline.user.windows.all_buildtype.ade.yml
@@ -1,0 +1,34 @@
+environment:
+  host:
+    os: 'windows'
+    flavor: 'server'
+    version: '2016'
+  runtime:
+    provider: 'appcontainer'
+    image: 'cdpxwin.azurecr.io/global/vse2017u7/vse2017u7-external-winltsc2016-20190731:latest'
+    source_mode: 'map'
+
+workspace_options:                         # Metadata section
+  force_workspace_wipe: false              # Default is always true
+  enable_git_long_paths: true              # Default is always false
+  download_current_artifacts: true         # Default is always false
+  # downloaded artifacts from the previous phase(s) go here -- Windows: C:\temppriordrop\current Linux: /temppriordrop/current
+  show_global_sub_tasks: true              # DEPRECATED
+  show_user_sub_tasks: true                # DEPRECATED
+
+version:
+  name: 'Azure Disk Encryption for Linux'
+  major: 1                                                              
+  minor: 1                                                              
+  tag: 'buddy'
+  system: 'buildrevision'
+  
+build:
+  commands:
+    - !!buildcommand
+      name: 'No-op script'
+      command: 'VMEncryption\cdpx_windows_copy.cmd'
+      artifacts:
+        - from: 'cdpx-artifacts'
+          include:
+            - '**/*'

--- a/VMEncryption/cdpx_windows_copy.cmd
+++ b/VMEncryption/cdpx_windows_copy.cmd
@@ -1,0 +1,2 @@
+dir /s C:\temppriordrop
+xcopy /Y /I /E C:\temppriordrop\current\drop\LinuxBuild\outputs\build\dist C:\source\cdpx-artifacts


### PR DESCRIPTION
Current CDPx Linux build implementation does not push artifacts automatically over to CloudVault but the Windows build does. OneBranch team suggested to workaround this problem by introducing a second build phase as a dummy Windows build which takes artifacts from the Linux build phase, binplaces them by a simple local copy, and automatically copy them over to CloudVault.

- Removed manifest.xml placing since it is already in the ZIP file.

- Removed an additional folder in the drop location. 