### PR TITLE
Monitor install mdsd fixes

### DIFF
--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -381,7 +381,6 @@ def install():
                     for var in list(default_configs.keys()):
                         # use a split to avoid matching defaults found in the value of other settings
                         if var in line.split('=')[0]:
-                            line = "export " + var + "=" + default_configs[var] + "\n"
                             vars_set.add(var)
                             break
                     new_data += line

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -379,7 +379,8 @@ def install():
                 data = f.readlines()
                 for line in data:
                     for var in list(default_configs.keys()):
-                        if var in line:
+                        # use a split to avoid matching defaults found in the value of other settings
+                        if var in line.split('=')[0]:
                             line = "export " + var + "=" + default_configs[var] + "\n"
                             vars_set.add(var)
                             break


### PR DESCRIPTION
When AzureMonitorLinuxAgent-1.7.0 is installed on a VM with azure-mdsd already installed/configured, the install script overwrites any settings specified in /etc/default/mdsd. This behavior seems out-of-sync with the mdsd manpage and other Geneva docs which suggest configuring azure-mdsd with /etc/default/mdsd.

For example, we use a custom fluentd port via MDSD_OPTIONS, this is lost when the 1.7.0 extension is installed.

This PR changes the config update code to split the line around `=` to be more intelligent in matching default variables. It also preserves any user settings which are otherwise defaults.

To test these changes to agent.py I copied the agent.py into /var/lib/waagent/Microsoft.Azure.Monitor.AzureMonitorLinuxAgent-1.7.0 and re-ran the shim.sh install script. I observed /etc/default/mdsd was updated but our customizations were preserved.
