### PR TITLE
Adding Resource disk validation for encryptFormatAll

### DIFF
--- a/VMEncryption/main/ResourceDiskUtil.py
+++ b/VMEncryption/main/ResourceDiskUtil.py
@@ -61,6 +61,11 @@ class ResourceDiskUtil(object):
         cmd = 'cryptsetup isLuks ' + self.RD_DEV_PATH
         return (int)(self.executor.Execute(cmd, suppress_logging=True)) == CommonVariables.process_success
 
+    def _resource_disk_exists(self):
+        """ true if udev name for resource disk exists """
+        cmd = 'test -b ' + self.RD_BASE_DEV_PATH
+        return (int)(self.executor.Execute(cmd, suppress_logging=True)) == CommonVariables.process_success
+
     def _resource_disk_partition_exists(self):
         """ true if udev name for resource disk partition exists """
         cmd = 'test -b ' + self.RD_DEV_PATH

--- a/VMEncryption/main/ResourceDiskUtil.py
+++ b/VMEncryption/main/ResourceDiskUtil.py
@@ -64,7 +64,11 @@ class ResourceDiskUtil(object):
     def _resource_disk_exists(self):
         """ true if udev name for resource disk exists """
         cmd = 'test -b ' + self.RD_BASE_DEV_PATH
-        return (int)(self.executor.Execute(cmd, suppress_logging=True)) == CommonVariables.process_success
+        if (int)(self.executor.Execute(cmd, suppress_logging=True)) == CommonVariables.process_success:
+            self.logger.log("Resource disk exists.")
+            return True
+        self.logger.log("Resource disk does not exist.")
+        return False
 
     def _resource_disk_partition_exists(self):
         """ true if udev name for resource disk partition exists """
@@ -285,21 +289,21 @@ class ResourceDiskUtil(object):
             f.writelines(lines)
 
     def encrypt_format_mount(self):
-        if not self.prepare():
-            self.logger.log("Failed to prepare VM for Resource Disk Encryption", CommonVariables.ErrorLevel)
-            return False
-        if not self._encrypt():
-            self.logger.log("Failed to encrypt Resource Disk Encryption", CommonVariables.ErrorLevel)
-            return False
-        if not self._format_encrypted_partition():
-            self.logger.log("Failed to format the encrypted Resource Disk Encryption", CommonVariables.ErrorLevel)
-            return False
-        if not self._mount_resource_disk(self.RD_MAPPER_PATH):
-            self.logger.log("Failed to mount after formatting and encrypting the Resource Disk Encryption", CommonVariables.ErrorLevel)
-            return False
-        # We haven't failed so far, lets just add the RD to crypttab
-        self.add_resource_disk_to_crypttab()
-            
+        if self._resource_disk_exists():
+            if not self.prepare():
+                self.logger.log("Failed to prepare VM for Resource Disk Encryption", CommonVariables.ErrorLevel)
+                return False
+            if not self._encrypt():
+                self.logger.log("Failed to encrypt Resource Disk Encryption", CommonVariables.ErrorLevel)
+                return False
+            if not self._format_encrypted_partition():
+                self.logger.log("Failed to format the encrypted Resource Disk Encryption", CommonVariables.ErrorLevel)
+                return False
+            if not self._mount_resource_disk(self.RD_MAPPER_PATH):
+                self.logger.log("Failed to mount after formatting and encrypting the Resource Disk Encryption", CommonVariables.ErrorLevel)
+                return False
+            # We haven't failed so far, lets just add the RD to crypttab
+            self.add_resource_disk_to_crypttab()
         return True
 
     def add_resource_disk_to_crypttab(self):

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -927,7 +927,7 @@ def enable_encryption():
                                           code=str(CommonVariables.configuration_error),
                                           message='Failed to encrypt resource disk. Please make sure no process is using it.')
                         else:
-                            logger.log("Resource disk is present or encrypted successfully.")
+                            logger.log("Resource disk is not present or encrypted successfully.")
                 encryption_marker = mark_encryption(command=extension_parameter.command,
                                                     volume_type=extension_parameter.VolumeType,
                                                     disk_format_query=extension_parameter.DiskFormatQuery)

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -918,20 +918,16 @@ def enable_encryption():
                         passphrase_file = bek_util.get_bek_passphrase_file(encryption_config)
                         crypt_mount_config_util = CryptMountConfigUtil(logger=logger, encryption_environment=encryption_environment, disk_util=disk_util)
                         resource_disk_util = ResourceDiskUtil(logger, disk_util, crypt_mount_config_util, passphrase_file, get_public_settings(), DistroPatcher.distro_info)
-                        if resource_disk_util._resource_disk_exists():
-                            rd_encrypted = resource_disk_util.encrypt_resource_disk()
-                            if not rd_encrypted:
-                                hutil.save_seq()
-                                hutil.do_exit(exit_code=CommonVariables.configuration_error,
-                                              operation='EnableEncryption',
-                                              status=CommonVariables.extension_error_status,
-                                              code=str(CommonVariables.configuration_error),
-                                              message='Failed to encrypt resource disk. Please make sure no process is using it.')
-                            else:
-                                logger.log("Resource disk encrypted successfully.")
+                        rd_encrypted = resource_disk_util.encrypt_resource_disk()
+                        if not rd_encrypted:
+                            hutil.save_seq()
+                            hutil.do_exit(exit_code=CommonVariables.configuration_error,
+                                          operation='EnableEncryption',
+                                          status=CommonVariables.extension_error_status,
+                                          code=str(CommonVariables.configuration_error),
+                                          message='Failed to encrypt resource disk. Please make sure no process is using it.')
                         else:
-                            logger.log("Resource disk does not exist. Skipping encryption for Resource disk.")
-
+                            logger.log("Resource disk is present or encrypted successfully.")
                 encryption_marker = mark_encryption(command=extension_parameter.command,
                                                     volume_type=extension_parameter.VolumeType,
                                                     disk_format_query=extension_parameter.DiskFormatQuery)

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -918,16 +918,19 @@ def enable_encryption():
                         passphrase_file = bek_util.get_bek_passphrase_file(encryption_config)
                         crypt_mount_config_util = CryptMountConfigUtil(logger=logger, encryption_environment=encryption_environment, disk_util=disk_util)
                         resource_disk_util = ResourceDiskUtil(logger, disk_util, crypt_mount_config_util, passphrase_file, get_public_settings(), DistroPatcher.distro_info)
-                        rd_encrypted = resource_disk_util.encrypt_resource_disk()
-                        if not rd_encrypted:
-                            hutil.save_seq()
-                            hutil.do_exit(exit_code=CommonVariables.configuration_error,
-                                          operation='EnableEncryption',
-                                          status=CommonVariables.extension_error_status,
-                                          code=str(CommonVariables.configuration_error),
-                                          message='Failed to encrypt resource disk. Please make sure no process is using it.')
+                        if resource_disk_util._resource_disk_exists():
+                            rd_encrypted = resource_disk_util.encrypt_resource_disk()
+                            if not rd_encrypted:
+                                hutil.save_seq()
+                                hutil.do_exit(exit_code=CommonVariables.configuration_error,
+                                              operation='EnableEncryption',
+                                              status=CommonVariables.extension_error_status,
+                                              code=str(CommonVariables.configuration_error),
+                                              message='Failed to encrypt resource disk. Please make sure no process is using it.')
+                            else:
+                                logger.log("Resource disk encrypted successfully.")
                         else:
-                            logger.log("Resource disk encrypted successfully.")
+                            logger.log("Resource disk does not exist. Skipping encryption for Resource disk.")
 
                 encryption_marker = mark_encryption(command=extension_parameter.command,
                                                     volume_type=extension_parameter.VolumeType,

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -927,7 +927,7 @@ def enable_encryption():
                                           code=str(CommonVariables.configuration_error),
                                           message='Failed to encrypt resource disk. Please make sure no process is using it.')
                         else:
-                            logger.log("Resource disk is not present or encrypted successfully.")
+                            logger.log("Resource Disk is either absent or encrypted successfully.")
                 encryption_marker = mark_encryption(command=extension_parameter.command,
                                                     volume_type=extension_parameter.VolumeType,
                                                     disk_format_query=extension_parameter.DiskFormatQuery)

--- a/VMEncryption/main/test/test_resource_disk_util.py
+++ b/VMEncryption/main/test/test_resource_disk_util.py
@@ -232,3 +232,15 @@ class TestResourceDiskUtil(unittest.TestCase):
         mock_icm.return_value = False
         rd_mounted = self.resource_disk.encrypt_resource_disk()
         self.assertFalse(rd_mounted)
+
+    @mock.patch('ResourceDiskUtil.ResourceDiskUtil._resource_disk_exists', return_value=True)
+    @mock.patch('ResourceDiskUtil.ResourceDiskUtil.prepare')
+    def test_encrypt_format_mount_resource_disk_exists(self, mock_prepare, mock_resource_disk_exists):
+        self.resource_disk.encrypt_format_mount()
+        self.assertEqual(mock_prepare.call_count, 1)
+
+    @mock.patch('ResourceDiskUtil.ResourceDiskUtil._resource_disk_exists', return_value=False)
+    @mock.patch('ResourceDiskUtil.ResourceDiskUtil.prepare')
+    def test_encrypt_format_mount_resource_disk_does_not_exist(self, mock_prepare, mock_resource_disk_exists):
+        self.assertEqual(self.resource_disk.encrypt_format_mount(), True)
+        self.assertEqual(mock_prepare.call_count, 0)


### PR DESCRIPTION
This PR includes:

Verification of Resource disk existence prior enabling encryption on resource disk when using EncryptFormatAll. The encryptFormatAll operation used to fail as there was no check to verify whether resource disk exists before the encryption operation.