### PR TITLE
Bug fix DistInfo() should return 'Default' instead of 'Abstract'

### DIFF
--- a/VMBackup/main/patch/__init__.py
+++ b/VMBackup/main/patch/__init__.py
@@ -63,7 +63,7 @@ def DistInfo():
     except Exception as e:
         errMsg = 'Failed to retrieve the distinfo with error: %s, stack trace: %s' % (str(e), traceback.format_exc())
         logger.log(errMsg)
-        distinfo = ['Abstract','1.0']
+        distinfo = ['Default','1.0']
         return distinfo
 
 def GetMyPatching(logger):


### PR DESCRIPTION
In DistInfo(), when an exception occurs (e.g. if the os-release
file is missing), ['Abstract','1.0'] is returned.
In that case GetMyPatching() tries to instantiate AbstractPatching().
This will fail because the import for AbstractPatching is
missing.

DistInfo() should return ['Default','1.0'].