### PR TITLE
ADE SP fix for invalid literal

### DIFF
--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -260,7 +260,7 @@ def update_encryption_settings(extra_items_to_encrypt=[]):
 
     encryption_config = EncryptionConfig(encryption_environment, logger)
     config_secret_seq = encryption_config.get_secret_seq_num()
-    if config_secret_seq is None:
+    if not config_secret_seq:
         current_secret_seq_num = -1
     else:
         current_secret_seq_num = int(config_secret_seq)

--- a/VMEncryption/main/test/test_disk_util.py
+++ b/VMEncryption/main/test/test_disk_util.py
@@ -1,7 +1,6 @@
 import unittest
 import os.path
 import json
-import sys
 
 from DiskUtil import DiskUtil
 from EncryptionEnvironment import EncryptionEnvironment
@@ -134,29 +133,20 @@ class Test_Disk_Util(unittest.TestCase):
         get_device_items_mock.side_effect = lambda x: get_device_items_dict[x]
 
         azure_devices = self.disk_util.get_azure_devices()
-        if sys.version_info[0] < 3:
-            self.assertItemsEqual(["sda", "sdb", "sdc"], map(lambda x: x.name, azure_devices))
-        else:
-            self.assertCountEqual(["sda", "sdb", "sdc"], map(lambda x: x.name, azure_devices))
+        self.assertItemsEqual(["sda", "sdb", "sdc"], map(lambda x: x.name, azure_devices))
 
         # add a partition to sdb
         get_device_items_dict["/dev/sdb"].append(self._create_device_item(name="sdb1"))
 
         azure_devices = self.disk_util.get_azure_devices()
-        if sys.version_info[0] < 3:
-            self.assertItemsEqual(["sda", "sdb", "sdb1", "sdc"], map(lambda x: x.name, azure_devices))
-        else:
-            self.assertCountEqual(["sda", "sdb", "sdb1", "sdc"], map(lambda x: x.name, azure_devices))
+        self.assertItemsEqual(["sda", "sdb", "sdb1", "sdc"], map(lambda x: x.name, azure_devices))
 
         # change ide device to also be sda
         get_ide_mock.return_value = ["sda"]
 
         azure_devices = self.disk_util.get_azure_devices()
         # There should only be one SDA, not two
-        if sys.version_info[0] < 3:
-            self.assertItemsEqual(["sda", "sdb", "sdb1"], map(lambda x: x.name, azure_devices))
-        else:
-            self.assertCountEqual(["sda", "sdb", "sdb1"], map(lambda x: x.name, azure_devices))
+        self.assertItemsEqual(["sda", "sdb", "sdb1"], map(lambda x: x.name, azure_devices))
 
     @mock.patch("os.path.exists", return_value=False)
     @mock.patch("DiskUtil.EncryptionMarkConfig.config_file_exists", return_value=False)

--- a/VMEncryption/main/test/test_disk_util.py
+++ b/VMEncryption/main/test/test_disk_util.py
@@ -1,6 +1,7 @@
 import unittest
 import os.path
 import json
+import sys
 
 from DiskUtil import DiskUtil
 from EncryptionEnvironment import EncryptionEnvironment
@@ -133,20 +134,29 @@ class Test_Disk_Util(unittest.TestCase):
         get_device_items_mock.side_effect = lambda x: get_device_items_dict[x]
 
         azure_devices = self.disk_util.get_azure_devices()
-        self.assertItemsEqual(["sda", "sdb", "sdc"], map(lambda x: x.name, azure_devices))
+        if sys.version_info[0] < 3:
+            self.assertItemsEqual(["sda", "sdb", "sdc"], map(lambda x: x.name, azure_devices))
+        else:
+            self.assertCountEqual(["sda", "sdb", "sdc"], map(lambda x: x.name, azure_devices))
 
         # add a partition to sdb
         get_device_items_dict["/dev/sdb"].append(self._create_device_item(name="sdb1"))
 
         azure_devices = self.disk_util.get_azure_devices()
-        self.assertItemsEqual(["sda", "sdb", "sdb1", "sdc"], map(lambda x: x.name, azure_devices))
+        if sys.version_info[0] < 3:
+            self.assertItemsEqual(["sda", "sdb", "sdb1", "sdc"], map(lambda x: x.name, azure_devices))
+        else:
+            self.assertCountEqual(["sda", "sdb", "sdb1", "sdc"], map(lambda x: x.name, azure_devices))
 
         # change ide device to also be sda
         get_ide_mock.return_value = ["sda"]
 
         azure_devices = self.disk_util.get_azure_devices()
         # There should only be one SDA, not two
-        self.assertItemsEqual(["sda", "sdb", "sdb1"], map(lambda x: x.name, azure_devices))
+        if sys.version_info[0] < 3:
+            self.assertItemsEqual(["sda", "sdb", "sdb1"], map(lambda x: x.name, azure_devices))
+        else:
+            self.assertCountEqual(["sda", "sdb", "sdb1"], map(lambda x: x.name, azure_devices))
 
     @mock.patch("os.path.exists", return_value=False)
     @mock.patch("DiskUtil.EncryptionMarkConfig.config_file_exists", return_value=False)

--- a/VMEncryption/main/test/test_encryption_config.py
+++ b/VMEncryption/main/test/test_encryption_config.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+#
+# *********************************************************
+# Copyright (c) Microsoft. All rights reserved.
+#
+# Apache 2.0 License
+#
+# You may obtain a copy of the License at
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+# *********************************************************
+
+""" Unit tests for the EncryptionConfig module """
+
+import unittest
+
+from EncryptionConfig import EncryptionConfig
+from EncryptionEnvironment import EncryptionEnvironment
+from .console_logger import ConsoleLogger
+
+class Test_EncryptionConfig(unittest.TestCase):
+    def setUp(self):
+        self.logger = ConsoleLogger()
+        self.encryption_config = EncryptionConfig(EncryptionEnvironment(None, self.logger), self.logger)
+
+    def test_get_cfg_none(self):
+        self.assertEqual(self.encryption_config.get_cfg_val(None),"")
+        
+    def test_get_cfg_empty_string(self):
+        self.assertEqual(self.encryption_config.get_cfg_val(""),"")

--- a/VMEncryption/main/test/test_handler_util.py
+++ b/VMEncryption/main/test/test_handler_util.py
@@ -108,6 +108,18 @@ try:
         def test_do_parse_context_update_encryption_settings(self):
             self.assertIsNotNone(self.hutil.do_parse_context('UpdateEncryptionSettings'))
 
+        @mock.patch('EncryptionConfig.EncryptionConfig.get_secret_seq_num')
+        def test_update_encryption_settings_when_secret_seq_num_none(self,get_secret_seq_num):
+            # test update encryption settings when get_secret_seq_num is mocked to return None
+            get_secret_seq_num.return_value = None
+            self.assertIsNotNone(self.hutil.do_parse_context('UpdateEncryptionSettings'))
+
+        @mock.patch('EncryptionConfig.EncryptionConfig.get_secret_seq_num')
+        def test_update_encryption_settings_when_secret_seq_num_empty_string(self,get_secret_seq_num):
+            # test update encryption settings when get_secret_seq_num is mocked to return empty string
+            get_secret_seq_num.return_value = ""
+            self.assertIsNotNone(self.hutil.do_parse_context('UpdateEncryptionSettings'))
+
         def test_do_parse_context_update(self):
             self.assertIsNotNone(self.hutil.do_parse_context('Update'))
 


### PR DESCRIPTION
Fixes python2/python3 compatibility issue that resulted in "invalid literal for int() with base 10:" 