### PR TITLE
Prevent telegraf duplicates

### DIFF
--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -805,8 +805,8 @@ def metrics_watcher(hutil_error, hutil_log):
 
                             me_handler.setup_me(is_lad=False)
 
-                            start_telegraf_out, log_messages = telhandler.start_telegraf(is_lad=False)
-                            if start_telegraf_out:
+                            start_telegraf_res, log_messages = telhandler.start_telegraf(is_lad=False)
+                            if start_telegraf_res:
                                 hutil_log("Successfully started metrics-sourcer.")
                             else:
                                 hutil_error(log_messages)
@@ -863,8 +863,8 @@ def metrics_watcher(hutil_error, hutil_log):
                                     hutil_log(tel_msg)
                                 else:
                                     hutil_error(tel_msg)
-                                start_telegraf_out, log_messages = telhandler.start_telegraf(is_lad=False)
-                                if start_telegraf_out:
+                                start_telegraf_res, log_messages = telhandler.start_telegraf(is_lad=False)
+                                if start_telegraf_res:
                                     hutil_log("Successfully started metrics-sourcer.")
                                 else:
                                     hutil_error(log_messages)

--- a/Diagnostic/diagnostic.py
+++ b/Diagnostic/diagnostic.py
@@ -324,19 +324,6 @@ def main(command):
                             'Exit code={0}, Output={1}'.format(cmd_exit_code, cmd_output))
             oms.tear_down_omsagent_for_lad(RunGetOutput, True)
 
-            #Stop the telegraf and ME services
-            tel_out, tel_msg = telhandler.stop_telegraf_service(is_lad=True)
-            if tel_out:
-                hutil.log(tel_msg)
-            else:
-                hutil.error(tel_msg)
-
-            me_out, me_msg = me_handler.stop_metrics_service(is_lad=True)
-            if me_out:
-                hutil.log(me_msg)
-            else:
-                hutil.error(me_msg)
-
             #Delete the telegraf and ME services
             tel_rm_out, tel_rm_msg = telhandler.remove_telegraf_service()
             if tel_rm_out:

--- a/Diagnostic/diagnostic.py
+++ b/Diagnostic/diagnostic.py
@@ -375,8 +375,8 @@ def main(command):
                     return
 
                 # Start the Telegraf and ME services on enable after installation is complete
-                start_telegraf_out, log_messages = telhandler.start_telegraf(is_lad=True)
-                if start_telegraf_out:
+                start_telegraf_res, log_messages = telhandler.start_telegraf(is_lad=True)
+                if start_telegraf_res:
                     hutil.log("Successfully started metrics-sourcer.")
                 else:
                     hutil.error(log_messages)
@@ -612,8 +612,8 @@ def start_mdsd(configurator):
                             hutil.log(tel_msg)
                         else:
                             hutil.error(tel_msg)
-                        start_telegraf_out, log_messages = telhandler.start_telegraf(is_lad=True)
-                        if start_telegraf_out:
+                        start_telegraf_res, log_messages = telhandler.start_telegraf(is_lad=True)
+                        if start_telegraf_res:
                             hutil.log("Successfully started metrics-sourcer.")
                         else:
                             hutil.error(log_messages)

--- a/Diagnostic/diagnostic.py
+++ b/Diagnostic/diagnostic.py
@@ -361,27 +361,6 @@ def main(command):
                 hutil.do_status_report(g_ext_op_type, "error", '-1', "Install failed")
                 return
 
-            #Start the Telegraf and ME services on Enable after installation is complete
-            start_telegraf_out, log_messages = telhandler.start_telegraf(is_lad=True)
-            if start_telegraf_out:
-                hutil.log("Successfully started metrics-sourcer.")
-            else:
-                hutil.error(log_messages)
-
-            if enable_metrics_ext:
-                # Generate/regenerate MSI Token required by ME
-                msi_token_generated, me_msi_token_expiry_epoch, log_messages = me_handler.generate_MSI_token()
-                if msi_token_generated:
-                    hutil.log("Successfully generated metrics-extension MSI Auth token.")
-                else:
-                    hutil.error(log_messages)
-
-                start_metrics_out, log_messages = me_handler.start_metrics(is_lad=True)
-                if start_metrics_out:
-                    hutil.log("Successfully started metrics-extension.")
-                else:
-                    hutil.error(log_messages)
-
             if g_dist_config.use_systemd():
                 install_lad_as_systemd_service()
             hutil.do_status_report(g_ext_op_type, "success", '0', "Install succeeded")
@@ -395,7 +374,7 @@ def main(command):
                     hutil.do_status_report(g_ext_op_type, "error", '-1', "Enabled failed")
                     return
 
-                #Start the Telegraf and ME services on Enable after installation is complete
+                # Start the Telegraf and ME services on enable after installation is complete
                 start_telegraf_out, log_messages = telhandler.start_telegraf(is_lad=True)
                 if start_telegraf_out:
                     hutil.log("Successfully started metrics-sourcer.")

--- a/LAD-AMA-Common/metrics_ext_utils/metrics_ext_handler.py
+++ b/LAD-AMA-Common/metrics_ext_utils/metrics_ext_handler.py
@@ -296,7 +296,6 @@ def setup_me_service(configFolder, monitoringAccount, metrics_ext_bin, me_influx
 
     if not os.path.exists(configFolder):
         raise Exception("Metrics extension config directory does not exist. Failed to set up ME service.")
-        return False
 
     if os.path.isfile(me_service_template_path):
         copyfile(me_service_template_path, me_service_path)
@@ -309,13 +308,10 @@ def setup_me_service(configFolder, monitoringAccount, metrics_ext_bin, me_influx
             daemon_reload_status = os.system("sudo systemctl daemon-reload")
             if daemon_reload_status != 0:
                 raise Exception("Unable to reload systemd after ME service file change. Failed to set up ME service.")
-                return False
         else:
             raise Exception("Unable to copy Metrics extension service file to {0}. Failed to set up ME service.".format(me_service_path))
-            return False
     else:
         raise Exception("Metrics extension service template file does not exist at {0}. Failed to set up ME service.".format(me_service_template_path))
-        return False
     return True
 
 
@@ -623,7 +619,6 @@ def setup_me(is_lad):
 
     if aad_auth_url == "":
         raise Exception("Unable to find AAD Authentication URL in the request error response. Failed to set up ME.")
-        return False
 
     #create metrics conf
     me_conf = create_metrics_extension_conf(az_resource_id, aad_auth_url)
@@ -685,7 +680,6 @@ def setup_me(is_lad):
             os.chmod(metrics_ext_bin, stat.S_IXGRP | stat.S_IRGRP | stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | stat.S_IXOTH | stat.S_IROTH)
     else:
         raise Exception("Unable to copy MetricsExtension Binary, could not find file at the location {0} . Failed to set up ME.".format(me_bin_local_path))
-        return False
 
     if is_lad:
         me_influx_port = metrics_constants.lad_metrics_extension_udp_port

--- a/LAD-AMA-Common/telegraf_utils/telegraf_config_handler.py
+++ b/LAD-AMA-Common/telegraf_utils/telegraf_config_handler.py
@@ -76,11 +76,9 @@ def parse_config(data, me_url, mdsd_url, is_lad, az_resource_id, subscription_id
     
     if len(data) == 0:
         raise Exception("Empty config data received.")
-        return []
 
     if me_url is None or mdsd_url is None:
         raise Exception("No url provided for Influxdb output plugin to ME, AMA.")
-        return []
 
     telegraf_json = {}
 
@@ -142,7 +140,6 @@ def parse_config(data, me_url, mdsd_url, is_lad, az_resource_id, subscription_id
 
     if len(telegraf_json) == 0:
         raise Exception("Unable to parse telegraf config into intermediate dictionary.")
-        return []
 
     excess_diskio_plugin_list_lad = ["total_transfers_filesystem", "read_bytes_filesystem", "total_bytes_filesystem", "write_bytes_filesystem", "reads_filesystem", "writes_filesystem"]
     excess_diskio_field_drop_list_str = ""
@@ -515,31 +512,28 @@ def stop_telegraf_service(is_lad):
         if os.path.isfile(telegraf_service_path):
             code = os.system("sudo systemctl stop metrics-sourcer")
         else:
-            return False, "Telegraf service file does not exist. Failed to stop telegraf service: metrics-sourcer.service ."
+            return False, "Telegraf service file does not exist. Failed to stop telegraf service: metrics-sourcer.service."
 
         if code != 0:
             return False, "Unable to stop telegraf service: metrics-sourcer.service. Run systemctl status metrics-sourcer.service for more info."
-    else:
-        #This VM does not have systemd, So we will use the pid from the last ran telegraf process and terminate it
-        _, configFolder = get_handler_vars()
-        telegraf_conf_dir = configFolder + "/telegraf_configs/"
-        telegraf_pid_path = telegraf_conf_dir + "telegraf_pid.txt"
-        if os.path.isfile(telegraf_pid_path):
-            pid = ""
-            with open(telegraf_pid_path, "r") as f:
-                pid = f.read()
-            if pid != "":
-                # Check if the process running is indeed telegraf, ignore if the process output doesn't contain telegraf
-                proc = subprocess.Popen(["ps -o cmd= {0}".format(pid)], stdout=subprocess.PIPE, shell=True)
-                output = proc.communicate()[0]
-                if telegraf_bin in output.decode('utf-8', 'ignore'):
-                    os.kill(int(pid), signal.SIGKILL)
-                else:
-                    return False, "Found a different process running with PID {0}. Failed to stop telegraf.".format(pid)
-            else:
-                return False, "No pid found for an currently running telegraf process in {0}. Failed to stop telegraf.".format(telegraf_pid_path)
-        else:
-            return False, "File containing the pid for the running telegraf process at {0} does not exit. Failed to stop telegraf".format(telegraf_pid_path)
+
+    # Whether or not VM has systemd, let's check if we have any telegraf pids saved and if so, terminate the associated process
+    _, configFolder = get_handler_vars()
+    telegraf_conf_dir = configFolder + "/telegraf_configs/"
+    telegraf_pid_path = telegraf_conf_dir + "telegraf_pid.txt"
+    if os.path.isfile(telegraf_pid_path):
+        with open(telegraf_pid_path, "r") as f:
+            for pid in f.readlines():
+                # Verify the pid actually belongs to telegraf
+                cmd_path = os.path.join("/proc", str(pid.strip("\n")), "cmdline")
+                if os.path.exists(cmd_path):
+                    with open(cmd_path, "r") as cmd_f:
+                        cmdline = cmd_f.readlines()
+                        if cmdline[0].find(telegraf_bin) >= 0:
+                            os.kill(int(pid), signal.SIGKILL)
+        os.remove(pids_filepath)
+    else if not metrics_utils.is_systemd():
+        return False, "Could not find telegraf service nor process to stop."
 
     return True, "Successfully stopped metrics-sourcer service"
 
@@ -567,21 +561,20 @@ def remove_telegraf_service():
 
 def setup_telegraf_service(telegraf_bin, telegraf_d_conf_dir, telegraf_agent_conf):
     """
-    Remove the metrics-sourcer service if the VM is using systemd
-    This method is called after stop_telegraf_service by the main extension code during Extension uninstall
-    :param is_lad: boolean whether the extension is LAD or not (AMA)
+    Add the metrics-sourcer service if the VM is using systemd
+    This method is called in handle_config
+    :param telegraf_bin: path to the telegraf binary
+    :param telegraf_d_conf_dir: path to telegraf .d conf subdirectory
+    :param telegraf_agent_conf: path to telegraf .conf file
     """
     telegraf_service_path = get_telegraf_service_path()
     telegraf_service_template_path = os.getcwd() + "/services/metrics-sourcer.service"
 
-
     if not os.path.exists(telegraf_d_conf_dir):
         raise Exception("Telegraf config directory does not exist. Failed to setup telegraf service.")
-        return False
 
     if not os.path.isfile(telegraf_agent_conf):
         raise Exception("Telegraf agent config does not exist. Failed to setup telegraf service.")
-        return False
 
     if os.path.isfile(telegraf_service_template_path):
 
@@ -595,21 +588,18 @@ def setup_telegraf_service(telegraf_bin, telegraf_d_conf_dir, telegraf_agent_con
             daemon_reload_status = os.system("sudo systemctl daemon-reload")
             if daemon_reload_status != 0:
                 raise Exception("Unable to reload systemd after Telegraf service file change. Failed to setup telegraf service.")
-                return False
         else:
             raise Exception("Unable to copy Telegraf service template file to {0}. Failed to setup telegraf service.".format(telegraf_service_path))
-            return False
     else:
         raise Exception("Telegraf service template file does not exist at {0}. Failed to setup telegraf service.".format(telegraf_service_template_path))
-        return False
 
     return True
 
 
 def start_telegraf(is_lad):
     """
-    Start the telegraf service if VM is using is systemd, otherwise start the binary as a process and store the pid,
-    to a file in the telegraf config directory,
+    Start the telegraf service if VM is using is systemd, otherwise start the binary as a process and store the pid
+    to a file in the telegraf config directory
     This method is called after config setup is completed by the main extension code
     :param is_lad: boolean whether the extension is LAD or not (AMA)
     """
@@ -626,14 +616,17 @@ def start_telegraf(is_lad):
         log_messages += "Telegraf binary does not exist. Failed to start telegraf service."
         return False, log_messages
 
-    # If the VM has systemd, then we will copy over the systemd unit file and use that to start/stop
+    # Ensure that any old telegraf processes are cleaned up to avoid duplication
+    stop_telegraf_service(is_lad)
+
+    # If the VM has systemd, telegraf will be managed as a systemd service
     if metrics_utils.is_systemd():
         service_restart_status = os.system("sudo systemctl restart metrics-sourcer")
         if service_restart_status != 0:
             log_messages += "Unable to start Telegraf service. Failed to start telegraf service."
             return False, log_messages
 
-    #Else start telegraf as a process and save the pid to a file so that we can terminate it while disabling/uninstalling
+    # Otherwise, start telegraf as a process and save the pid to a file so that we can terminate it while disabling/uninstalling
     else:
         _, configFolder = get_handler_vars()
         telegraf_conf_dir = configFolder + "/telegraf_configs/"
@@ -652,8 +645,8 @@ def start_telegraf(is_lad):
             telegraf_pid = proc.pid
 
             # Write this pid to a file for future use
-            with open(telegraf_pid_path, "w+") as f:
-                f.write(str(telegraf_pid))
+            with open(telegraf_pid_path, "w") as f:
+                f.write(str(telegraf_pid) + '\n')
         else:
             out, err = proc.communicate()
             log_messages += "Unable to run telegraf binary as a process due to error - {0}. Failed to start telegraf.".format(err)
@@ -716,11 +709,9 @@ def handle_config(config_data, me_url, mdsd_url, is_lad):
 
     if retries > max_retries:
         raise Exception("Unable to find 'compute' key in imds query response. Reached max retry limit of - {0} times. Failed to setup Telegraf.".format(max_retries))
-        return False
 
     if "resourceId" not in data["compute"]:
         raise Exception("Unable to find 'resourceId' key in imds query response. Failed to setup Telegraf.")
-        return False
 
     az_resource_id = data["compute"]["resourceId"]
 
@@ -733,19 +724,16 @@ def handle_config(config_data, me_url, mdsd_url, is_lad):
 
     if "subscriptionId" not in data["compute"]:
         raise Exception("Unable to find 'subscriptionId' key in imds query response. Failed to setup Telegraf.")
-        return False
 
     subscription_id = data["compute"]["subscriptionId"]
 
     if "resourceGroupName" not in data["compute"]:
         raise Exception("Unable to find 'resourceGroupName' key in imds query response. Failed to setup Telegraf.")
-        return False
 
     resource_group = data["compute"]["resourceGroupName"]
 
     if "location" not in data["compute"]:
         raise Exception("Unable to find 'location' key in imds query response. Failed to setup Telegraf.")
-        return False
 
     region = data["compute"]["location"]
 

--- a/LAD-AMA-Common/telegraf_utils/telegraf_config_handler.py
+++ b/LAD-AMA-Common/telegraf_utils/telegraf_config_handler.py
@@ -645,8 +645,11 @@ def start_telegraf(is_lad):
             telegraf_pid = proc.pid
 
             # Write this pid to a file for future use
-            with open(telegraf_pid_path, "w") as f:
-                f.write(str(telegraf_pid) + '\n')
+            try:
+                with open(telegraf_pid_path, "a") as f:
+                    f.write(str(telegraf_pid) + '\n')
+            except Exception as e:
+                log_messages += "Successfully started telegraf binary, but could not save telegraf pidfile."
         else:
             out, err = proc.communicate()
             log_messages += "Unable to run telegraf binary as a process due to error - {0}. Failed to start telegraf.".format(err)

--- a/OmsAgent/omsagent.py
+++ b/OmsAgent/omsagent.py
@@ -532,11 +532,11 @@ def enable():
     the settings provided are incomplete or incorrect.
     Note: enable operation times out from WAAgent at 5 minutes
     """
-    
+
     if HUtilObject is not None:
         if HUtilObject.is_seq_smaller():
             return 0, "Current sequence number " + HUtilObject._context._seq_no + " is not greater than the sequence number of the most recent executed configuration, skipping enable."
-    
+
     exit_if_vm_not_supported('Enable')
 
     public_settings, protected_settings = get_settings()
@@ -677,7 +677,7 @@ def enable():
 
         #start telemetry process if enable is successful
         start_telemetry_process()
-        
+
         #save sequence number
         HUtilObject.save_seq()
 


### PR DESCRIPTION
It was reported that in some cases LAD may end up spawning numerous telegraf processes, leading to high resource consumption. This PR will address this by ensuring we
- Check for and stop previous telegraf processes before starting new one
- Do not start telegraf after Install and Enable both (should only happen for Enable); similarly remove redundant stop during Uninstall (already happens in Disable)
- When stopping telegraf, iterate through all PIDs that may be saved in the pidfile, in case there are multiple. Also, just read the `/proc/<pid>/cmdline` which seems simpler than making an `os.system` call, and is already well used in OMS/AMA wrappers.

263228506