### PR TITLE
Add python-future as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "VMEncryption/transitions"]
 	path = VMEncryption/transitions
 	url = https://github.com/tyarkoni/transitions.git
+[submodule "OmsAgent/ext/python-future"]
+	path = OmsAgent/ext/python-future
+	url = https://github.com/PythonCharmers/python-future

--- a/OmsAgent/omsagent.py
+++ b/OmsAgent/omsagent.py
@@ -17,16 +17,21 @@
 # limitations under the License.
 
 from __future__ import print_function
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str
+import sys
+
+# future imports have no effect on python 3 (verified in official docs)
+# importing from source causes import errors on python 3, lets skip import
+if sys.version_info[0] < 3:
+    from future import standard_library
+    standard_library.install_aliases()
+    from builtins import str
+
 import os
 import os.path
 import signal
 import pwd
 import grp
 import re
-import sys
 import traceback
 import time
 import platform

--- a/OmsAgent/omsagent_shim.sh
+++ b/OmsAgent/omsagent_shim.sh
@@ -1,24 +1,28 @@
 #!/usr/bin/env bash
 
-# The entry point for the OMS extension through which the correct python version (if any) is used to invoke omsagent.py. 
+# The entry point for the OMS extension through which the correct python version (if any) is used to invoke omsagent.py.
 # We default to python2 and always invoke with the versioned python command to accomodate the RHEL 8+ python strategy.
 # Control arguments passed to the shim are redirected to omsagent.py without validation.
 
 COMMAND="./omsagent.py"
 PYTHON=""
+FUTURE_PATH=""
 ARG="$@"
 
 function find_python() {
     local python_exec_command=$1
+    local future_path=$2
 
     if command -v python2 >/dev/null 2>&1 ; then
         eval ${python_exec_command}="python2"
+        eval ${future_path}="${PWD}/ext/future:"
     elif command -v python3 >/dev/null 2>&1 ; then
         eval ${python_exec_command}="python3"
+        # do not set future_path; future seems to cause interference with preexisting packages in python 3 environment
     fi
 }
 
-find_python PYTHON
+find_python PYTHON FUTURE_PATH
 
 if [ -z "$PYTHON" ]
 then
@@ -28,5 +32,5 @@ else
     ${PYTHON} --version
 fi
 
-PYTHONPATH=${PWD}/ext/future:${PYTHONPATH} ${PYTHON} ${COMMAND} ${ARG}
+PYTHONPATH=${FUTURE_PATH}${PYTHONPATH} ${PYTHON} ${COMMAND} ${ARG}
 exit $?

--- a/OmsAgent/omsagent_shim.sh
+++ b/OmsAgent/omsagent_shim.sh
@@ -18,17 +18,6 @@ function find_python() {
     fi
 }
 
-# Usage: run_command "shell command" "description of action"
-function run_command() {
-    eval $1
-    if [ $? != 0 ]; then
-        echo "$2 failed, command: $1" >&2
-        exit 52
-    else
-        echo "$2 succeeded"
-    fi
-}
-
 find_python PYTHON
 
 if [ -z "$PYTHON" ]
@@ -39,42 +28,5 @@ else
     ${PYTHON} --version
 fi
 
-# Install python-future dependency required for omsagent.py.
-# Infer distro and use the appropriate package manager,
-# falling back on direct package manager detection
-ACTION="python-future install"
-if [ -f "/etc/debian_version" ]; then # Ubuntu, Debian
-    dpkg-query -l python-future | grep ^ii
-    if [ $? != 0 ]; then
-        run_command "apt-get update" "python-future preinstall"
-        run_command "apt-get install -y python-future" $ACTION
-    fi
-elif [ -f "/etc/redhat-release" ]; then # RHEL, CentOS, Oracle
-    rpm -qi python-future
-    if [ $? != 0 ]; then
-        run_command "yum install -y python-future" $ACTION
-    fi
-elif [ -f "/etc/os-release" ]; then # Possibly SLES, openSUSE
-    grep PRETTY_NAME /etc/os-release | sed 's/PRETTY_NAME=//g' | tr -d '="' | grep -i suse
-    if [ $? != 0 ]; then
-        echo "Unsupported or indeterminable operating system" >&2
-        exit 51
-    fi
-    rpm -qi python-future
-    if [ $? != 0 ]; then
-        run_command "zypper --non-interactive install python-future" $ACTION
-    fi
-elif [ -x "$(command -v apt-get)" ]; then
-    run_command "apt-get update" "python-future preinstall"
-    run_command "apt-get install -y python-future" $ACTION
-elif [ -x "$(command -v yum)" ]; then
-    run_command "yum install -y python-future" $ACTION
-elif [ -x "$(command -v zypper)" ]; then
-    run_command "zypper --non-interactive install python-future" $ACTION
-else
-    echo "Unsupported or indeterminable operating system" >&2
-    exit 51
-fi
-
-${PYTHON} ${COMMAND} ${ARG}
+PYTHONPATH=${PWD}/ext/future:${PYTHONPATH} ${PYTHON} ${COMMAND} ${ARG}
 exit $?

--- a/OmsAgent/packaging.sh
+++ b/OmsAgent/packaging.sh
@@ -28,11 +28,13 @@ fi
 cp -r ../Utils .
 cp ../Common/WALinuxAgent-2.0.16/waagent .
 
-# cleanup packages
-rm -rf packages
-mkdir -p packages
+# cleanup packages, ext
+rm -rf packages ext/future
+mkdir -p packages ext/future
 # copy shell bundle to packages/
 cp $bundle_path packages/
+# copy just the source of python-future
+cp -r ext/python-future/src/* ext/future
 # sync the file copy
 sync
 
@@ -43,7 +45,7 @@ fi
 
 echo "Packaging extension $PACKAGE_NAME to $output_path"
 excluded_files="omsagent.version packaging.sh apply_version.sh update_version.sh"
-zip -r $output_path/$PACKAGE_NAME * -x $excluded_files "./Fairfax/*" "./Mooncake/*" "./test/*" "./extension-test/*" "./references"
+zip -r $output_path/$PACKAGE_NAME * -x $excluded_files "./test/*" "./extension-test/*" "./references" "./ext/python-future/*"
 
 # cleanup newly added dir or files
 rm -rf Utils/ waagent


### PR DESCRIPTION
- Original approach of using package managers to install python-future is not viable (package is not hosted in standard RPM repos), neither is using pip to install future (same reason, installing even pip is not straightforward/reliable).
- Instead, let's add python-future as a submodule. When we create the extension zip with `packaging.sh` the source files will be copied to `./ext/future`, which we add to PYTHONPATH.