### PR TITLE
Hotfix for ovf-env.xml for IOError in python2

### DIFF
--- a/Utils/distroutils.py
+++ b/Utils/distroutils.py
@@ -81,7 +81,7 @@ class GenericDistro(object):
         home = None
         try:
             home = ext_utils.get_line_starting_with("HOME", "/etc/default/useradd").split('=')[1].strip()
-        except (ValueError, KeyError, AttributeError, OSError):
+        except (ValueError, KeyError, AttributeError, EnvironmentError):
             pass
         if (home is None) or (not home.startswith("/")):
             home = "/home"
@@ -156,12 +156,12 @@ class GenericDistro(object):
         user_entry = None
         try:
             user_entry = pwd.getpwnam(user)
-        except (KeyError, OSError):
+        except (KeyError, EnvironmentError):
             pass
         uid_min = None
         try:
             uid_min = int(ext_utils.get_line_starting_with("UID_MIN", "/etc/login.defs").split()[1])
-        except (ValueError, KeyError, AttributeError, OSError):
+        except (ValueError, KeyError, AttributeError, EnvironmentError):
             pass
         if uid_min is None:
             uid_min = 100
@@ -193,7 +193,7 @@ class GenericDistro(object):
             else:
                 ext_utils.set_file_contents("/etc/sudoers.d/waagent", user + " ALL = (ALL) ALL\n")
             os.chmod("/etc/sudoers.d/waagent", 0o440)
-        except OSError:
+        except EnvironmentError:
             logger.error("CreateAccount: Failed to configure sudo access for user.")
             return "Failed to configure sudo privileges (0x08)."
         home = self.get_home()
@@ -220,7 +220,7 @@ class GenericDistro(object):
         user_entry = None
         try:
             user_entry = pwd.getpwnam(user)
-        except (KeyError, OSError):
+        except (KeyError, EnvironmentError):
             pass
         if user_entry is None:
             logger.error("DeleteAccount: " + user + " not found.")
@@ -228,7 +228,7 @@ class GenericDistro(object):
         uid_min = None
         try:
             uid_min = int(ext_utils.get_line_starting_with("UID_MIN", "/etc/login.defs").split()[1])
-        except (ValueError, KeyError, AttributeError, OSError):
+        except (ValueError, KeyError, AttributeError, EnvironmentError):
             pass
         if uid_min is None:
             uid_min = 100
@@ -240,7 +240,7 @@ class GenericDistro(object):
         ext_utils.run(['userdel', '-f', '-r', user])
         try:
             os.remove("/etc/sudoers.d/waagent")
-        except OSError:
+        except EnvironmentError:
             pass
         return
 
@@ -274,13 +274,13 @@ class FreeBSDDistro(GenericDistro):
         userentry = None
         try:
             userentry = pwd.getpwnam(user)
-        except (OSError, KeyError):
+        except (EnvironmentError, KeyError):
             pass
         uidmin = None
         try:
             if os.path.isfile("/etc/login.defs"):
                 uidmin = int(ext_utils.get_line_starting_with("UID_MIN", "/etc/login.defs").split()[1])
-        except (ValueError, KeyError, AttributeError, OSError):
+        except (ValueError, KeyError, AttributeError, EnvironmentError):
             pass
             pass
         if uidmin is None:
@@ -318,7 +318,7 @@ class FreeBSDDistro(GenericDistro):
             else:
                 ext_utils.set_file_contents(self.sudoers_dir_base + "/sudoers.d/waagent", user + " ALL = (ALL) ALL\n")
             os.chmod(self.sudoers_dir_base + "/sudoers.d/waagent", 0o440)
-        except (ValueError, KeyError, AttributeError, OSError):
+        except (ValueError, KeyError, AttributeError, EnvironmentError):
             logger.error("CreateAccount: Failed to configure sudo access for user.")
             return "Failed to configure sudo privileges (0x08)."
         home = self.get_home()
@@ -349,7 +349,7 @@ class FreeBSDDistro(GenericDistro):
         userentry = None
         try:
             userentry = pwd.getpwnam(user)
-        except (OSError, KeyError):
+        except (EnvironmentError, KeyError):
             pass
         if userentry is None:
             logger.error("DeleteAccount: " + user + " not found.")
@@ -359,7 +359,7 @@ class FreeBSDDistro(GenericDistro):
             if os.path.isfile("/etc/login.defs"):
                 uidmin = int(
                     ext_utils.get_line_starting_with("UID_MIN", "/etc/login.defs").split()[1])
-        except (ValueError, KeyError, AttributeError, OSError):
+        except (ValueError, KeyError, AttributeError, EnvironmentError):
             pass
         if uidmin is None:
             uidmin = 100
@@ -372,7 +372,7 @@ class FreeBSDDistro(GenericDistro):
         ext_utils.run(['rmuser', '-y', user], chk_err=False)
         try:
             os.remove(self.sudoers_dir_base + "/sudoers.d/waagent")
-        except OSError:
+        except EnvironmentError:
             pass
         return
 
@@ -417,12 +417,12 @@ class CoreOSDistro(GenericDistro):
         userentry = None
         try:
             userentry = pwd.getpwnam(user)
-        except (OSError, KeyError):
+        except (EnvironmentError, KeyError):
             pass
         uidmin = None
         try:
             uidmin = int(ext_utils.get_line_starting_with("UID_MIN", "/etc/login.defs").split()[1])
-        except (ValueError, KeyError, AttributeError, OSError):
+        except (ValueError, KeyError, AttributeError, EnvironmentError):
             pass
         if uidmin is None:
             uidmin = 100
@@ -447,7 +447,7 @@ class CoreOSDistro(GenericDistro):
             else:
                 ext_utils.set_file_contents("/etc/sudoers.d/waagent", user + " ALL = (ALL) ALL\n")
             os.chmod("/etc/sudoers.d/waagent", 0o440)
-        except OSError:
+        except EnvironmentError:
             logger.error("CreateAccount: Failed to configure sudo access for user.")
             return "Failed to configure sudo privileges (0x08)."
         home = self.get_home()

--- a/Utils/extensionutils.py
+++ b/Utils/extensionutils.py
@@ -48,7 +48,7 @@ def change_owner(file_path, user):
     p = None
     try:
         p = pwd.getpwnam(user)
-    except (KeyError, OSError):
+    except (KeyError, EnvironmentError):
         pass
     if p is not None:
         os.chown(file_path, p[2], p[3])
@@ -61,7 +61,7 @@ def create_dir(dir_path, user, mode):
     """
     try:
         os.makedirs(dir_path, mode)
-    except OSError:
+    except EnvironmentError:
         pass
     change_owner(dir_path, user)
 
@@ -75,7 +75,7 @@ def set_file_contents(file_path, contents):
     try:
         with open(file_path, "wb+") as F:
             F.write(contents)
-    except OSError as e:
+    except EnvironmentError as e:
         logger.error_with_prefix(
             'SetFileContents', 'Writing to file ' + file_path + ' Exception is ' + str(e))
         return None
@@ -94,7 +94,7 @@ def append_file_contents(file_path, contents):
     try:
         with open(file_path, "a+") as F:
             F.write(contents)
-    except OSError as e:
+    except EnvironmentError as e:
         logger.error_with_prefix(
             'AppendFileContents', 'Appending to file ' + file_path + ' Exception is ' + str(e))
         return None
@@ -112,7 +112,7 @@ def get_file_contents(file_path, as_bin=False):
         with open(file_path, mode) as F:
             contents = F.read()
             return contents
-    except OSError as e:
+    except EnvironmentError as e:
         logger.error_with_prefix(
             'GetFileContents', 'Reading from file ' + file_path + ' Exception is ' + str(e))
         return None
@@ -127,7 +127,7 @@ def replace_file_with_contents_atomic(filepath, contents):
         contents = contents.encode('latin-1')
     try:
         os.write(handle, contents)
-    except OSError as e:
+    except EnvironmentError as e:
         logger.error_with_prefix(
             'ReplaceFileContentsAtomic', 'Writing to file ' + filepath + ' Exception is ' + str(e))
         return None
@@ -136,18 +136,18 @@ def replace_file_with_contents_atomic(filepath, contents):
     try:
         os.rename(temp, filepath)
         return None
-    except OSError as e:
+    except EnvironmentError as e:
         logger.error_with_prefix(
             'ReplaceFileContentsAtomic', 'Renaming ' + temp + ' to ' + filepath + ' Exception is ' + str(e)
         )
     try:
         os.remove(filepath)
-    except OSError as e:
+    except EnvironmentError as e:
         logger.error_with_prefix(
             'ReplaceFileContentsAtomic', 'Removing ' + filepath + ' Exception is ' + str(e))
     try:
         os.rename(temp, filepath)
-    except OSError as e:
+    except EnvironmentError as e:
         logger.error_with_prefix(
             'ReplaceFileContentsAtomic', 'Removing ' + filepath + ' Exception is ' + str(e))
         return 1
@@ -159,7 +159,7 @@ def run_command_and_write_stdout_to_file(command, output_file):
     try:
         p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=False)
         stdout, stderr = p.communicate()
-    except OSError as e:
+    except EnvironmentError as e:
         logger.error('CalledProcessError.  Error message is ' + str(e))
         return e.errno
     if p.returncode != 0:
@@ -189,7 +189,7 @@ def run_command_get_output(cmd, chk_err=True, log_cmd=True):
             logger.error(
                 'CalledProcessError.  Command result was ' + (e.output[:-1]).decode('latin-1'))
         return e.returncode, e.output.decode('latin-1')
-    except OSError as e:
+    except EnvironmentError as e:
         if chk_err and log_cmd:
             logger.error(
                 'CalledProcessError.  Error message is ' + str(e))
@@ -223,7 +223,7 @@ def run_send_stdin(cmd, cmd_input, chk_err=True, log_cmd=True):
         me = subprocess.Popen(cmd, shell=False, stdin=subprocess.PIPE, stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
         output = me.communicate(cmd_input)
         subprocess_executed = True
-    except OSError as e:
+    except EnvironmentError as e:
         if chk_err and log_cmd:
             logger.error('CalledProcessError.  Error Code is ' + str(e.errno))
             logger.error('CalledProcessError.  Command was ' + str(cmd))
@@ -346,5 +346,5 @@ def add_extension_event(name, op, is_success, duration=0, version="1.0", message
     event.ExtensionType = extension_type
     try:
         event.save()
-    except OSError:
+    except EnvironmentError:
         logger.error("Error " + traceback.format_exc())

--- a/VMAccess/manifest.xml
+++ b/VMAccess/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.OSTCExtensions</ProviderNameSpace>
   <Type>VMAccessForLinux</Type>
-  <Version>1.5.7</Version>
+  <Version>1.5.8</Version>
   <Label>Microsoft Azure VM Access Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>

--- a/VMAccess/vmaccess.py
+++ b/VMAccess/vmaccess.py
@@ -229,7 +229,7 @@ def _set_user_account_pub_key(protect_settings, hutil):
     try:
         ovf_xml = ext_utils.get_file_contents('/var/lib/waagent/ovf-env.xml')
         ovf_env = ovf_utils.OvfEnv.parse(ovf_xml, Configuration)
-    except (OSError, ValueError, KeyError, AttributeError):
+    except (EnvironmentError, ValueError, KeyError, AttributeError):
         pass
     if ovf_xml is None or ovf_env is None:
         # default ovf_env with empty data


### PR DESCRIPTION
IOError is an alias for OSError in python3, the code was written with that expectation. They don't overlap in python 2.
Changed all OSError to EnvironmentError to fix the issue.

EnvironmentError is the parent class for OSError and IOError in python 2. In python 3 IOError and EnvironmentError are both aliases to OSError.