### PR TITLE
Removing older metrics config during onboarding

### DIFF
--- a/LAD-AMA-Common/metrics_ext_utils/metrics_ext_handler.py
+++ b/LAD-AMA-Common/metrics_ext_utils/metrics_ext_handler.py
@@ -19,7 +19,7 @@
 import urllib2
 import json
 import os
-from shutil import copyfile
+from shutil import copyfile, rmtree
 import stat
 import filecmp
 import metrics_ext_utils.metrics_constants as metrics_constants
@@ -570,8 +570,11 @@ def setup_me(is_lad):
     #write configs to disk
     logFolder, configFolder = get_handler_vars()
     me_config_dir = configFolder + "/metrics_configs/"
-    if not os.path.exists(me_config_dir):
-        os.mkdir(me_config_dir)
+
+    # Clear older config directory if exists. 
+    if os.path.exists(me_config_dir):
+        rmtree(me_config_dir)    
+    os.mkdir(me_config_dir)
 
 
     me_conf_path = me_config_dir + "MetricsExtensionV1_Configuration.json"

--- a/LAD-AMA-Common/telegraf_utils/telegraf_config_handler.py
+++ b/LAD-AMA-Common/telegraf_utils/telegraf_config_handler.py
@@ -22,7 +22,7 @@ from telegraf_utils.telegraf_name_map import name_map
 import subprocess
 import signal
 import urllib2
-from shutil import copyfile
+from shutil import copyfile, rmtree
 import time
 import metrics_ext_utils.metrics_constants as metrics_constants
 import metrics_ext_utils.metrics_common_utils as metrics_utils
@@ -361,12 +361,13 @@ def write_configs(configs, telegraf_conf_dir, telegraf_d_conf_dir):
     :param telegraf_conf_dir: Path where the telegraf.conf is written to on the disk
     :param telegraf_d_conf_dir: Path where the individual module telegraf configs are written to on the disk
     """
+    # Delete the older config folder to prevent telegraf from loading older configs
+    if os.path.exists(telegraf_conf_dir):
+        rmtree(telegraf_conf_dir)
 
-    if not os.path.exists(telegraf_conf_dir):
-        os.mkdir(telegraf_conf_dir)
+    os.mkdir(telegraf_conf_dir)
 
-    if not os.path.exists(telegraf_d_conf_dir):
-        os.mkdir(telegraf_d_conf_dir)
+    os.mkdir(telegraf_d_conf_dir)
 
     for configfile in configs:
         if configfile["filename"] == "telegraf.conf" or configfile["filename"] == "intermediate.json":


### PR DESCRIPTION
The current metrics code overwrites the existing config files (which are individually written per module) but doesn't clear them prior to onboarding. Due to this, in the edge case where cx removes every field of a particular module (mem, cpu, net etc), the config parser doesn't create a config for that module and thus the older config file for that module doesn't get cleared and telegraf reads them. **Telegraf does filter out these additional modules while sending data to mdsd but sends all of the modules (old and new) to ME. This change fixes that issue.**

Tests - 
Tested this alongside LAD 4.0 tests in all supported distros. This code is shared between AMA and LAD so the tests are sufficient coverage for both. 

Note: This doesn't happen when the cx removes only some of the counters of a module because then the config file is actually overwritten by the new config for that module.