### PR TITLE
AMA: short circuit enable() logic when sequence number has not changed

### DIFF
--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -524,7 +524,7 @@ def enable():
     the settings provided are incomplete or incorrect.
     Note: enable operation times out from WAAgent at 5 minutes
     """
-    global AMAServiceStartCommand, AMAServiceStatusCommand, HUtilObject
+    global AMAServiceStartCommand, AMAServiceStatusCommand
 
     if HUtilObject:
         if(HUtilObject.is_seq_smaller()):

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -524,7 +524,12 @@ def enable():
     the settings provided are incomplete or incorrect.
     Note: enable operation times out from WAAgent at 5 minutes
     """
-    global AMAServiceStartCommand, AMAServiceStatusCommand
+    global AMAServiceStartCommand, AMAServiceStatusCommand, HUtilObject
+
+    if HUtilObject:
+        if(HUtilObject.is_seq_smaller()):
+            HUtilObject.log("Current sequence number, " + HUtilObject._context._seq_no + ", is not greater than the sequence number of the most recent executed configuration. Exiting...")
+            sys.exit(0)
 
     exit_if_vm_not_supported('Enable')
 
@@ -557,6 +562,7 @@ def enable():
     if exit_code == 0:
         #start metrics process if enable is successful
         start_metrics_process()
+        HUtilObject.save_seq()
     else:
         status_exit_code, status_output = run_command_and_log(AMAServiceStatusCommand)
         if status_exit_code != 0:

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -528,8 +528,7 @@ def enable():
 
     if HUtilObject:
         if(HUtilObject.is_seq_smaller()):
-            HUtilObject.log("Current sequence number, " + HUtilObject._context._seq_no + ", is not greater than the sequence number of the most recent executed configuration. Exiting...")
-            sys.exit(0)
+            return 0, "Current sequence number, " + HUtilObject._context._seq_no + ", is not greater than the sequence number of the most recent executed configuration. Skipping enable"
 
     exit_if_vm_not_supported('Enable')
 


### PR DESCRIPTION
Added logic to short circuit the enable() method when the [n].settings file in the config folder has not changed. 

The call to HandlerUtil.save_seq() stores the last sequence number that enable successfully ran for in mrseq. 
The check at the start of the function determines whether n (from most recent [n].settings file)> saved sequence number in mrseq before proceeding with enable()