### PR TITLE
Fixing install errors due to no metrics config

### DIFF
--- a/Diagnostic/lad_config_all.py
+++ b/Diagnostic/lad_config_all.py
@@ -380,8 +380,8 @@ class LadConfigAll:
                     lad_query_instance_id = uuid_for_instance_id
                 self._set_xml_attr("instanceID", lad_query_instance_id, "Events/DerivedEvents/DerivedEvent/LADQuery")
             else:
-                return False, 'Unable to find resource id in the config. Failed to generate configs for Metrics in mdsd ' \
-                        '(see extension error logs for more details)'
+                self._logger_log('Unable to find resource id in the config. Failed to generate configs for Metrics in mdsd ' \
+                        '(see extension error logs for more details)')
 
             #Only enable Metrics if AzMonSink is in the config
             azmonsink = self._sink_configs_public.get_sink_by_name("AzMonSink")

--- a/Diagnostic/lad_config_all.py
+++ b/Diagnostic/lad_config_all.py
@@ -358,12 +358,13 @@ class LadConfigAll:
             self._rsyslog_config = lad_logging_config_helper.get_rsyslog_config()
             self._syslog_ng_config = lad_logging_config_helper.get_syslog_ng_config()
             parsed_perf_settings = lad_logging_config_helper.parse_lad_perf_settings(lad_cfg)
-            self._telegraf_config, self._telegraf_namespaces = telhandler.handle_config(parsed_perf_settings, self._telegraf_me_url, self._telegraf_mdsd_url, True)
+            if len(parsed_perf_settings) > 0:
+                self._telegraf_config, self._telegraf_namespaces = telhandler.handle_config(parsed_perf_settings, self._telegraf_me_url, self._telegraf_mdsd_url, True)
 
-            #Handle the EH, JsonBlob and AzMonSink logic
-            self._update_metric_collection_settings(lad_cfg, self._telegraf_namespaces)
-            mdsd_telegraf_config = lad_logging_config_helper.get_mdsd_telegraf_config(self._telegraf_namespaces)
-            copy_source_mdsdevent_eh_url_elems(self._mdsd_config_xml_tree, mdsd_telegraf_config)
+                #Handle the EH, JsonBlob and AzMonSink logic
+                self._update_metric_collection_settings(lad_cfg, self._telegraf_namespaces)
+                mdsd_telegraf_config = lad_logging_config_helper.get_mdsd_telegraf_config(self._telegraf_namespaces)
+                copy_source_mdsdevent_eh_url_elems(self._mdsd_config_xml_tree, mdsd_telegraf_config)
 
             resource_id = self._ext_settings.get_resource_id()
             if resource_id:


### PR DESCRIPTION
In the current design there is a flaw where LAD installation exits (telegraf setup throws exception) if it finds that there are no configs enabled for metrics. Adding a check before we create the telegraf configs to make sure not to pass invalid arguments. 