### PR TITLE
Fix MONITORING_ROLE_INSTANCE typo

### DIFF
--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -439,7 +439,7 @@ def install():
             if MONITORING_ROLE != "":
                 default_configs["MONITORING_ROLE"] = MONITORING_ROLE
 
-            if MONITORING_TENANT != "":
+            if MONITORING_ROLE_INSTANCE != "":
                 default_configs["MONITORING_ROLE_INSTANCE"] = MONITORING_ROLE_INSTANCE
 
     config_file = "/etc/default/mdsd"


### PR DESCRIPTION
Code checks if MONITORING_TENANT exists before assigning MONITORING_ROLE_INSTANCE, rather than checking if MONITORING_ROLE_INSTANCE exists in this scenario (like the other settings do).