### PR TITLE
AMA python2/3 interoperability 

### DIFF
--- a/AzureMonitorAgent/HandlerManifest.json
+++ b/AzureMonitorAgent/HandlerManifest.json
@@ -3,14 +3,15 @@
     "name":  "AzureMonitorLinuxAgent",
     "version": "1.5.124",
     "handlerManifest": {
-      "installCommand": "agent.py -install",
-      "uninstallCommand": "agent.py -uninstall",
-      "updateCommand": "agent.py -update",
-      "enableCommand": "agent.py -enable",
-      "disableCommand": "agent.py -disable",
+      "installCommand": "shim.sh -install",
+      "uninstallCommand": "shim.sh -uninstall",
+      "updateCommand": "shim.sh -update",
+      "enableCommand": "shim.sh -enable",
+      "disableCommand": "shim.sh -disable",
       "rebootAfterInstall": false,
       "reportHeartbeat": false,
-      "updateMode": "UpdateWithInstall"
+      "updateMode": "UpdateWithInstall",
+      "continueOnUpdateFailure": "true"
     }
   }
 ]

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -17,11 +17,16 @@
 # limitations under the License.
 
 from __future__ import print_function
-from __future__ import division
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str
-from past.utils import old_div
+import sys
+# future imports have no effect on python 3 (verified in official docs)
+# importing from source causes import errors on python 3, lets skip import
+if sys.version_info[0] < 3:
+    from __future__ import division
+    from future import standard_library
+    standard_library.install_aliases()
+    from builtins import str
+    from past.utils import old_div
+
 import os
 import os.path
 import datetime
@@ -31,7 +36,6 @@ import grp
 import re
 import filecmp
 import stat
-import sys
 import traceback
 import time
 import platform
@@ -197,7 +201,7 @@ def get_free_space_mb(dirname):
     Get the free space in MB in the directory path.
     """
     st = os.statvfs(dirname)
-    return old_div(old_div(st.f_bavail * st.f_frsize, 1024), 1024)
+    return (st.f_bavail * st.f_frsize) // (1024 * 1024)
 
 
 def is_systemd():
@@ -518,7 +522,7 @@ def start_metrics_process():
     
     #start telemetry watcher
     oneagent_filepath = os.path.join(os.getcwd(),'agent.py')
-    args = ['python', oneagent_filepath, '-metrics']
+    args = ['python{0}'.format(sys.version_info[0]), oneagent_filepath, '-metrics']
     log = open(os.path.join(os.getcwd(), 'daemon.log'), 'w')
     HUtilObject.log('start watcher process '+str(args))
     subprocess.Popen(args, stdout=log, stderr=log)
@@ -714,7 +718,7 @@ def start_arc_process():
     
     #start telemetry watcher
     oneagent_filepath = os.path.join(os.getcwd(),'agent.py')
-    args = ['python', oneagent_filepath, '-arc']
+    args = ['python{0}'.format(sys.version_info[0]), oneagent_filepath, '-arc']
     log = open(os.path.join(os.getcwd(), 'daemon.log'), 'w')
     HUtilObject.log('start watcher process '+str(args))
     subprocess.Popen(args, stdout=log, stderr=log)
@@ -901,9 +905,9 @@ def is_vm_supported_for_extension(operation):
     The supported distros of the AzureMonitorLinuxAgent are allowed to utilize
     this VM extension. All other distros will get error code 51
     """
-    supported_dists = {'redhat' : ['6', '7'], # CentOS
+    supported_dists = {'redhat' : ['6', '7', '8'], # Rhel
                        'centos' : ['6', '7'], # CentOS
-                       'red hat' : ['6', '7'], # Oracle, RHEL
+                       'red hat' : ['6', '7', '8'], # Oracle, RHEL
                        'oracle' : ['6', '7'], # Oracle
                        'debian' : ['8', '9'], # Debian
                        'ubuntu' : ['14.04', '16.04', '18.04'], # Ubuntu

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -905,6 +905,7 @@ def find_vm_distro(operation):
     Finds the Linux Distribution this vm is running on. 
     """
     vm_dist = vm_id = vm_ver =  None
+    parse_manually = False
     try:
         vm_dist, vm_ver, vm_id = platform.linux_distribution()
     except AttributeError:

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -586,29 +586,29 @@ def metrics_watcher(hutil_error, hutil_log):
                             #Stop the telegraf and ME services
                             tel_out, tel_msg = telhandler.stop_telegraf_service(is_lad=False)
                             if tel_out:
-                                hutil_log_info(tel_msg)
+                                hutil_log(tel_msg)
                             else:
-                                hutil_log_error(tel_msg)
+                                hutil_error(tel_msg)
 
                             #Delete the telegraf and ME services
                             tel_rm_out, tel_rm_msg = telhandler.remove_telegraf_service()
                             if tel_rm_out:
-                                hutil_log_info(tel_rm_msg)
+                                hutil_log(tel_rm_msg)
                             else:
-                                hutil_log_error(tel_rm_msg)
+                                hutil_error(tel_rm_msg)
 
                         if me_handler.is_running(is_lad=False):
                             me_out, me_msg = me_handler.stop_metrics_service(is_lad=False)
                             if me_out:
-                                hutil_log_info(me_msg)
+                                hutil_log(me_msg)
                             else:
-                                hutil_log_error(me_msg)
+                                hutil_error(me_msg)
 
                             me_rm_out, me_rm_msg = me_handler.remove_metrics_service(is_lad=False)
                             if me_rm_out:
-                                hutil_log_info(me_rm_msg)
+                                hutil_log(me_rm_msg)
                             else:
-                                hutil_log_error(me_rm_msg)
+                                hutil_error(me_rm_msg)
                     else:
                         crc = hashlib.sha256(data.encode('utf-8')).hexdigest()                    
 
@@ -1324,7 +1324,7 @@ def run_get_output(cmd, chk_err = False, log_cmd = True):
 
     # On python 3, encode returns a byte object, so we must decode back to a string
     if sys.version_info >= (3,):
-        output = output.decode()
+        output = output.decode('utf-8')
 
     return exit_code, output.strip()
 

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -949,10 +949,10 @@ def is_vm_supported_for_extension(operation):
     this VM extension. All other distros will get error code 51
     """
     supported_dists = {'redhat' : ['6', '7', '8'], # Rhel
-                       'centos' : ['6', '7'], # CentOS
+                       'centos' : ['6', '7', '8'], # CentOS
                        'red hat' : ['6', '7', '8'], # Oracle, RHEL
-                       'oracle' : ['6', '7'], # Oracle
-                       'debian' : ['8', '9'], # Debian
+                       'oracle' : ['6', '7', '8'], # Oracle
+                       'debian' : ['8', '9', '10'], # Debian
                        'ubuntu' : ['14.04', '16.04', '18.04', '20.04'], # Ubuntu
                        'suse' : ['12'], 'sles' : ['15'] # SLES
     }
@@ -1324,7 +1324,7 @@ def run_get_output(cmd, chk_err = False, log_cmd = True):
 
     # On python 3, encode returns a byte object, so we must decode back to a string
     if sys.version_info >= (3,):
-        output = output.decode('utf-8')
+        output = output.decode('utf-8', 'ignore')
 
     return exit_code, output.strip()
 

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -17,6 +17,11 @@
 # limitations under the License.
 
 from __future__ import print_function
+from __future__ import division
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from past.utils import old_div
 import os
 import os.path
 import datetime
@@ -34,8 +39,8 @@ import subprocess
 import json
 import base64
 import inspect
-import urllib
-import urllib2
+import urllib.request, urllib.parse, urllib.error
+import urllib.request, urllib.error, urllib.parse
 import shutil
 import crypt
 import xml.dom.minidom
@@ -192,7 +197,7 @@ def get_free_space_mb(dirname):
     Get the free space in MB in the directory path.
     """
     st = os.statvfs(dirname)
-    return st.f_bavail * st.f_frsize / 1024 / 1024
+    return old_div(old_div(st.f_bavail * st.f_frsize, 1024), 1024)
 
 
 def is_systemd():
@@ -248,7 +253,7 @@ def install():
         default_configs["ENABLE_MCS"] = "true"
     else:
         # look for LA protected settings
-        for var in protected_settings.keys():
+        for var in list(protected_settings.keys()):
             if "_key" in var or "_id" in var:
                 default_configs[var] = protected_settings.get(var)
         
@@ -330,14 +335,14 @@ def install():
             with open(config_file, "r") as f:
                 data = f.readlines()
                 for line in data:
-                    for var in default_configs.keys():
+                    for var in list(default_configs.keys()):
                         if var in line:
                             line = "export " + var + "=" + default_configs[var] + "\n"
                             vars_set.add(var)
                             break
                     new_data += line
             
-            for var in default_configs.keys():
+            for var in list(default_configs.keys()):
                 if var not in vars_set:
                     new_data += "export " + var + "=" + default_configs[var] + "\n"
 
@@ -790,8 +795,8 @@ def arc_watcher(hutil_error, hutil_log):
             arc_endpoint = metrics_utils.get_arc_endpoint()
             try:
                 msiauthurl = arc_endpoint + "/metadata/identity/oauth2/token?api-version=2019-11-01&resource=https://monitor.azure.com/"
-                req = urllib2.Request(msiauthurl, headers={'Metadata':'true'})
-                res = urllib2.urlopen(req)
+                req = urllib.request.Request(msiauthurl, headers={'Metadata':'true'})
+                res = urllib.request.urlopen(req)
             except:
                 # The above request is expected to fail and add a key to the path - 
                 authkey_dir = "/var/opt/azcmagent/tokens/"
@@ -908,7 +913,7 @@ def is_vm_supported_for_extension(operation):
     vm_supported = False
     vm_dist, vm_ver = find_vm_distro(operation)
     # Find this VM distribution in the supported list
-    for supported_dist in supported_dists.keys():
+    for supported_dist in list(supported_dists.keys()):
         if not vm_dist.lower().startswith(supported_dist):
             continue
 

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -42,7 +42,6 @@ import json
 import base64
 import inspect
 import urllib.request, urllib.parse, urllib.error
-import urllib.request, urllib.error, urllib.parse
 import shutil
 import crypt
 import xml.dom.minidom

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -612,6 +612,8 @@ def metrics_watcher(hutil_error, hutil_log):
                         crc = hashlib.sha256(data.encode('utf-8')).hexdigest()                    
 
                         if(crc != last_crc):
+                            # Resetting the me_msi_token_expiry_epoch variable if we set up ME again.
+                            me_msi_token_expiry_epoch = None
                             hutil_log("Start processing metric configuration")
                             hutil_log(data)
 

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
 import os
 import os.path
 import datetime
@@ -216,7 +217,7 @@ def install():
     package_directory = os.path.join(os.getcwd(), PackagesDirectory)
     bundle_path = os.path.join(package_directory, BundleFileName)
     os.chmod(bundle_path, 100)
-    print (PackageManager, " and ", BundleFileName)
+    print(PackageManager, " and ", BundleFileName)
     OneAgentInstallCommand = "{0} -i {1}".format(PackageManager, bundle_path)        
     hutil_log_info('Running command "{0}"'.format(OneAgentInstallCommand))
 
@@ -253,35 +254,35 @@ def install():
         
         # check if required GCS params are available
         MONITORING_GCS_CERT_CERTFILE = None
-        if protected_settings.has_key("certificate"):
+        if "certificate" in protected_settings:
             MONITORING_GCS_CERT_CERTFILE = base64.standard_b64decode(protected_settings.get("certificate"))
 
         MONITORING_GCS_CERT_KEYFILE = None
-        if protected_settings.has_key("certificateKey"):
+        if "certificateKey" in protected_settings:
             MONITORING_GCS_CERT_KEYFILE = base64.standard_b64decode(protected_settings.get("certificateKey"))
 
         MONITORING_GCS_ENVIRONMENT = ""
-        if protected_settings.has_key("monitoringGCSEnvironment"):
+        if "monitoringGCSEnvironment" in protected_settings:
             MONITORING_GCS_ENVIRONMENT = protected_settings.get("monitoringGCSEnvironment")
 
         MONITORING_GCS_NAMESPACE = ""
-        if protected_settings.has_key("namespace"):
+        if "namespace" in protected_settings:
             MONITORING_GCS_NAMESPACE = protected_settings.get("namespace")
 
         MONITORING_GCS_ACCOUNT = ""
-        if protected_settings.has_key("monitoringGCSAccount"):
+        if "monitoringGCSAccount" in protected_settings:
             MONITORING_GCS_ACCOUNT = protected_settings.get("monitoringGCSAccount")
 
         MONITORING_GCS_REGION = ""
-        if protected_settings.has_key("monitoringGCSRegion"):
+        if "monitoringGCSRegion" in protected_settings:
             MONITORING_GCS_REGION = protected_settings.get("monitoringGCSRegion")
 
         MONITORING_CONFIG_VERSION = ""
-        if protected_settings.has_key("configVersion"):
+        if "configVersion" in protected_settings:
             MONITORING_CONFIG_VERSION = protected_settings.get("configVersion")
 
         MONITORING_GCS_AUTH_ID_TYPE = ""
-        if protected_settings.has_key("MONITORING_GCS_AUTH_ID_TYPE"):
+        if "MONITORING_GCS_AUTH_ID_TYPE" in protected_settings:
             MONITORING_GCS_AUTH_ID_TYPE = protected_settings.get("MONITORING_GCS_AUTH_ID_TYPE")
 
         if ((MONITORING_GCS_CERT_CERTFILE is None or MONITORING_GCS_CERT_KEYFILE is None) and (MONITORING_GCS_AUTH_ID_TYPE is "")) or MONITORING_GCS_ENVIRONMENT is "" or MONITORING_GCS_NAMESPACE is "" or MONITORING_GCS_ACCOUNT is "" or MONITORING_GCS_REGION is "" or MONITORING_CONFIG_VERSION is "":
@@ -799,7 +800,7 @@ def arc_watcher(hutil_error, hutil_log):
                 # Copy the tokens to mdsd accessible dir
                 for filename in os.listdir(authkey_dir):
                     filepath = authkey_dir + filename
-                    print filepath
+                    print(filepath)
                     shutil.copy(filepath, arc_token_mdsd_dir)
                 
                 # Change the ownership of the mdsd arc token dir to be accessible by syslog (since mdsd runs as syslog user)
@@ -1097,8 +1098,8 @@ def get_settings():
             hutil_log_error('Unable to load handler settings from ' \
                             '{0}'.format(settings_path))
 
-        if (h_settings.has_key('protectedSettings')
-                and h_settings.has_key('protectedSettingsCertThumbprint')
+        if ('protectedSettings' in h_settings
+                and 'protectedSettingsCertThumbprint' in h_settings
                 and h_settings['protectedSettings'] is not None
                 and h_settings['protectedSettingsCertThumbprint'] is not None):
             encoded_settings = h_settings['protectedSettings']

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -886,7 +886,7 @@ def find_package_manager(operation):
     dist, ver = find_vm_distro(operation)
 
     dpkg_set = set(["debian", "ubuntu"])
-    rpm_set = set(["oracle", "redhat", "centos", "red hat", "suse"])
+    rpm_set = set(["oracle", "redhat", "centos", "red hat", "suse", "sles"])
     for dpkg_dist in dpkg_set:
         if dist.lower().startswith(dpkg_dist):
             PackageManager = "dpkg"

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -511,27 +511,27 @@ def stop_metrics_process():
         if tel_out:
             hutil_log_info(tel_msg)
         else:
-            HUtilObject.error(tel_msg)
+            hutil_log_error(tel_msg)
         
         #Delete the telegraf and ME services
         tel_rm_out, tel_rm_msg = telhandler.remove_telegraf_service()
         if tel_rm_out:
             hutil_log_info(tel_rm_msg)
         else:
-            HUtilObject.error(tel_rm_msg)
+            hutil_log_error(tel_rm_msg)
     
     if me_handler.is_running(is_lad=False):
         me_out, me_msg = me_handler.stop_metrics_service(is_lad=False)
         if me_out:
             hutil_log_info(me_msg)
         else:
-            HUtilObject.error(me_msg)
+            hutil_log_error(me_msg)
 
         me_rm_out, me_rm_msg = me_handler.remove_metrics_service(is_lad=False)
         if me_rm_out:
             hutil_log_info(me_rm_msg)
         else:
-            HUtilObject.error(me_rm_msg)
+            hutil_log_error(me_rm_msg)
 
     pids_filepath = os.path.join(os.getcwd(),'amametrics.pid')
 
@@ -588,27 +588,27 @@ def metrics_watcher(hutil_error, hutil_log):
                             if tel_out:
                                 hutil_log_info(tel_msg)
                             else:
-                                HUtilObject.error(tel_msg)
+                                hutil_log_error(tel_msg)
 
                             #Delete the telegraf and ME services
                             tel_rm_out, tel_rm_msg = telhandler.remove_telegraf_service()
                             if tel_rm_out:
                                 hutil_log_info(tel_rm_msg)
                             else:
-                                HUtilObject.error(tel_rm_msg)
+                                hutil_log_error(tel_rm_msg)
 
                         if me_handler.is_running(is_lad=False):
                             me_out, me_msg = me_handler.stop_metrics_service(is_lad=False)
                             if me_out:
                                 hutil_log_info(me_msg)
                             else:
-                                HUtilObject.error(me_msg)
+                                hutil_log_error(me_msg)
 
                             me_rm_out, me_rm_msg = me_handler.remove_metrics_service(is_lad=False)
                             if me_rm_out:
                                 hutil_log_info(me_rm_msg)
                             else:
-                                HUtilObject.error(me_rm_msg)
+                                hutil_log_error(me_rm_msg)
                     else:
                         crc = hashlib.sha256(data.encode('utf-8')).hexdigest()                    
 
@@ -733,7 +733,7 @@ def metrics():
     with open(pids_filepath, 'w') as f:
         f.write(str(py_pid) + '\n')
 
-    watcher_thread = Thread(target = metrics_watcher, args = [HUtilObject.error, HUtilObject.log])
+    watcher_thread = Thread(target = metrics_watcher, args = [hutil_log_error, hutil_log_info])
     watcher_thread.start()
     watcher_thread.join()
 
@@ -770,7 +770,7 @@ def start_arc_watcher():
         f.write(str(py_pid) + '\n')
     hutil_log_info("Written all the pids")
     print("Written all the pids")
-    watcher_thread = Thread(target = arc_watcher, args = [HUtilObject.error, HUtilObject.log])
+    watcher_thread = Thread(target = arc_watcher, args = [hutil_log_error, hutil_log_info])
     watcher_thread.start()
     watcher_thread.join()
 

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -550,7 +550,7 @@ def metrics_watcher(hutil_error, hutil_log):
                     json_data = json.loads(data)  
                     
                     if len(json_data) == 0:
-                        last_crc = hashlib.sha256(data).hexdigest()                    
+                        last_crc = hashlib.sha256(data.encode('utf-8')).hexdigest()                    
                         if telhandler.is_running(is_lad=False):
                             #Stop the telegraf and ME services
                             tel_out, tel_msg = telhandler.stop_telegraf_service(is_lad=False)
@@ -579,7 +579,7 @@ def metrics_watcher(hutil_error, hutil_log):
                             else:
                                 HUtilObject.error(me_rm_msg)
                     else:
-                        crc = hashlib.sha256(data).hexdigest()                    
+                        crc = hashlib.sha256(data.encode('utf-8')).hexdigest()                    
                         generate_token = False
                         me_token_path = os.path.join(os.getcwd(), "/config/metrics_configs/AuthToken-MSI.json")
 

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -95,6 +95,7 @@ if sys.version_info < (2,7):
             return "Command '%s' returned non-zero exit status %d" % (self.cmd, self.returncode)
 
     subprocess.check_output = check_output
+    subprocess.CalledProcessError = CalledProcessError
 
 # Global Variables
 PackagesDirectory = 'packages'

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -119,6 +119,7 @@ DisableOneAgentServiceCommand = ''
 DPKGLockedErrorCode = 56
 MissingorInvalidParameterErrorCode = 53
 UnsupportedOperatingSystem = 51
+IndeterminateOperatingSystem = 51
 
 # Configuration
 HUtilObject = None
@@ -934,7 +935,7 @@ def find_vm_distro(operation):
                         vm_ver = line.split('=')[1]
                         vm_ver = vm_ver.replace('\"', '').replace('\n', '')
         except:
-            log_and_exit(operation, UndeterminateOperatingSystem, 'Undeterminate operating system')
+            log_and_exit(operation, IndeterminateOperatingSystem, 'Indeterminate operating system')
     return vm_dist, vm_ver
 
 
@@ -979,7 +980,7 @@ def is_vm_supported_for_extension(operation):
                 except IndexError:
                     vm_ver_match = False
                     break
-                if vm_ver_num is not supported_ver_num:
+                if vm_ver_num != supported_ver_num:
                     vm_ver_match = False
                     break
             if vm_ver_match:

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -972,7 +972,7 @@ def run_command_and_log(cmd, check_error = True, log_cmd = True):
     """
     exit_code, output = run_get_output(cmd, check_error, log_cmd)
     if log_cmd:
-        hutil_log_info('Output of command "{0}": \n{1}'.format(cmd, output))
+        hutil_log_info('Output of command "{0}": \n{1}'.format(cmd.rstrip(), output))
     else:
         hutil_log_info('Output: \n{0}'.format(output))
         
@@ -1276,8 +1276,14 @@ def run_get_output(cmd, chk_err = False, log_cmd = True):
         except subprocess.CalledProcessError as e:
             exit_code = e.returncode
             output = e.output
+    
+    output = output.encode('utf-8')
 
-    return exit_code, output.encode('utf-8').strip()
+    # On python 3, encode returns a byte object, so we must decode back to a string
+    if sys.version_info >= (3,):
+        output = output.decode()
+
+    return exit_code, output.strip()
 
 
 def init_waagent_logger():

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -101,8 +101,8 @@ if sys.version_info < (2,7):
 PackagesDirectory = 'packages'
 # TO BE CHANGED WITH EACH NEW RELEASE IF THE BUNDLE VERSION CHANGES
 # TODO: Installer should automatically figure this out from the folder instead of requiring this update
-BundleFileNameDeb = 'azure-mdsd_1.5.124-build.master.89_x86_64.deb'
-BundleFileNameRpm = 'azure-mdsd_1.5.124-build.master.89_x86_64.rpm'
+BundleFileNameDeb = 'azure-mdsd_1.5.133-build.master.157_x86_64.deb'
+BundleFileNameRpm = 'azure-mdsd_1.5.133-build.master.157_x86_64.rpm'
 BundleFileName = ''
 TelegrafBinName = 'telegraf'
 InitialRetrySleepSeconds = 30
@@ -912,8 +912,14 @@ def find_vm_distro(operation):
             vm_dist, vm_ver, vm_id = platform.dist()
         except AttributeError:
             hutil_log_info("Falling back to /etc/os-release distribution parsing")
+    # Some python versions *IF BUILT LOCALLY* (ex 3.5) give string responses (ex. 'bullseye/sid') to platform.dist() function
+    # This causes exception in the method below. Thus adding a check to switch to manual parsing in this case 
+    try:
+        temp_vm_ver = int(vm_ver.split('.')[0])
+    except:
+        parse_manually = True
 
-    if not vm_dist and not vm_ver: # SLES 15 and others
+    if (not vm_dist and not vm_ver) or parse_manually: # SLES 15 and others
         try:
             with open('/etc/os-release', 'r') as fp:
                 for line in fp:
@@ -923,7 +929,6 @@ def find_vm_distro(operation):
                         vm_dist = vm_dist.replace('\"', '').replace('\n', '')
                     elif line.startswith('VERSION_ID='):
                         vm_ver = line.split('=')[1]
-                        vm_ver = vm_ver.split('.')[0]
                         vm_ver = vm_ver.replace('\"', '').replace('\n', '')
         except:
             log_and_exit(operation, UndeterminateOperatingSystem, 'Undeterminate operating system')
@@ -944,7 +949,7 @@ def is_vm_supported_for_extension(operation):
                        'red hat' : ['6', '7', '8'], # Oracle, RHEL
                        'oracle' : ['6', '7'], # Oracle
                        'debian' : ['8', '9'], # Debian
-                       'ubuntu' : ['14.04', '16.04', '18.04'], # Ubuntu
+                       'ubuntu' : ['14.04', '16.04', '18.04', '20.04'], # Ubuntu
                        'suse' : ['12'], 'sles' : ['15'] # SLES
     }
 

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -580,6 +580,34 @@ def metrics_watcher(hutil_error, hutil_log):
                                 HUtilObject.error(me_rm_msg)
                     else:
                         crc = hashlib.sha256(data.encode('utf-8')).hexdigest()                    
+
+                        if(crc != last_crc):
+                            hutil_log("Start processing metric configuration")
+                            hutil_log(data)
+
+                            telegraf_config, telegraf_namespaces = telhandler.handle_config(
+                                json_data, 
+                                "udp://127.0.0.1:" + metrics_constants.ama_metrics_extension_udp_port, 
+                                "unix:///var/run/mdsd/default_influx.socket",
+                                is_lad=False)
+
+                            me_handler.setup_me(is_lad=False)
+
+                            start_telegraf_out, log_messages = telhandler.start_telegraf(is_lad=False)
+                            if start_telegraf_out:
+                                hutil_log("Successfully started metrics-sourcer.")
+                            else:
+                                hutil_error(log_messages)
+
+
+                            start_metrics_out, log_messages = me_handler.start_metrics(is_lad=False)
+                            if start_metrics_out:
+                                hutil_log("Successfully started metrics-extension.")
+                            else:
+                                hutil_error(log_messages)
+
+                            last_crc = crc
+                        
                         generate_token = False
                         me_token_path = os.path.join(os.getcwd(), "/config/metrics_configs/AuthToken-MSI.json")
 
@@ -608,33 +636,6 @@ def metrics_watcher(hutil_error, hutil_log):
                                 hutil_log("Successfully refreshed metrics-extension MSI Auth token.")
                             else:
                                 hutil_error(log_messages)
-
-                        if(crc != last_crc):
-                            hutil_log("Start processing metric configuration")
-                            hutil_log(data)
-
-                            telegraf_config, telegraf_namespaces = telhandler.handle_config(
-                                json_data, 
-                                "udp://127.0.0.1:" + metrics_constants.ama_metrics_extension_udp_port, 
-                                "unix:///var/run/mdsd/default_influx.socket",
-                                is_lad=False)
-
-                            me_handler.setup_me(is_lad=False)
-
-                            start_telegraf_out, log_messages = telhandler.start_telegraf(is_lad=False)
-                            if start_telegraf_out:
-                                hutil_log("Successfully started metrics-sourcer.")
-                            else:
-                                hutil_error(log_messages)
-
-
-                            start_metrics_out, log_messages = me_handler.start_metrics(is_lad=False)
-                            if start_metrics_out:
-                                hutil_log("Successfully started metrics-extension.")
-                            else:
-                                hutil_error(log_messages)
-
-                            last_crc = crc
 
                         telegraf_restart_retries = 0
                         me_restart_retries = 0

--- a/AzureMonitorAgent/packaging.sh
+++ b/AzureMonitorAgent/packaging.sh
@@ -33,12 +33,15 @@ cp -r  ../LAD-AMA-Common/telegraf_utils .
 cp -r  ../Diagnostic/services .
 
 # cleanup packages, ext
-rm -rf packages MetricsExtensionBin
-mkdir -p packages MetricsExtensionBin
+rm -rf packages MetricsExtensionBin ext/future
+mkdir -p packages MetricsExtensionBin ext/future
 
 # copy shell bundle to packages/
 cp $input_path/azure-mdsd_$AGENT_VERSION* packages/
 cp $input_path/MetricsExtension MetricsExtensionBin/
+
+# copy just the source of python-future
+cp -r ext/python-future/src/* ext/future
 
 # sync the file copy
 sync
@@ -50,7 +53,7 @@ fi
 
 echo "Packaging extension $PACKAGE_NAME to $output_path"
 excluded_files="agent.version packaging.sh apply_version.sh update_version.sh"
-zip -r $output_path/$PACKAGE_NAME * -x $excluded_files "./test/*" "./extension-test/*" "./references"
+zip -r $output_path/$PACKAGE_NAME * -x $excluded_files "./test/*" "./extension-test/*" "./references" "./ext/python-future/*"
 
 # cleanup newly added dir or files
 rm -rf Utils/ waagent

--- a/AzureMonitorAgent/shim.sh
+++ b/AzureMonitorAgent/shim.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# This is the main driver file for AMA extension. This file first checks if Python 2 or 3 is available on the VM 
+# This is the main driver file for AMA extension. This file first checks if Python 3 or 2 is available on the VM 
 # and if yes then uses that Python (if both are available then, default is set to python3) to run extension operations in agent.py
 # Control arguments passed to the shim are redirected to agent.py without validation.
 
@@ -13,12 +13,12 @@ function find_python() {
     local python_exec_command=$1
     local future_path=$2
 
-    if command -v python2 >/dev/null 2>&1 ; then
-        eval ${python_exec_command}="python2"
-        eval ${future_path}="${PWD}/ext/future:"
-    elif command -v python3 >/dev/null 2>&1 ; then
+    if command -v python3 >/dev/null 2>&1 ; then
         eval ${python_exec_command}="python3"
         # do not set future_path; future seems to cause interference with preexisting packages in python 3 environment
+    elif command -v python2 >/dev/null 2>&1 ; then
+        eval ${python_exec_command}="python2"
+        eval ${future_path}="${PWD}/ext/future:"
     fi
 }
 
@@ -26,7 +26,7 @@ find_python PYTHON FUTURE_PATH
 
 if [ -z "$PYTHON" ] # If python is not installed, we will fail the install with the following error, requiring cx to have python pre-installed
 then
-    echo "No Python interpreter found, which is an AMA extension dependency. Please install either Python 2 or 3." >&2
+    echo "No Python interpreter found, which is an AMA extension dependency. Please install Python 3, or Python 2 if the former is unavailable." >&2
     exit 52 # Missing Dependency
 else
     ${PYTHON} --version

--- a/AzureMonitorAgent/shim.sh
+++ b/AzureMonitorAgent/shim.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# This is the main driver file for AMA extension. This file first checks if Python 2 or 3 is available on the VM 
+# and if yes then uses that Python (if both are available then, default is set to python3) to run extension operations in agent.py
+# Control arguments passed to the shim are redirected to omsagent.py without validation.
+
+COMMAND="./agent.py"
+PYTHON=""
+FUTURE_PATH=""
+ARG="$@"
+
+function find_python() {
+    local python_exec_command=$1
+    local future_path=$2
+
+    if command -v python2 >/dev/null 2>&1 ; then
+        eval ${python_exec_command}="python2"
+        eval ${future_path}="${PWD}/ext/future:"
+    elif command -v python3 >/dev/null 2>&1 ; then
+        eval ${python_exec_command}="python3"
+        # do not set future_path; future seems to cause interference with preexisting packages in python 3 environment
+    fi
+}
+
+find_python PYTHON FUTURE_PATH
+
+if [ -z "$PYTHON" ] # Need to discuss if we want to install python explicitly or ask the cx to install it
+then
+    echo "No Python interpreter found, which is an OMS extension dependency. Please install either Python 2 or 3." >&2
+    exit 52 # Missing Dependency
+else
+    ${PYTHON} --version
+fi
+
+PYTHONPATH=${FUTURE_PATH}${PYTHONPATH} ${PYTHON} ${COMMAND} ${ARG}
+exit $?

--- a/AzureMonitorAgent/shim.sh
+++ b/AzureMonitorAgent/shim.sh
@@ -24,7 +24,7 @@ function find_python() {
 
 find_python PYTHON FUTURE_PATH
 
-if [ -z "$PYTHON" ] # Need to discuss if we want to install python explicitly or ask the cx to install it
+if [ -z "$PYTHON" ] # If python is not installed, we will fail the install with the following error, requiring cx to have python pre-installed
 then
     echo "No Python interpreter found, which is an AMA extension dependency. Please install either Python 2 or 3." >&2
     exit 52 # Missing Dependency

--- a/AzureMonitorAgent/shim.sh
+++ b/AzureMonitorAgent/shim.sh
@@ -2,7 +2,7 @@
 
 # This is the main driver file for AMA extension. This file first checks if Python 2 or 3 is available on the VM 
 # and if yes then uses that Python (if both are available then, default is set to python3) to run extension operations in agent.py
-# Control arguments passed to the shim are redirected to omsagent.py without validation.
+# Control arguments passed to the shim are redirected to agent.py without validation.
 
 COMMAND="./agent.py"
 PYTHON=""
@@ -26,7 +26,7 @@ find_python PYTHON FUTURE_PATH
 
 if [ -z "$PYTHON" ] # Need to discuss if we want to install python explicitly or ask the cx to install it
 then
-    echo "No Python interpreter found, which is an OMS extension dependency. Please install either Python 2 or 3." >&2
+    echo "No Python interpreter found, which is an AMA extension dependency. Please install either Python 2 or 3." >&2
     exit 52 # Missing Dependency
 else
     ${PYTHON} --version

--- a/LAD-AMA-Common/metrics_ext_utils/metrics_ext_handler.py
+++ b/LAD-AMA-Common/metrics_ext_utils/metrics_ext_handler.py
@@ -570,7 +570,15 @@ def setup_me(is_lad):
     amrurl = "https://management.azure.com/subscriptions/" + subscription_id + "?api-version=2014-04-01"
     try:
         req = urllib.request.Request(amrurl, headers={'Content-Type':'application/json'})
-        res = urllib.request.urlopen(req)
+
+        # urlopen alias in future backport is broken on py2.6, fails on urls with HTTPS - https://github.com/PythonCharmers/python-future/issues/167
+        # Using this hack of switching between py2 and 3 to avoid this
+        if sys.version_info < (2,7):
+            from urllib2 import HTTPError, Request, urlopen
+            urlopen(req)
+        else:
+            res = urllib.request.urlopen(req)
+
     except Exception as e:
         err_res = e.headers["WWW-Authenticate"]
         for line in err_res.split(","):

--- a/LAD-AMA-Common/metrics_ext_utils/metrics_ext_handler.py
+++ b/LAD-AMA-Common/metrics_ext_utils/metrics_ext_handler.py
@@ -16,7 +16,10 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import urllib2
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+import urllib.request, urllib.error, urllib.parse
 import json
 import os
 from shutil import copyfile, rmtree
@@ -143,8 +146,8 @@ def generate_Arc_MSI_token():
             arc_endpoint = metrics_utils.get_arc_endpoint()
             try:
                 msiauthurl = arc_endpoint + "/metadata/identity/oauth2/token?api-version=2019-11-01&resource=https://management.azure.com/"
-                req = urllib2.Request(msiauthurl, headers={'Metadata':'true'})
-                res = urllib2.urlopen(req)
+                req = urllib.request.Request(msiauthurl, headers={'Metadata':'true'})
+                res = urllib.request.urlopen(req)
             except:
                 # The above request is expected to fail and add a key to the path - 
                 authkey_dir = "/var/opt/azcmagent/tokens/"
@@ -160,8 +163,8 @@ def generate_Arc_MSI_token():
                 with open(authkey_path, "r") as f:
                     key = f.read()
                 auth += key
-                req = urllib2.Request(msiauthurl, headers={'Metadata':'true', 'authorization':auth})
-                res = urllib2.urlopen(req)
+                req = urllib.request.Request(msiauthurl, headers={'Metadata':'true', 'authorization':auth})
+                res = urllib.request.urlopen(req)
                 data = json.loads(res.read())
 
             if not data or "access_token" not in data:
@@ -218,8 +221,8 @@ def generate_MSI_token():
             data = None
             while retries <= max_retries:
                 msiauthurl = "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://ingestion.monitor.azure.com/"
-                req = urllib2.Request(msiauthurl, headers={'Metadata':'true', 'Content-Type':'application/json'})
-                res = urllib2.urlopen(req)
+                req = urllib.request.Request(msiauthurl, headers={'Metadata':'true', 'Content-Type':'application/json'})
+                res = urllib.request.urlopen(req)
                 data = json.loads(res.read())
 
                 if not data or "access_token" not in data:
@@ -495,8 +498,8 @@ def get_imds_values(is_lad):
     while retries <= max_retries:
 
         #query imds to get the required information
-        req = urllib2.Request(imdsurl, headers={'Metadata':'true'})
-        res = urllib2.urlopen(req)
+        req = urllib.request.Request(imdsurl, headers={'Metadata':'true'})
+        res = urllib.request.urlopen(req)
         data = json.loads(res.read())
 
         if "compute" not in data:
@@ -561,8 +564,8 @@ def setup_me(is_lad):
     aad_auth_url = ""
     amrurl = "https://management.azure.com/subscriptions/" + subscription_id + "?api-version=2014-04-01"
     try:
-        req = urllib2.Request(amrurl, headers={'Content-Type':'application/json'})
-        res = urllib2.urlopen(req)
+        req = urllib.request.Request(amrurl, headers={'Content-Type':'application/json'})
+        res = urllib.request.urlopen(req)
     except Exception as e:
         err_res = e.headers["WWW-Authenticate"]
         for line in err_res.split(","):

--- a/LAD-AMA-Common/metrics_ext_utils/metrics_ext_handler.py
+++ b/LAD-AMA-Common/metrics_ext_utils/metrics_ext_handler.py
@@ -16,9 +16,14 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str
+# future imports have no effect on python 3 (verified in official docs)
+# importing from source causes import errors on python 3, lets skip import
+import sys
+if sys.version_info[0] < 3:
+    from future import standard_library
+    standard_library.install_aliases()
+    from builtins import str
+    
 import urllib.request, urllib.error, urllib.parse
 import json
 import os
@@ -44,7 +49,7 @@ def is_running(is_lad):
 
     proc = subprocess.Popen(["ps  aux | grep MetricsExtension | grep -v grep"], stdout=subprocess.PIPE, shell=True)
     output = proc.communicate()[0]
-    if metrics_bin in output:
+    if metrics_bin in output.decode():
         return True
     else:
         return False
@@ -89,7 +94,7 @@ def stop_metrics_service(is_lad):
                 # Check if the process running is indeed MetricsExtension, ignore if the process output doesn't contain MetricsExtension
                 proc = subprocess.Popen(["ps -o cmd= {0}".format(pid)], stdout=subprocess.PIPE, shell=True)
                 output = proc.communicate()[0]
-                if metrics_ext_bin in output:
+                if metrics_ext_bin in output.decode():
                     os.kill(int(pid), signal.SIGKILL)
                 else:
                     return False, "Found a different process running with PID {0}. Failed to stop MetricsExtension.".format(pid)

--- a/LAD-AMA-Common/metrics_ext_utils/metrics_ext_handler.py
+++ b/LAD-AMA-Common/metrics_ext_utils/metrics_ext_handler.py
@@ -49,7 +49,7 @@ def is_running(is_lad):
 
     proc = subprocess.Popen(["ps  aux | grep MetricsExtension | grep -v grep"], stdout=subprocess.PIPE, shell=True)
     output = proc.communicate()[0]
-    if metrics_bin in output.decode('utf-8'):
+    if metrics_bin in output.decode('utf-8', 'ignore'):
         return True
     else:
         return False
@@ -94,7 +94,7 @@ def stop_metrics_service(is_lad):
                 # Check if the process running is indeed MetricsExtension, ignore if the process output doesn't contain MetricsExtension
                 proc = subprocess.Popen(["ps -o cmd= {0}".format(pid)], stdout=subprocess.PIPE, shell=True)
                 output = proc.communicate()[0]
-                if metrics_ext_bin in output.decode('utf-8'):
+                if metrics_ext_bin in output.decode('utf-8', 'ignore'):
                     os.kill(int(pid), signal.SIGKILL)
                 else:
                     return False, "Found a different process running with PID {0}. Failed to stop MetricsExtension.".format(pid)
@@ -170,7 +170,7 @@ def generate_Arc_MSI_token():
                 auth += key
                 req = urllib.request.Request(msiauthurl, headers={'Metadata':'true', 'authorization':auth})
                 res = urllib.request.urlopen(req)
-                data = json.loads(res.read().decode('utf-8'))
+                data = json.loads(res.read().decode('utf-8', 'ignore'))
 
             if not data or "access_token" not in data:
                 retries += 1
@@ -228,7 +228,7 @@ def generate_MSI_token():
                 msiauthurl = "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://ingestion.monitor.azure.com/"
                 req = urllib.request.Request(msiauthurl, headers={'Metadata':'true', 'Content-Type':'application/json'})
                 res = urllib.request.urlopen(req)
-                data = json.loads(res.read().decode('utf-8'))
+                data = json.loads(res.read().decode('utf-8', 'ignore'))
 
                 if not data or "access_token" not in data:
                     retries += 1
@@ -505,7 +505,7 @@ def get_imds_values(is_lad):
         #query imds to get the required information
         req = urllib.request.Request(imdsurl, headers={'Metadata':'true'})
         res = urllib.request.urlopen(req)
-        data = json.loads(res.read().decode('utf-8'))
+        data = json.loads(res.read().decode('utf-8', 'ignore'))
 
         if "compute" not in data:
             retries += 1

--- a/LAD-AMA-Common/metrics_ext_utils/metrics_ext_handler.py
+++ b/LAD-AMA-Common/metrics_ext_utils/metrics_ext_handler.py
@@ -170,7 +170,7 @@ def generate_Arc_MSI_token():
                 auth += key
                 req = urllib.request.Request(msiauthurl, headers={'Metadata':'true', 'authorization':auth})
                 res = urllib.request.urlopen(req)
-                data = json.loads(res.read())
+                data = json.loads(res.read().decode('utf-8'))
 
             if not data or "access_token" not in data:
                 retries += 1
@@ -228,7 +228,7 @@ def generate_MSI_token():
                 msiauthurl = "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://ingestion.monitor.azure.com/"
                 req = urllib.request.Request(msiauthurl, headers={'Metadata':'true', 'Content-Type':'application/json'})
                 res = urllib.request.urlopen(req)
-                data = json.loads(res.read())
+                data = json.loads(res.read().decode('utf-8'))
 
                 if not data or "access_token" not in data:
                     retries += 1
@@ -505,7 +505,7 @@ def get_imds_values(is_lad):
         #query imds to get the required information
         req = urllib.request.Request(imdsurl, headers={'Metadata':'true'})
         res = urllib.request.urlopen(req)
-        data = json.loads(res.read())
+        data = json.loads(res.read().decode('utf-8'))
 
         if "compute" not in data:
             retries += 1

--- a/LAD-AMA-Common/metrics_ext_utils/metrics_ext_handler.py
+++ b/LAD-AMA-Common/metrics_ext_utils/metrics_ext_handler.py
@@ -49,7 +49,7 @@ def is_running(is_lad):
 
     proc = subprocess.Popen(["ps  aux | grep MetricsExtension | grep -v grep"], stdout=subprocess.PIPE, shell=True)
     output = proc.communicate()[0]
-    if metrics_bin in output.decode():
+    if metrics_bin in output.decode('utf-8'):
         return True
     else:
         return False
@@ -94,7 +94,7 @@ def stop_metrics_service(is_lad):
                 # Check if the process running is indeed MetricsExtension, ignore if the process output doesn't contain MetricsExtension
                 proc = subprocess.Popen(["ps -o cmd= {0}".format(pid)], stdout=subprocess.PIPE, shell=True)
                 output = proc.communicate()[0]
-                if metrics_ext_bin in output.decode():
+                if metrics_ext_bin in output.decode('utf-8'):
                     os.kill(int(pid), signal.SIGKILL)
                 else:
                     return False, "Found a different process running with PID {0}. Failed to stop MetricsExtension.".format(pid)

--- a/LAD-AMA-Common/telegraf_utils/telegraf_config_handler.py
+++ b/LAD-AMA-Common/telegraf_utils/telegraf_config_handler.py
@@ -16,9 +16,14 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str
+# future imports have no effect on python 3 (verified in official docs)
+# importing from source causes import errors on python 3, lets skip import
+import sys
+if sys.version_info[0] < 3:
+    from future import standard_library
+    standard_library.install_aliases()
+    from builtins import str
+
 import json
 import os
 from telegraf_utils.telegraf_name_map import name_map
@@ -441,7 +446,7 @@ def is_running(is_lad):
 
     proc = subprocess.Popen(["ps  aux | grep telegraf | grep -v grep"], stdout=subprocess.PIPE, shell=True)
     output = proc.communicate()[0]
-    if telegraf_bin in output:
+    if telegraf_bin in output.decode():
         return True
     else:
         return False
@@ -484,7 +489,7 @@ def stop_telegraf_service(is_lad):
                 # Check if the process running is indeed telegraf, ignore if the process output doesn't contain telegraf
                 proc = subprocess.Popen(["ps -o cmd= {0}".format(pid)], stdout=subprocess.PIPE, shell=True)
                 output = proc.communicate()[0]
-                if telegraf_bin in output:
+                if telegraf_bin in output.decode():
                     os.kill(int(pid), signal.SIGKILL)
                 else:
                     return False, "Found a different process running with PID {0}. Failed to stop telegraf.".format(pid)

--- a/LAD-AMA-Common/telegraf_utils/telegraf_config_handler.py
+++ b/LAD-AMA-Common/telegraf_utils/telegraf_config_handler.py
@@ -446,7 +446,7 @@ def is_running(is_lad):
 
     proc = subprocess.Popen(["ps  aux | grep telegraf | grep -v grep"], stdout=subprocess.PIPE, shell=True)
     output = proc.communicate()[0]
-    if telegraf_bin in output.decode('utf-8'):
+    if telegraf_bin in output.decode('utf-8', 'ignore'):
         return True
     else:
         return False
@@ -489,7 +489,7 @@ def stop_telegraf_service(is_lad):
                 # Check if the process running is indeed telegraf, ignore if the process output doesn't contain telegraf
                 proc = subprocess.Popen(["ps -o cmd= {0}".format(pid)], stdout=subprocess.PIPE, shell=True)
                 output = proc.communicate()[0]
-                if telegraf_bin in output.decode('utf-8'):
+                if telegraf_bin in output.decode('utf-8', 'ignore'):
                     os.kill(int(pid), signal.SIGKILL)
                 else:
                     return False, "Found a different process running with PID {0}. Failed to stop telegraf.".format(pid)
@@ -662,7 +662,7 @@ def handle_config(config_data, me_url, mdsd_url, is_lad):
 
         req = urllib.request.Request(imdsurl, headers={'Metadata':'true'})
         res = urllib.request.urlopen(req)
-        data = json.loads(res.read().decode('utf-8'))
+        data = json.loads(res.read().decode('utf-8', 'ignore'))
 
         if "compute" not in data:
             retries += 1

--- a/LAD-AMA-Common/telegraf_utils/telegraf_config_handler.py
+++ b/LAD-AMA-Common/telegraf_utils/telegraf_config_handler.py
@@ -446,7 +446,7 @@ def is_running(is_lad):
 
     proc = subprocess.Popen(["ps  aux | grep telegraf | grep -v grep"], stdout=subprocess.PIPE, shell=True)
     output = proc.communicate()[0]
-    if telegraf_bin in output.decode():
+    if telegraf_bin in output.decode('utf-8'):
         return True
     else:
         return False
@@ -489,7 +489,7 @@ def stop_telegraf_service(is_lad):
                 # Check if the process running is indeed telegraf, ignore if the process output doesn't contain telegraf
                 proc = subprocess.Popen(["ps -o cmd= {0}".format(pid)], stdout=subprocess.PIPE, shell=True)
                 output = proc.communicate()[0]
-                if telegraf_bin in output.decode():
+                if telegraf_bin in output.decode('utf-8'):
                     os.kill(int(pid), signal.SIGKILL)
                 else:
                     return False, "Found a different process running with PID {0}. Failed to stop telegraf.".format(pid)

--- a/LAD-AMA-Common/telegraf_utils/telegraf_config_handler.py
+++ b/LAD-AMA-Common/telegraf_utils/telegraf_config_handler.py
@@ -662,7 +662,7 @@ def handle_config(config_data, me_url, mdsd_url, is_lad):
 
         req = urllib.request.Request(imdsurl, headers={'Metadata':'true'})
         res = urllib.request.urlopen(req)
-        data = json.loads(res.read())
+        data = json.loads(res.read().decode('utf-8'))
 
         if "compute" not in data:
             retries += 1

--- a/LAD-AMA-Common/telegraf_utils/telegraf_config_handler.py
+++ b/LAD-AMA-Common/telegraf_utils/telegraf_config_handler.py
@@ -16,12 +16,15 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
 import json
 import os
 from telegraf_utils.telegraf_name_map import name_map
 import subprocess
 import signal
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 from shutil import copyfile, rmtree
 import time
 import metrics_ext_utils.metrics_constants as metrics_constants
@@ -652,8 +655,8 @@ def handle_config(config_data, me_url, mdsd_url, is_lad):
     data = None
     while retries <= max_retries:
 
-        req = urllib2.Request(imdsurl, headers={'Metadata':'true'})
-        res = urllib2.urlopen(req)
+        req = urllib.request.Request(imdsurl, headers={'Metadata':'true'})
+        res = urllib.request.urlopen(req)
         data = json.loads(res.read())
 
         if "compute" not in data:


### PR DESCRIPTION
1) Followed the steps listed by Henry in his OMS py2/3 PR - #1012 . Initially followed the [guide ](https://sebastianraschka.com/Articles/2014_python_2_3_key_diff.html#integer-division) and using the [futurize tool](https://python-future.org/automatic_conversion.html).  
2) Manually fixed quite a few issues that couldn't be ported with automation. 
3) Re-used OMSAgent's shim file for interoping with py2/3. Currently we are not installing python if it isnt there. 
4) Added python-future as a submodule and using it in the shim file during agent.py's execution
5) Also added the continueOnUpdateFailure flag in Handlermanifest.json file to make the extension installation process more stable (that flag allows waagent to override faulty installations when they're stuck in update-disable loop and can't be updated or removed)
6) Added the subprocess monkey-patch #1114 from OMSAgent's fix
7) Replaced HutilObject.log with hutil_log_info method that has additional None check 
8) Added future submodule in extension packaging logic

Creating the PR now to make the review process easy/streamlined

Things left to do - 
- Test on all the distros in our support matrix and add them in the code as supported once individually verified. 
- Test with diff py versions on RHEL/Ubuntu