### PR TITLE
ADE SP add check for pre-installed packages to ubuntu patching

### DIFF
--- a/VMEncryption/main/patch/UbuntuPatching.py
+++ b/VMEncryption/main/patch/UbuntuPatching.py
@@ -47,33 +47,44 @@ class UbuntuPatching(AbstractPatching):
         self.umount_path = '/bin/umount'
         self.touch_path = '/usr/bin/touch'
 
+    def packages_installed(self, packages):
+        ''' return true if all packages in list are already installed '''
+        installed = True
+        for package in packages:
+            cmd = "dpkg-query -s {package} | grep -q 'install ok installed'"
+            if not self.command_executor.ExecuteInBash(cmd, False, None, None, True):
+                installed = False
+                self.logger.log("{1} package not yet installed".format(package))
+        return installed
+
     def install_cryptsetup(self):
         packages = ['cryptsetup-bin']
-        cmd = " ".join(['apt-get', 'install', '-y', '--no-upgrade'] + packages)
-        return_code = self.command_executor.Execute(cmd, timeout=30)
-        if return_code == -9:
-            msg = "Command: apt-get install timed out. Make sure apt-get is configured correctly and there are no network problems."
-            raise Exception(msg)
 
-        # If install fails, try running apt-get update and then try install again
-        if return_code != 0:
-            self.logger.log('cryptsetup installation failed. Retrying installation after running update')
-            return_code = self.command_executor.Execute('apt-get -o Acquire::ForceIPv4=true -y update', timeout=30)
-            # Fail early if apt-get update times out.
-            if return_code == -9:
-                msg = "Command: apt-get -o Acquire::ForceIPv4=true -y update timed out. Make sure apt-get is configured correctly."
-                raise Exception(msg)
-            cmd = " ".join(['apt-get', 'install', '-y'] + packages)
+        if self.packages_installed(packages):
+            return
+        else:
+            cmd = " ".join(['apt-get', 'install', '-y', '--no-upgrade'] + packages)
             return_code = self.command_executor.Execute(cmd, timeout=30)
             if return_code == -9:
                 msg = "Command: apt-get install timed out. Make sure apt-get is configured correctly and there are no network problems."
                 raise Exception(msg)
-            return return_code
+
+            # If install fails, try running apt-get update and then try install again
+            if return_code != 0:
+                self.logger.log('cryptsetup installation failed. Retrying installation after running update')
+                return_code = self.command_executor.Execute('apt-get -o Acquire::ForceIPv4=true -y update', timeout=30)
+                # Fail early if apt-get update times out.
+                if return_code == -9:
+                    msg = "Command: apt-get -o Acquire::ForceIPv4=true -y update timed out. Make sure apt-get is configured correctly."
+                    raise Exception(msg)
+                cmd = " ".join(['apt-get', 'install', '-y'] + packages)
+                return_code = self.command_executor.Execute(cmd, timeout=30)
+                if return_code == -9:
+                    msg = "Command: apt-get install timed out. Make sure apt-get is configured correctly and there are no network problems."
+                    raise Exception(msg)
+                return return_code
 
     def install_extras(self):
-        cmd = " ".join(['apt-get', 'update'])
-        self.command_executor.Execute(cmd)
-
         # select the appropriate version specific parted package
         if (sys.version_info >= (3,)):
             parted = 'python3-parted'
@@ -89,8 +100,14 @@ class UbuntuPatching(AbstractPatching):
                     'procps',
                     'psmisc']
 
-        cmd = " ".join(['apt-get', 'install', '-y'] + packages)
-        self.command_executor.Execute(cmd)
+        if self.packages_installed(packages):
+            return
+        else:
+            cmd = " ".join(['apt-get', 'update'])
+            self.command_executor.Execute(cmd)
+
+            cmd = " ".join(['apt-get', 'install', '-y'] + packages)
+            self.command_executor.Execute(cmd)
 
     def update_prereq(self):
         self.logger.log("Trying to update Ubuntu osencrypt entry.")

--- a/VMEncryption/main/test/test_UbuntuPatching.py
+++ b/VMEncryption/main/test/test_UbuntuPatching.py
@@ -174,3 +174,34 @@ class Test_UbuntuPatching(unittest.TestCase):
         self.assertEqual(ce_mock.call_count, 0)
         self.assertEqual(exists_mock.call_count, 1)
         self.assertEqual(expected_crypttab_contents, open_mock.content_dict["/etc/crypttab"])
+
+    @mock.patch('CommandExecutor.CommandExecutor.Execute')
+    def test_packages_installed(self, ce_mock):
+        ce_mock.return_value = True
+        packages = []
+        self.assertTrue(self.UbuntuPatching._packages_installed(packages))
+        self.assertEqual(ce_mock.call_count, 0)
+
+        ce_mock.reset_mock()
+        ce_mock.return_value = True
+        packages = ["a"]
+        self.assertTrue(self.UbuntuPatching._packages_installed(packages))
+        self.assertEqual(ce_mock.call_count, 1)
+
+        ce_mock.reset_mock()
+        ce_mock.return_value = False
+        packages = ["a"]
+        self.assertFalse(self.UbuntuPatching._packages_installed(packages))
+        self.assertEqual(ce_mock.call_count, 1)
+
+        ce_mock.reset_mock()
+        ce_mock.return_value = True
+        packages = ["a", "b", "c"]
+        self.assertTrue(self.UbuntuPatching._packages_installed(packages))
+        self.assertEqual(ce_mock.call_count, 3)
+
+        ce_mock.reset_mock()
+        ce_mock.return_value = False
+        packages = ["a", "b", "c"]
+        self.assertFalse(self.UbuntuPatching._packages_installed(packages))
+        self.assertEqual(ce_mock.call_count, 3)


### PR DESCRIPTION
- checks for presence of pre-installed packages on ubuntu, and skip if already installed
- better performance in mainline scenario when packages are present in base image
- better reliability when external package management servers are unavailable or within isolated networks