### PR TITLE
Update vmaccess.py for better parsing conf file

### DIFF
--- a/VMAccess/vmaccess.py
+++ b/VMAccess/vmaccess.py
@@ -54,12 +54,12 @@ class ConfigurationProvider(object):
         try:
             for line in ext_utils.get_file_contents(wala_config_file).split('\n'):
                 if not line.startswith("#") and "=" in line:
-                    parts = line.split()[0].split('=')
-                    value = parts[1].strip("\" ")
-                    if value != "None":
-                        self.values[parts[0]] = value
-                    else:
-                        self.values[parts[0]] = None
+                    parts = line.split('=', 1)
+                    if len(parts) < 2:
+                        continue
+                    key = parts[0].strip()
+                    value = parts[1].split('#')[0].strip("\" ").strip()
+                    self.values[key] = value if value != "None" else None
         # when get_file_contents returns none
         except AttributeError:
             logger.error("Unable to parse {0}".format(wala_config_file))


### PR DESCRIPTION
vmaccess.py raises an error if there are spaces

Example:
```
>>> conf
'OS.SshClientAliveInterval = 600'
>>> parts = conf.split()[0].split('=')
>>> parts[0]
'OS.SshClientAliveInterval'
>>> parts[1]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
IndexError: list index out of range
```

This change fix this:
```
>>> conf
'OS.SshClientAliveInterval = 600'
>>> parts = conf.split('=',1)
>>> parts
['OS.SshClientAliveInterval ', ' 600']
>>> key = parts[0].strip()
>>> value = parts[1].split('#')[0].strip("\" ").strip()
>>> print key, value
OS.SshClientAliveInterval 600
```