### PR TITLE
mdsd default run dir during config validation

### DIFF
--- a/Diagnostic/diagnostic.py
+++ b/Diagnostic/diagnostic.py
@@ -525,8 +525,8 @@ def start_mdsd(configurator):
     tmp_env_dict = {}  # Need to get the additionally needed env vars (SSL_CERT_*) for this mdsd run as well...
     g_dist_config.extend_environment(tmp_env_dict)
     added_env_str = ' '.join('{0}={1}'.format(k, tmp_env_dict[k]) for k in tmp_env_dict)
-    config_validate_cmd = '{0}{1}{2} -v -c {3}'.format(added_env_str, ' ' if added_env_str else '',
-                                                       g_mdsd_bin_path, xml_file)
+    config_validate_cmd = '{0}{1}{2} -v -c {3} -r {4}'.format(added_env_str, ' ' if added_env_str else '',
+                                                       g_mdsd_bin_path, xml_file, g_ext_dir)
     config_validate_cmd_status, config_validate_cmd_msg = RunGetOutput(config_validate_cmd)
     if config_validate_cmd_status is not 0:
         # Invalid config. Log error and report success.

--- a/Diagnostic/manifest.xml
+++ b/Diagnostic/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.Azure.Diagnostics</ProviderNameSpace>
   <Type>LinuxDiagnostic</Type>
-  <Version>3.0.129</Version>
+  <Version>4.0.1</Version>
   <Label>Microsoft Azure Diagnostic Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>


### PR DESCRIPTION
It was a bug introduced by the LADMaster -> Master in mdsd branch. The latest mdsd version, when validating the config, looks for the default /var/run/mdsd directory to check if it exists or not. but that directory is only created when mdsd is run. So when LAD runs this check before mdsd is run, it fails. 

Also changing version in manifest.xml (this is only used for logging purposes and isnt automatically updated by cdpx as I had thought)