### PR TITLE
Adding the endpoint for EX Cloud for omsagent,py

### DIFF
--- a/OmsAgent/omsagent.py
+++ b/OmsAgent/omsagent.py
@@ -80,6 +80,7 @@ WorkspaceCheckCommand = '{0} -l'.format(OMSAdminPath)
 OnboardCommandWithOptionalParams = '{0} -w {1} -s {2} {3}' # Public Cloud
 # OnboardCommandWithOptionalParams = '{0} -d opinsights.azure.us -w {1} -s {2} {3}' # Fairfax
 # OnboardCommandWithOptionalParams = '{0} -d opinsights.azure.cn -w {1} -s {2} {3}' # Mooncake
+# OnboardCommandWithOptionalParams = '{0} -d opinsights.azure.eaglex.ic.gov -w {1} -s {2} {3}' #EX
 RestartOMSAgentServiceCommand = '{0} restart'.format(OMSAgentServiceScript)
 DisableOMSAgentServiceCommand = '{0} disable'.format(OMSAgentServiceScript)
 


### PR DESCRIPTION
Added the optional parameter value for EX region for future deployments. The current EX deployment for 1.12.* **will follow the same format as the current Fairfax deployment to maintain parity and not this change.** 

This change can take effect from 1.13.* releases to FF/MC/EX onwards