### PR TITLE
Increase timeout for package installation.

### DIFF
--- a/VMEncryption/main/patch/centosPatching.py
+++ b/VMEncryption/main/patch/centosPatching.py
@@ -87,7 +87,7 @@ class centosPatching(redhatPatching):
             packages.remove('cryptsetup')
 
         if self.command_executor.Execute("rpm -q " + " ".join(packages)):
-            return_code = self.command_executor.Execute("yum install -y " + " ".join(packages), timeout=30)
+            return_code = self.command_executor.Execute("yum install -y " + " ".join(packages), timeout=100)
             if return_code == -9:
                 msg = "Command: yum install timed out. Make sure yum is configured correctly and there are no network problems."
                 raise Exception(msg)

--- a/VMEncryption/main/patch/redhatPatching.py
+++ b/VMEncryption/main/patch/redhatPatching.py
@@ -95,7 +95,7 @@ class redhatPatching(AbstractPatching):
             packages.remove('cryptsetup')
             
         if self.command_executor.Execute("rpm -q " + " ".join(packages)):
-            return_code = self.command_executor.Execute("yum install -y " + " ".join(packages), timeout=30)
+            return_code = self.command_executor.Execute("yum install -y " + " ".join(packages), timeout=100)
             if return_code == -9:
                 msg = "Command: yum install timed out. Make sure yum is configured correctly and there are no network problems."
                 raise Exception(msg)


### PR DESCRIPTION
Older RHEL distros does not seem to have cryptsetup-reencrypt package by default. It leads to extension trying to download them. When yum is run for the first time it does some configuration before downloading and installing the package. Hence, it exceeds the original 30 sec timeout. Increased the timeout to 100 sec to account for yum configuration.