### PR TITLE
`sshd_config` Backup Permission Preservation

### DIFF
--- a/VMAccess/manifest.xml
+++ b/VMAccess/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.OSTCExtensions</ProviderNameSpace>
   <Type>VMAccessForLinux</Type>
-  <Version>1.5.8</Version>
+  <Version>1.5.9</Version>
   <Label>Microsoft Azure VM Access Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>

--- a/VMAccess/vmaccess.py
+++ b/VMAccess/vmaccess.py
@@ -447,7 +447,10 @@ def _backup_sshd_config(sshd_file_path):
     if os.path.exists(sshd_file_path):
         backup_file_name = '%s_%s' % (
             sshd_file_path, time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()))
-        shutil.copyfile(sshd_file_path, backup_file_name)
+        # When copying, make sure to preserve permissions and ownership.
+        ownership = os.stat(sshd_file_path)
+        shutil.copy2(sshd_file_path, backup_file_name)
+        os.chown(backup_file_name, ownership.st_uid, ownership.st_gid)
 
 
 def _save_cert_str_as_file(cert_txt, file_name):


### PR DESCRIPTION
The following PR proposes a change to how backups of `sshd_config` are performed. Specifically, the following is being done:

* `copy2` is being leveraged in order to preserve original ownership and file metadata.
* An additional `chown` is being performed to make sure that the original owner and group are preserved.

The method `_backup_sshd_config` is called in a couple of cases: resetting the SSH configuration, or changing any user's password. In particular, this was being triggered while updating a user via the Azure CLI (`az vm user update ...`). The way current backups are being performed with `copyfile` does preserve the _contents_ of the configuration, however it doesn't preserve any specific permissions made to the configuration. In the cases of some OS configurations (e.g. CentOS 7) where the configuration is "for `root`'s eyes only" (permission set `600`), these configuration backups lose this permission set, and given that `/etc/ssh` can be accessed by non-root users this causes the configuration backups to be accessible by non-root users as well.