### PR TITLE
ADE DP QOS error codes for luksAddKey path

### DIFF
--- a/VMEncryption/main/Common.py
+++ b/VMEncryption/main/Common.py
@@ -198,6 +198,7 @@ class CommonVariables:
     backup_slice_file_error = 21
     unmount_oldroot_error = 22
     operation_lookback_failed = 23
+    luks_add_key_error = 24
     unknown_error = 100
 
     """

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -291,7 +291,7 @@ def update_encryption_settings():
 
                 before_keyslots = disk_util.luks_dump_keyslots(crypt_item.dev_path, crypt_item.luks_header_path)
                 logger.log("Before key addition, keyslots for {0}: {1}".format(crypt_item.dev_path, before_keyslots))
-                
+
                 logger.log("Adding new key for {0}".format(crypt_item.dev_path))
                 luks_add_result = disk_util.luks_add_key(passphrase_file=existing_passphrase_file,
                                                          dev_path=crypt_item.dev_path,
@@ -300,7 +300,7 @@ def update_encryption_settings():
                                                          new_key_path=temp_keyfile.name)
 
                 # if unable to add key, stop updating encryption settings and return QOS error code
-                if luks_add_result is None or luks_add_result !=0: 
+                if luks_add_result is None or luks_add_result!=0: 
                     message = "cryptsetup luksAddKeyresult is {0}".format(luks_add_result)
                     logger.log(msg=message, level=CommonVariables.ErrorLevel)
                     hutil.do_exit(exit_code=CommonVariables.luks_add_key_error,

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -290,22 +290,19 @@ def update_encryption_settings():
                     continue
 
                 before_keyslots = disk_util.luks_dump_keyslots(crypt_item.dev_path, crypt_item.luks_header_path)
-
                 logger.log("Before key addition, keyslots for {0}: {1}".format(crypt_item.dev_path, before_keyslots))
-
+                
                 logger.log("Adding new key for {0}".format(crypt_item.dev_path))
-
                 luks_add_result = disk_util.luks_add_key(passphrase_file=existing_passphrase_file,
                                                          dev_path=crypt_item.dev_path,
                                                          mapper_name=crypt_item.mapper_name,
                                                          header_file=crypt_item.luks_header_path,
                                                          new_key_path=temp_keyfile.name)
 
-                message = "cryptsetup luksAddKeyresult is {0}".format(luks_add_result)
-                logger.log(message)
-
                 # if unable to add key, stop updating encryption settings and return QOS error code
                 if luks_add_result is None or luks_add_result !=0: 
+                    message = "cryptsetup luksAddKeyresult is {0}".format(luks_add_result)
+                    logger.log(msg=message, level=CommonVariables.ErrorLevel)
                     hutil.do_exit(exit_code=CommonVariables.luks_add_key_error,
                             operation='UpdateEncryptionSettings',
                             status=CommonVariables.extension_error_status,
@@ -322,7 +319,7 @@ def update_encryption_settings():
                 except Exception as e:
                     message = "Unable to find new keyslot:  {0}, stack trace: {1}".format(e, traceback.format_exc())
                     logger.log(msg=message, level=CommonVariables.ErrorLevel)
-                    hutil.do_exit(exit_code=CommonVariables.unknown_error,
+                    hutil.do_exit(exit_code=CommonVariables.luks_add_key_error,
                                 operation='UpdateEncryptionSettings',
                                 status=CommonVariables.extension_error_status,
                                 code=str(CommonVariables.luks_add_key_error),


### PR DESCRIPTION
- add QOS specific error constant for improved tracking of errors during luks add key path
- exit with custom error if keypath is invalid or cryptsetup luksAddKey returns a nonzero exit code 
- exit with custom error if key slot not found after add ("ValueError: True is not in list")