### PR TITLE
ADE SP add grub-pc-bin to install_extras

### DIFF
--- a/VMEncryption/main/patch/UbuntuPatching.py
+++ b/VMEncryption/main/patch/UbuntuPatching.py
@@ -83,6 +83,7 @@ class UbuntuPatching(AbstractPatching):
         # construct package installation list
         packages = ['at',
                     'cryptsetup-bin',
+                    'grub-pc-bin'
                     'lsscsi',
                     parted,
                     'python-six',

--- a/VMEncryption/main/patch/UbuntuPatching.py
+++ b/VMEncryption/main/patch/UbuntuPatching.py
@@ -83,7 +83,7 @@ class UbuntuPatching(AbstractPatching):
         # construct package installation list
         packages = ['at',
                     'cryptsetup-bin',
-                    'grub-pc-bin'
+                    'grub-pc-bin',
                     'lsscsi',
                     parted,
                     'python-six',


### PR DESCRIPTION
- grub-pc-bin is a required package that has historically been present in all supported Ubuntu images 
- If removed as part of an update to the base image, its absence will break ADE scenarios 
- This additional check installs the package if needed
- The public facing documentation has also been updated to include this in the list of required packages: 
https://docs.microsoft.com/en-us/azure/virtual-machines/linux/disk-encryption-isolated-network#package-management