### PR TITLE
Setting default udp payload value for influxdb output

### DIFF
--- a/LAD-AMA-Common/telegraf_utils/telegraf_config_handler.py
+++ b/LAD-AMA-Common/telegraf_utils/telegraf_config_handler.py
@@ -363,10 +363,11 @@ def parse_config(data, me_url, mdsd_url, is_lad, az_resource_id, subscription_id
     if is_lad:
         agentconf += "  fielddrop = [" + excess_diskio_field_drop_list_str[:-2] + "]\n"
     agentconf += "  urls = [\"" + str(me_url) + "\"]\n\n"
+    agentconf += "  udp_payload = \"1024B\"\n\n"
     agentconf += "\n# Configuration for sending metrics to MDSD\n"
     agentconf += "[[outputs.socket_writer]]\n"
     agentconf += "  namepass = [" + storage_namepass_str[:-2] + "]\n"
-    agentconf += "  data_format = \"influx\"\n\n"
+    agentconf += "  data_format = \"influx\"\n"
     agentconf += "  address = \"" + str(mdsd_url) + "\"\n\n"
     agentconf += "\n# Configuration for outputing metrics to file. Uncomment to enable.\n"
     agentconf += "#[[outputs.file]]\n"


### PR DESCRIPTION
We saw an issue where telegraf's influxdb output plugin was logging error logs due to the event size increasing the default value of upd payload (512B).

The suggested solution in telegraf's github issues is to increase the udp_payload parameter for influxdb output  - https://github.com/influxdata/telegraf/issues/6622

Went on a call with the cx and tested with increasing the udp_payload value to 1024B which resolved the issue. 