### PR TITLE
Moving general lad sinks config back to protected from public. 

### DIFF
--- a/Diagnostic/diagnostic.py
+++ b/Diagnostic/diagnostic.py
@@ -239,7 +239,7 @@ def create_core_components_configs():
     ladconfig = configurator._ladCfg()
     sinks = LadUtil.getFeatureWideSinksFromLadCfg(ladconfig, 'performanceCounters')
     for name in sinks:
-        sink = configurator._sink_configs.get_sink_by_name(name)
+        sink = configurator._sink_configs_public.get_sink_by_name(name)
         if sink is not None:
             if sink['name'] == 'AzMonSink':
                 enable_metrics_ext = True

--- a/Diagnostic/diagnostic.py
+++ b/Diagnostic/diagnostic.py
@@ -237,7 +237,6 @@ def create_core_components_configs():
 
     global enable_metrics_ext
     ladconfig = configurator._ladCfg()
-    sinks = LadUtil.getFeatureWideSinksFromLadCfg(ladconfig, 'performanceCounters')
     sink = configurator._sink_configs_public.get_sink_by_name("AzMonSink")
     if sink is not None:
         if sink['name'] == 'AzMonSink':

--- a/Diagnostic/diagnostic.py
+++ b/Diagnostic/diagnostic.py
@@ -238,11 +238,10 @@ def create_core_components_configs():
     global enable_metrics_ext
     ladconfig = configurator._ladCfg()
     sinks = LadUtil.getFeatureWideSinksFromLadCfg(ladconfig, 'performanceCounters')
-    for name in sinks:
-        sink = configurator._sink_configs_public.get_sink_by_name(name)
-        if sink is not None:
-            if sink['name'] == 'AzMonSink':
-                enable_metrics_ext = True
+    sink = configurator._sink_configs_public.get_sink_by_name("AzMonSink")
+    if sink is not None:
+        if sink['name'] == 'AzMonSink':
+            enable_metrics_ext = True
 
     return configurator
 


### PR DESCRIPTION
The portal UI team needs to have AzMonSink config in public. So we had moved the entire sinks config from protected to public. But a better design approach is to only move AzMonSink config in public as the other sinks config can have urls and secrets that are better left in protected. 