### PR TITLE
Get python-future with pip

### DIFF
--- a/OmsAgent/omsagent_shim.sh
+++ b/OmsAgent/omsagent_shim.sh
@@ -1,22 +1,14 @@
 #!/usr/bin/env bash
 
-# The entry point for the OMS extension through which the correct python version (if any) is used to invoke omsagent.py. 
+# The entry point for the OMS extension through which the correct python version (if any) is used to invoke omsagent.py.
 # We default to python2 and always invoke with the versioned python command to accomodate the RHEL 8+ python strategy.
 # Control arguments passed to the shim are redirected to omsagent.py without validation.
 
 COMMAND="./omsagent.py"
 PYTHON=""
+PIP=""
+PACKAGES=""
 ARG="$@"
-
-function find_python() {
-    local python_exec_command=$1
-
-    if command -v python2 >/dev/null 2>&1 ; then
-        eval ${python_exec_command}="python2"
-    elif command -v python3 >/dev/null 2>&1 ; then
-        eval ${python_exec_command}="python3"
-    fi
-}
 
 # Usage: run_command "shell command" "description of action"
 function run_command() {
@@ -29,7 +21,30 @@ function run_command() {
     fi
 }
 
-find_python PYTHON
+function find_python_env() {
+    local python_exec_command=$1
+    local pip_exec_command=$2
+    local pip_packages=$3
+
+    if command -v python2 >/dev/null 2>&1 ; then
+        eval ${python_exec_command}="python2"
+        eval ${pip_exec_command}="pip2"
+        if [ -x "$(command -v python2.6 >/dev/null 2>&1)" ]; then # get-pip script differs for 2.6
+            eval ${pip_packages}="future importlib"
+            run_command "curl https://bootstrap.pypa.io/2.6/get-pip.py -o get-pip.py" "pip download"
+        else
+            eval ${pip_packages}="future"
+            run_command "curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py" "pip download"
+        fi
+    elif command -v python3 >/dev/null 2>&1 ; then
+        eval ${python_exec_command}="python3"
+        eval ${pip_exec_command}="pip3"
+        eval ${pip_packages}="future importlib"
+        run_command "curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py" "pip download"
+    fi
+}
+
+find_python_env PYTHON PIP PACKAGES
 
 if [ -z "$PYTHON" ]
 then
@@ -39,42 +54,13 @@ else
     ${PYTHON} --version
 fi
 
-# Install python-future dependency required for omsagent.py.
-# Infer distro and use the appropriate package manager,
-# falling back on direct package manager detection
-ACTION="python-future install"
-if [ -f "/etc/debian_version" ]; then # Ubuntu, Debian
-    dpkg-query -l python-future | grep ^ii
-    if [ $? != 0 ]; then
-        run_command "apt-get update" "python-future preinstall"
-        run_command "apt-get install -y python-future" $ACTION
-    fi
-elif [ -f "/etc/redhat-release" ]; then # RHEL, CentOS, Oracle
-    rpm -qi python-future
-    if [ $? != 0 ]; then
-        run_command "yum install -y python-future" $ACTION
-    fi
-elif [ -f "/etc/os-release" ]; then # Possibly SLES, openSUSE
-    grep PRETTY_NAME /etc/os-release | sed 's/PRETTY_NAME=//g' | tr -d '="' | grep -i suse
-    if [ $? != 0 ]; then
-        echo "Unsupported or indeterminable operating system" >&2
-        exit 51
-    fi
-    rpm -qi python-future
-    if [ $? != 0 ]; then
-        run_command "zypper --non-interactive install python-future" $ACTION
-    fi
-elif [ -x "$(command -v apt-get)" ]; then
-    run_command "apt-get update" "python-future preinstall"
-    run_command "apt-get install -y python-future" $ACTION
-elif [ -x "$(command -v yum)" ]; then
-    run_command "yum install -y python-future" $ACTION
-elif [ -x "$(command -v zypper)" ]; then
-    run_command "zypper --non-interactive install python-future" $ACTION
-else
-    echo "Unsupported or indeterminable operating system" >&2
-    exit 51
+# Install pip
+if [ -z "$PIP" ]; then
+    run_command "${PYTHON} get-pip.py" "Install pip"
 fi
+
+# Install future
+run_command "${PIP} install ${PACKAGES}" "Install python-future, importlib"
 
 ${PYTHON} ${COMMAND} ${ARG}
 exit $?


### PR DESCRIPTION
An alternative to the submodule approach in #1058 
- Pro: more "supported" way of getting a new python module, via pip; doesn't require as many steps during extension packaging; avoids hacky python version dependent path/imports setting
- Con: may be more prone to failure due to pip download failure, also apparently there can be some issues depending on whether chose to install pip itself or packages USING pip with or without the `--user` flag (issue threads [1](https://github.com/pypa/pip/issues/1668), [2](https://github.com/pypa/pip/issues/7209) ...)