### PR TITLE
Allow to pass tenant, role and roleInstance from the settings

### DIFF
--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -382,6 +382,19 @@ def install():
         if "monitoringGCSAuthId" in protected_settings:
             MONITORING_GCS_AUTH_ID = protected_settings.get("monitoringGCSAuthId")
 
+        MONITORING_TENANT = ""
+        if "monitoringTenant" in protected_settings:
+            MONITORING_TENANT = protected_settings.get("monitoringTenant")
+
+        MONITORING_ROLE = ""
+        if "monitoringRole" in protected_settings:
+            MONITORING_ROLE = protected_settings.get("monitoringRole")
+
+        MONITORING_ROLE_INSTANCE = ""
+        if "monitoringRoleInstance" in protected_settings:
+            MONITORING_ROLE_INSTANCE = protected_settings.get("monitoringRoleInstance")
+
+
         if ((MONITORING_GCS_CERT_CERTFILE is None or MONITORING_GCS_CERT_KEYFILE is None) and (MONITORING_GCS_AUTH_ID_TYPE == "")) or MONITORING_GCS_ENVIRONMENT == "" or MONITORING_GCS_NAMESPACE == "" or MONITORING_GCS_ACCOUNT == "" or MONITORING_GCS_REGION == "" or MONITORING_CONFIG_VERSION == "":
             waagent_log_error('Not all required GCS parameters are provided')
             raise ParameterMissingException
@@ -419,6 +432,15 @@ def install():
                 fh.close()
                 os.chown("/etc/mdsd.d/gcskey.pem", uid, gid)
                 os.system('chmod {1} {0}'.format("/etc/mdsd.d/gcskey.pem", 400))
+
+            if MONITORING_TENANT != "":
+                default_configs["MONITORING_TENANT"] = MONITORING_TENANT
+
+            if MONITORING_ROLE != "":
+                default_configs["MONITORING_ROLE"] = MONITORING_ROLE
+
+            if MONITORING_TENANT != "":
+                default_configs["MONITORING_ROLE_INSTANCE"] = MONITORING_ROLE_INSTANCE
 
     config_file = "/etc/default/mdsd"
     config_updated = False


### PR DESCRIPTION
Updated the script to handle monitoringTenant, monitoringRole and monitoringRoleInstance.
Those are missing by default and mdsd does not work properly if the type is TenantRole under the configuration (https://github.com/Azure/azure-linux-extensions/blob/1769f67c679450090e5d184e9e2abd2956d9352d/Diagnostic/mdsd/mdsd/CfgCtxManagement.cc#L74)

