### PR TITLE
use bytes type compare for p2/p3 compat

### DIFF
--- a/VMEncryption/main/CryptMountConfigUtil.py
+++ b/VMEncryption/main/CryptMountConfigUtil.py
@@ -614,17 +614,20 @@ class CryptMountConfigUtil(object):
         lines_to_keep_in_backup_fstab = []
         lines_to_put_back_to_fstab = []
 
-        with open('/etc/fstab.azure.backup', 'r') as f:
-            for line in f.readlines():
-                line = line.strip()
-                pattern = '\\s' + re.escape(mount_point_or_mapper_name) + '\\s'
+        try:
+            with open('/etc/fstab.azure.backup', 'r') as f:
+                for line in f.readlines():
+                    line = line.strip()
+                    pattern = '\\s' + re.escape(mount_point_or_mapper_name) + '\\s'
 
-                if re.search(pattern, line):
-                    self.logger.log("removing fstab.azure.backup line: {0}".format(line))
-                    lines_to_put_back_to_fstab.append(line)
-                    continue
+                    if re.search(pattern, line):
+                        self.logger.log("removing fstab.azure.backup line: {0}".format(line))
+                        lines_to_put_back_to_fstab.append(line)
+                        continue
 
-                lines_to_keep_in_backup_fstab.append(line)
+                    lines_to_keep_in_backup_fstab.append(line)
+        except:
+            self.logger.log("prior /etc/fstab.azure.backup file not found")
 
         with io.open('/etc/fstab.azure.backup', 'w') as f:
             contents = '\n'.join(lines_to_keep_in_backup_fstab)

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -360,7 +360,7 @@ def update_encryption_settings(extra_items_to_encrypt=[]):
             logger.log('Secret has already been updated')
             disk_util.log_lsblk_output()
 
-            if extension_parameter.passphrase and extension_parameter.passphrase != file(existing_passphrase_file).read():
+            if extension_parameter.passphrase and extension_parameter.passphrase != open(existing_passphrase_file,'r').read():
                 logger.log("The new passphrase has not been placed in BEK volume yet")
                 logger.log("Skipping removal of old passphrase")
                 exit_without_status_report()

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -142,7 +142,7 @@ def disable_encryption():
                                status_code=str(CommonVariables.success),
                                message='Encryption settings cleared')
 
-        bek_util.store_bek_passphrase(encryption_config, '')
+        bek_util.store_bek_passphrase(encryption_config, b'')
 
         bek_util.delete_bek_passphrase_file(encryption_config)
 

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -604,8 +604,8 @@ def mark_encryption(command, volume_type, disk_format_query):
 
 
 def is_daemon_running():
-    handler_path = os.path.join(os.getcwd(), __file__)
-    daemon_arg = "-daemon"
+    handler_path = os.path.join(os.getcwd(), __file__).encode('utf-8')
+    daemon_arg = b'-daemon'
 
     psproc = subprocess.Popen(['ps', 'aux'], stdout=subprocess.PIPE)
     pslist, _ = psproc.communicate()


### PR DESCRIPTION
-avoid TypeError on Python 3.x and support backwards compatibility with Python 2.7 by using a bytes-like object for comparison