### PR TITLE
Avoiding leaked snapshots 

### DIFF
--- a/VMBackup/main/ExtensionErrorCodeHelper.py
+++ b/VMBackup/main/ExtensionErrorCodeHelper.py
@@ -41,6 +41,7 @@ class ExtensionErrorCodeEnum():
     FailedPrepostPluginConfigNotFound = 316
     FailedPrepostPluginConfigPermissionError = 317
     FailedPrepostPluginConfigOwnershipError = 318
+    FailedGuestAgentInvokedCommandTooLate = 319
 
 class ExtensionErrorCodeHelper:
     ExtensionErrorCodeDict = {

--- a/VMBackup/main/ExtensionErrorCodeHelper.py
+++ b/VMBackup/main/ExtensionErrorCodeHelper.py
@@ -41,7 +41,7 @@ class ExtensionErrorCodeEnum():
     FailedPrepostPluginConfigNotFound = 316
     FailedPrepostPluginConfigPermissionError = 317
     FailedPrepostPluginConfigOwnershipError = 318
-    FailedGuestAgentInvokedCommandTooLate = 319
+    FailedGuestAgentInvokedCommandTooLate = 402
 
 class ExtensionErrorCodeHelper:
     ExtensionErrorCodeDict = {

--- a/VMBackup/main/ExtensionErrorCodeHelper.py
+++ b/VMBackup/main/ExtensionErrorCodeHelper.py
@@ -83,7 +83,8 @@ class ExtensionErrorCodeHelper:
             ExtensionErrorCodeEnum.error_http_failure : Status.ExtVmHealthStateEnum.red,
             ExtensionErrorCodeEnum.FailedRetryableSnapshotFailedRestrictedNetwork : Status.ExtVmHealthStateEnum.red,
             ExtensionErrorCodeEnum.FailedRetryableSnapshotFailedNoNetwork : Status.ExtVmHealthStateEnum.red,
-            ExtensionErrorCodeEnum.FailedSnapshotLimitReached : Status.ExtVmHealthStateEnum.red
+            ExtensionErrorCodeEnum.FailedSnapshotLimitReached : Status.ExtVmHealthStateEnum.red,
+            ExtensionErrorCodeEnum.FailedGuestAgentInvokedCommandTooLate : Status.ExtVmHealthStateEnum.red
             }
 
     ExtensionErrorCodeNameDict = {
@@ -123,7 +124,8 @@ class ExtensionErrorCodeHelper:
             ExtensionErrorCodeEnum.error_http_failure : "error_http_failure",
             ExtensionErrorCodeEnum.FailedRetryableSnapshotFailedRestrictedNetwork : "FailedRetryableSnapshotFailedRestrictedNetwork",
             ExtensionErrorCodeEnum.FailedRetryableSnapshotFailedNoNetwork : "FailedRetryableSnapshotFailedNoNetwork",
-            ExtensionErrorCodeEnum.FailedSnapshotLimitReached : "FailedSnapshotLimitReached"
+            ExtensionErrorCodeEnum.FailedSnapshotLimitReached : "FailedSnapshotLimitReached",
+            ExtensionErrorCodeEnum.FailedGuestAgentInvokedCommandTooLate : "FailedGuestAgentInvokedCommandTooLate"
             }
     
     @staticmethod

--- a/VMBackup/main/common.py
+++ b/VMBackup/main/common.py
@@ -119,6 +119,7 @@ class CommonVariables:
     FailedPrepostPluginConfigNotFound = 316
     FailedPrepostPluginConfigPermissionError = 317
     FailedPrepostPluginConfigOwnershipError = 318
+    FailedGuestAgentInvokedCommandTooLate = 319
 
     """
     Consistency-Types

--- a/VMBackup/main/common.py
+++ b/VMBackup/main/common.py
@@ -119,7 +119,7 @@ class CommonVariables:
     FailedPrepostPluginConfigNotFound = 316
     FailedPrepostPluginConfigPermissionError = 317
     FailedPrepostPluginConfigOwnershipError = 318
-    FailedGuestAgentInvokedCommandTooLate = 319
+    FailedGuestAgentInvokedCommandTooLate = 402
 
     """
     Consistency-Types

--- a/VMBackup/main/handle.py
+++ b/VMBackup/main/handle.py
@@ -341,6 +341,7 @@ def daemon():
 
             if total_span_in_seconds > MAX_TIMESPAN :
                 error_msg = "CRP timeout limit has reached, will not take snapshot."
+                errMsg = error_msg
                 hutil.SetExtErrorCode(ExtensionErrorCodeHelper.ExtensionErrorCodeEnum.FailedGuestAgentInvokedCommandTooLate)
                 temp_result=CommonVariables.FailedGuestAgentInvokedCommandTooLate
                 temp_status= 'error'

--- a/VMBackup/main/handle.py
+++ b/VMBackup/main/handle.py
@@ -334,10 +334,17 @@ def daemon():
             utcNow = datetime.datetime.utcnow()
             backup_logger.log('command start time is ' + str(commandStartTime) + " and utcNow is " + str(utcNow), True)
             timespan = utcNow - commandStartTime
-            MAX_TIMESPAN = 150 * 60 # in seconds
+            MAX_TIMESPAN = 140 * 60 # in seconds
             # handle the machine identity for the restoration scenario.
             total_span_in_seconds = timedelta_total_seconds(timespan)
             backup_logger.log('timespan is ' + str(timespan) + ' ' + str(total_span_in_seconds))
+
+            if total_span_in_seconds > MAX_TIMESPAN :
+                error_msg = "CRP timeout limit has reached, will not take snapshot."
+                hutil.SetExtErrorCode(ExtensionErrorCodeHelper.ExtensionErrorCodeEnum.FailedGuestAgentInvokedCommandTooLate)
+                temp_result=CommonVariables.FailedGuestAgentInvokedCommandTooLate
+                temp_status= 'error'
+                exit_with_commit_log(temp_status, temp_result,error_msg, para_parser)
 
         if(para_parser.taskId is not None and para_parser.taskId != ""):
             backup_logger.log('taskId: ' + str(para_parser.taskId), True)


### PR DESCRIPTION
Currently, this new error code doesn't come up as extensionErrorCode in BCmbackupStats. As I got to know, for it to show as ExtensionerrorCode in BCMbackup stats, this error Code with the same enum number value has to be present in the Status Codes in windows extension, that error code is already there. So I assume no other changes are required in the linux extension for the same. Please let me know if it is otherwise.