### PR TITLE
Change output of subprocess.communicate() to str

### DIFF
--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -931,7 +931,7 @@ def stop_arc_watcher():
             for pids in f.readlines():
                 proc = subprocess.Popen(["ps -o cmd= {0}".format(pids)], stdout=subprocess.PIPE, shell=True)
                 output = proc.communicate()[0]
-                if output and "arc" in output:
+                if output and "arc" in output.decode():
                     kill_cmd = "kill " + pids
                     run_command_and_log(kill_cmd)
 


### PR DESCRIPTION
subprocess.communicate() outputs a bytes-like object in this case, when we want it to be a string (for comparison purposes). In Python3, checking to see if "arc" is in output causes an error, since it's trying to compare a string and a bytes-like object. Using decode() on this bytes-like object will change it to a string, fixing this issue.

For this work item: https://msazure.visualstudio.com/One/_workitems/edit/10234552