### PR TITLE
Add support for NVMe disks.

### DIFF
--- a/VMEncryption/main/BekUtil.py
+++ b/VMEncryption/main/BekUtil.py
@@ -19,6 +19,7 @@
 from Common import TestHooks
 import base64
 import os.path
+import shutil
 
 """
 add retry-logic to the network api call.
@@ -82,6 +83,8 @@ class BekUtil(object):
 
             for file in os.listdir(self.bek_filesystem_mount_point):
                 if bek_filename in file:
+                    # Make sure LinuxPassPhraseFileName exist for Resource and Nvme disks 
+                    shutil.copy2(os.path.join(self.bek_filesystem_mount_point, file), os.path.join(self.bek_filesystem_mount_point, bek_filename))
                     return os.path.join(self.bek_filesystem_mount_point, file)
 
         except Exception as e:

--- a/VMEncryption/main/Common.py
+++ b/VMEncryption/main/Common.py
@@ -77,6 +77,7 @@ class CommonVariables:
     azure_symlinks_dir = '/dev/disk/azure'
     disk_by_id_root = '/dev/disk/by-id'
     disk_by_uuid_root = '/dev/disk/by-uuid'
+    nvme_disk_identifier = 'nvme'
 
     """
     parameter key names

--- a/VMEncryption/main/DiskUtil.py
+++ b/VMEncryption/main/DiskUtil.py
@@ -483,6 +483,17 @@ class DiskUtil(object):
 
         return sdx_path
 
+    def get_persistent_path_by_uuid(self, dev_path):
+        dev_realpath = os.path.realpath(dev_path)
+
+        for disk_by_uuid in os.listdir(CommonVariables.disk_by_uuid_root):
+            disk_by_uuid_path = os.path.join(CommonVariables.disk_by_uuid_root, disk_by_uuid)
+
+            if os.path.realpath(disk_by_uuid_path) == dev_realpath:
+                return disk_by_uuid_path
+
+        return dev_path
+        
     def get_device_path(self, dev_name):
         device_path = None
 

--- a/VMEncryption/test/test_disk_util.py
+++ b/VMEncryption/test/test_disk_util.py
@@ -99,3 +99,18 @@ class Test_Disk_Util(unittest.TestCase):
     def test_mount_all(self, cmd_exc_mock):
         self.disk_util.mount_all()
         self.assertEquals(cmd_exc_mock.call_count, 2)
+
+    @mock.patch("os.path.realpath")
+    @mock.patch("os.listdir")
+    def test_get_persistent_path_by_uuid(self, listdir_mock, realpath_mock):
+        listdir_mock.return_value = ['uuid1', 'uuid2']
+        realpath_mock.side_effect = ['/dev/disk1', '/dev/disk2', '/dev/disk1']
+        uuid_path = self.disk_util.get_persistent_path_by_uuid('/dev/disk1')
+        self.assertEquals('/dev/disk/by-uuid/uuid2', uuid_path)
+
+        listdir_mock.reset_mock()
+        realpath_mock.reset_mock()
+        listdir_mock.return_value = ['uuid1', 'uuid2']
+        realpath_mock.side_effect = ['/dev/disk3', '/dev/disk2', '/dev/disk1']
+        uuid_path = self.disk_util.get_persistent_path_by_uuid('/dev/disk3')
+        self.assertEquals('/dev/disk3', uuid_path)


### PR DESCRIPTION
1. NVMe disks will only be supported with encrypt format all. They will be skipped for standard encryption
2. Their dev path will be UUID based.
3. Stale NVMe disks entry will be cleaned from fstab/crypttab (NVMe disks are recreated after stop/start)