### PR TITLE
Fix systemctl crash on RHEL LVM.

### DIFF
--- a/VMEncryption/main/oscrypto/rhel_72_lvm/RHEL72LVMEncryptionStateMachine.py
+++ b/VMEncryption/main/oscrypto/rhel_72_lvm/RHEL72LVMEncryptionStateMachine.py
@@ -204,4 +204,7 @@ class RHEL72LVMEncryptionStateMachine(OSEncryptionStateMachine):
         self.stop_machine()
         self.log_machine_state()
 
-        self._reboot()
+        return_code = self.command_executor.Execute('reboot', timeout=120)
+        if return_code != 0:
+            self.logger.log("Reboot didn't succeed. Trying force reboot.")
+            self.command_executor.Execute('systemctl --force --force reboot')

--- a/VMEncryption/main/oscrypto/rhel_72_lvm/encryptstates/PatchBootSystemState.py
+++ b/VMEncryption/main/oscrypto/rhel_72_lvm/encryptstates/PatchBootSystemState.py
@@ -57,7 +57,7 @@ class PatchBootSystemState(OSEncryptionState):
 
         self.context.logger.log("Entering patch_boot_system state")
 
-        self.command_executor.Execute('systemctl restart lvm2-lvmetad', True)
+        self.command_executor.Execute('systemctl restart lvm2-lvmetad', False)
         self.command_executor.Execute('pvscan', True)
         self.command_executor.Execute('vgcfgrestore -f /volumes.lvm rootvg', True)
         self.command_executor.Execute('cryptsetup luksClose osencrypt', True)


### PR DESCRIPTION
1. Don't make systemctl failure as hard failure in PatchBootSystem state
2. Force reboot if normal reboot doesn't work
3. Change is isolated RHEL 7 LVM where the crash is observed