### PR TITLE
adding continueOnUpdateFailure tag to HandlerManifest

### DIFF
--- a/OmsAgent/HandlerManifest.json
+++ b/OmsAgent/HandlerManifest.json
@@ -11,7 +11,8 @@
       "rebootAfterInstall": false,
       "reportHeartbeat": false,
       "updateMode": "UpdateWithInstall",
-      "stopOnMultipleConnections": "true"
+      "stopOnMultipleConnections": "true",
+      "continueOnUpdateFailure": "true"
     }
   }
 ]


### PR DESCRIPTION
Adding continueOnUpdateFailure flag to the HandlerManifest.json (This was included in Fairfax release but never added to the code, this flag allows us to conitnue update of the extension in case the current version is in a failed state or doesn't get disabled)