### PR TITLE
Allow to use local path rather than passing the certificate and its key as parameter

### DIFF
--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -347,7 +347,7 @@ def install():
 
         # check if required GCS params are available
         MONITORING_GCS_CERT_CERTFILE = None
-        if "certificate" in protected_settings:           
+        if "certificate" in protected_settings:
             MONITORING_GCS_CERT_CERTFILE = base64.standard_b64decode(protected_settings.get("certificate"))
 
         if "certificatePath" in protected_settings:

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -348,11 +348,27 @@ def install():
         # check if required GCS params are available
         MONITORING_GCS_CERT_CERTFILE = None
         if "certificate" in protected_settings:
-            MONITORING_GCS_CERT_CERTFILE = base64.standard_b64decode(protected_settings.get("certificate"))
+            certificate = protected_settings.get("certificate")
+            # Try to handle a local path first if url style is provider,
+            # then fallback as base64 encoded certificate payload
+            if certificate.startsWith('file:'):
+                certificate = certificate[5:]
+                with open(certificate, 'r') as f:
+                    MONITORING_GCS_CERT_CERTFILE = f.read()
+            else:
+                MONITORING_GCS_CERT_CERTFILE = base64.standard_b64decode(certificate)
 
         MONITORING_GCS_CERT_KEYFILE = None
         if "certificateKey" in protected_settings:
-            MONITORING_GCS_CERT_KEYFILE = base64.standard_b64decode(protected_settings.get("certificateKey"))
+            certificateKey = protected_settings.get("certificateKey")
+            # Try to handle a local path first if url style is provider,
+            # then fallback as base64 encoded certificate payload
+            if certificateKey.startsWith('file:'):
+                certificateKey = certificateKey[5:]
+                with open(certificateKey, 'r') as f:
+                    MONITORING_GCS_CERT_KEYFILE = f.read()
+            else:
+                MONITORING_GCS_CERT_KEYFILE = base64.standard_b64decode(certificateKey)
 
         MONITORING_GCS_ENVIRONMENT = ""
         if "monitoringGCSEnvironment" in protected_settings:

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -351,16 +351,23 @@ def install():
             MONITORING_GCS_CERT_CERTFILE = base64.standard_b64decode(protected_settings.get("certificate"))
 
         if "certificatePath" in protected_settings:
-            with open(protected_settings.get("certificatePath"), 'r') as f:
-                MONITORING_GCS_CERT_CERTFILE = f.read()
+            try:
+                with open(protected_settings.get("certificatePath"), 'r') as f:
+                    MONITORING_GCS_CERT_CERTFILE = f.read()
+            except Exception as ex:
+                log_and_exit('Install', MissingorInvalidParameterErrorCode, 'Failed to read certificate {0}: {1}'.format(protected_settings.get("certificatePath"), ex))
 
         MONITORING_GCS_CERT_KEYFILE = None
         if "certificateKey" in protected_settings:
             MONITORING_GCS_CERT_KEYFILE = base64.standard_b64decode(protected_settings.get("certificateKey"))
 
         if "certificateKeyPath" in protected_settings:
-            with open(protected_settings.get("certificateKeyPath"), 'r') as f:
-                MONITORING_GCS_CERT_CERTFILE = f.read()
+            try:
+                with open(protected_settings.get("certificateKeyPath"), 'r') as f:
+                    MONITORING_GCS_CERT_CERTFILE = f.read()
+            except Exception as ex:
+                log_and_exit('Install', MissingorInvalidParameterErrorCode, 'Failed to read certificate key {0}: {1}'.format(protected_settings.get("certificateKeyPath"), ex))
+
 
         MONITORING_GCS_ENVIRONMENT = ""
         if "monitoringGCSEnvironment" in protected_settings:

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -364,10 +364,9 @@ def install():
         if "certificateKeyPath" in protected_settings:
             try:
                 with open(protected_settings.get("certificateKeyPath"), 'r') as f:
-                    MONITORING_GCS_CERT_CERTFILE = f.read()
+                    MONITORING_GCS_CERT_KEYFILE = f.read()
             except Exception as ex:
                 log_and_exit('Install', MissingorInvalidParameterErrorCode, 'Failed to read certificate key {0}: {1}'.format(protected_settings.get("certificateKeyPath"), ex))
-
 
         MONITORING_GCS_ENVIRONMENT = ""
         if "monitoringGCSEnvironment" in protected_settings:

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -347,28 +347,20 @@ def install():
 
         # check if required GCS params are available
         MONITORING_GCS_CERT_CERTFILE = None
-        if "certificate" in protected_settings:
-            certificate = protected_settings.get("certificate")
-            # Try to handle a local path first if url style is provider,
-            # then fallback as base64 encoded certificate payload
-            if certificate.startsWith('file:'):
-                certificate = certificate[5:]
-                with open(certificate, 'r') as f:
-                    MONITORING_GCS_CERT_CERTFILE = f.read()
-            else:
-                MONITORING_GCS_CERT_CERTFILE = base64.standard_b64decode(certificate)
+        if "certificate" in protected_settings:           
+            MONITORING_GCS_CERT_CERTFILE = base64.standard_b64decode(protected_settings.get("certificate"))
+
+        if "certificatePath" in protected_settings:
+            with open(protected_settings.get("certificatePath"), 'r') as f:
+                MONITORING_GCS_CERT_CERTFILE = f.read()
 
         MONITORING_GCS_CERT_KEYFILE = None
         if "certificateKey" in protected_settings:
-            certificateKey = protected_settings.get("certificateKey")
-            # Try to handle a local path first if url style is provider,
-            # then fallback as base64 encoded certificate payload
-            if certificateKey.startsWith('file:'):
-                certificateKey = certificateKey[5:]
-                with open(certificateKey, 'r') as f:
-                    MONITORING_GCS_CERT_KEYFILE = f.read()
-            else:
-                MONITORING_GCS_CERT_KEYFILE = base64.standard_b64decode(certificateKey)
+            MONITORING_GCS_CERT_KEYFILE = base64.standard_b64decode(protected_settings.get("certificateKey"))
+
+        if "certificateKeyPath" in protected_settings:
+            with open(protected_settings.get("certificateKeyPath"), 'r') as f:
+                MONITORING_GCS_CERT_CERTFILE = f.read()
 
         MONITORING_GCS_ENVIRONMENT = ""
         if "monitoringGCSEnvironment" in protected_settings:


### PR DESCRIPTION
The goal of this change is to simplify the deployment by not having to pass the certificates as a parameter, but rely on an existing location under the provisioned VM.
This will allow to leverage the secrets option in the ARM template:

                    "secrets": [
                        {
                            "sourceVault": {
                                "id": "..."
                            },
                            "vaultCertificates": [
                                {
                                    "certificateUrl": "..."
                                }
                            ]
                        }
                    ]

and reduce the need to manage the certificates externally by passing parameter like this:

                    "certificate": "file:/var/lib/waagent/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.crt",
                    "certificateKey": "file:/var/lib/waagent/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.prv"

