### PR TITLE
Support for newer distros by adding default distro; gitignore updated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@ var/
 # Editor
 *~
 
+# PyCharm
+.idea/
+.idea_modules/
+
 # PyInstaller
 #  Usually these files are written by a python script from a template 
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
@@ -59,6 +63,28 @@ docs/_build/
 
 # PyBuilder
 target/*
+
+
+# mac osx specific files
+.DS_Store
+
+### VirtualEnv template
+# Virtualenv
+# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+.Python
+pyvenv.cfg
+.venv
+pip-selfcheck.json
+
+# virtualenv
+venv/
+ENV/
+
+# dotenv
+.env
+
+# pyenv
+.python-version
 
 # VMBackup package ignors
 VMBackup/dist

--- a/Common/WALinuxAgent-2.0.16/waagent
+++ b/Common/WALinuxAgent-2.0.16/waagent
@@ -743,8 +743,7 @@ class AbstractDistro(object):
 
 class DefaultDistro(AbstractDistro):
     """
-    Asianux Distro concrete class
-    Put Asianux specific behavior here...
+    Default Distro concrete class: This class serves as a default OS behavior class.
     """
 
     def startDHCP(self):

--- a/Common/WALinuxAgent-2.0.16/waagent
+++ b/Common/WALinuxAgent-2.0.16/waagent
@@ -741,6 +741,30 @@ class AbstractDistro(object):
         pass
 
 
+class DefaultDistro(AbstractDistro):
+    """
+    Asianux Distro concrete class
+    Put Asianux specific behavior here...
+    """
+
+    def startDHCP(self):
+        """
+        Following the pattern used in WALinuxAgent for Default distro: This method is not implemented in the default
+        case.
+        """
+        pass
+
+    def stopDHCP(self):
+        """
+        Following the pattern used in WALinuxAgent for Default distro: This method is not implemented in the default
+        case.
+        """
+        pass
+
+    def __init__(self):
+        super(DefaultDistro, self).__init__()
+
+
 ############################################################
 #   GentooDistro
 ############################################################
@@ -6493,9 +6517,12 @@ def GetMyDistro(dist_class_name=''):
     else:
         Distro = dist_class_name
     if dist_class_name not in globals():
-        print(Distro + ' is not a supported distribution.')
-        return None
-    return globals()[dist_class_name]()  # the distro class inside this module.
+        print(Distro + ' is not a supported distribution. Reverting to DefaultDistro to support scenarios in'
+                       ' unknown/unsupported distribution.')
+        return DefaultDistro()
+
+    # the distro class inside this module. Check the implementations of AbstractDistro
+    return globals()[dist_class_name]()
 
 
 def DistInfo(fullname=0):

--- a/Common/WALinuxAgent-2.0.16/waagent
+++ b/Common/WALinuxAgent-2.0.16/waagent
@@ -6517,8 +6517,10 @@ def GetMyDistro(dist_class_name=''):
     else:
         Distro = dist_class_name
     if dist_class_name not in globals():
-        print(Distro + ' is not a supported distribution. Reverting to DefaultDistro to support scenarios in'
-                       ' unknown/unsupported distribution.')
+        msg = Distro + ' is not a supported distribution. Reverting to DefaultDistro to support scenarios in ' \
+                       'unknown/unsupported distribution.'
+        print(msg)
+        Log(msg)
         return DefaultDistro()
 
     # the distro class inside this module. Check the implementations of AbstractDistro


### PR DESCRIPTION
With newer distros coming up in Azure, some of the extension scenarios are failing because of the failing GetMyDistro() call, which gives a bad extensions experience to those VMs. I add a new DefaultDistro scenario which could help in preventing such scenarios and try to present a better user experience  in such cases.

Also update gitignore to prevent venv, pycharm and mac os files to be committed.