### PR TITLE
Enable Online Encryption for data disks.

### DIFF
--- a/VMEncryption/main/Common.py
+++ b/VMEncryption/main/Common.py
@@ -75,6 +75,7 @@ class CommonVariables:
     sector_size = 512
     luks_header_size = 4096 * 512
     luks_header_size_v2 = 32768 * 512
+    luks_header_sector_v2 = "32768S"
     default_block_size = 52428800
     min_filesystem_size_support = 52428800 * 3
     default_file_system = 'ext4'
@@ -130,6 +131,7 @@ class CommonVariables:
     EncryptionDecryptionOperationKey = 'DecryptionOperation'
     EncryptionVolumeTypeKey = 'VolumeType'
     EncryptionDiskFormatQueryKey = 'DiskFormatQuery'
+    EncryptionModeKey = 'EncryptionMode'
 
     """
     crypt ongoing item config keys

--- a/VMEncryption/main/DiskUtil.py
+++ b/VMEncryption/main/DiskUtil.py
@@ -337,7 +337,13 @@ class DiskUtil(object):
             return keyslots
 
     def luks_check_reencryption(self, dev_path, header_file):
-        luks_dump_out = self._luks_get_header_dump(header_file or dev_path)
+        device_header = None
+        if header_file is None:
+            device_header = dev_path
+        else:
+            device_header = header_file
+
+        luks_dump_out = self._luks_get_header_dump(device_header)
 
         luks_version = self._extract_luks_version_from_dump(luks_dump_out)
 

--- a/VMEncryption/main/EncryptionEnvironment.py
+++ b/VMEncryption/main/EncryptionEnvironment.py
@@ -28,7 +28,7 @@ class EncryptionEnvironment(object):
         self.logger = logger
         self.encryption_config_path = '/var/lib/azure_disk_encryption_config/'
         self.daemon_lock_file_path = os.path.join(self.encryption_config_path, 'daemon_lock_file.lck')
-        self.resume_daemon_status_file_path = os.path.join(self.encryption_config_path, 'resume_daemon_status.txt')
+        self.resume_daemon_status_file_path = os.path.join(self.encryption_config_path, 'resume_daemon_status-')
         self.encryption_config_file_path = os.path.join(self.encryption_config_path, 'azure_crypt_config.ini')
         self.extension_parameter_file_path = os.path.join(self.encryption_config_path, 'azure_crypt_params.ini')
         self.azure_crypt_mount_config_path = os.path.join(self.encryption_config_path, 'azure_crypt_mount')

--- a/VMEncryption/main/EncryptionMarkConfig.py
+++ b/VMEncryption/main/EncryptionMarkConfig.py
@@ -30,6 +30,7 @@ class EncryptionMarkConfig(object):
         self.command = None
         self.volume_type = None
         self.diskFormatQuery = None
+        self.encryption_mode = None
         self.encryption_mark_config = ConfigUtil(self.encryption_environment.azure_crypt_request_queue_path,
                                                  'encryption_request_queue',
                                                  self.logger)
@@ -42,6 +43,9 @@ class EncryptionMarkConfig(object):
 
     def get_encryption_disk_format_query(self):
         return self.encryption_mark_config.get_config(CommonVariables.EncryptionDiskFormatQueryKey)
+
+    def get_encryption_mode(self):
+        return self.encryption_mark_config.get_config(CommonVariables.EncryptionModeKey)
 
     def config_file_exists(self):
         """
@@ -58,6 +62,8 @@ class EncryptionMarkConfig(object):
         key_value_pairs.append(volume_type)
         disk_format_query = ConfigKeyValuePair(CommonVariables.EncryptionDiskFormatQueryKey, self.diskFormatQuery)
         key_value_pairs.append(disk_format_query)
+        encryption_mode = ConfigKeyValuePair(CommonVariables.EncryptionModeKey, self.encryption_mode)
+        key_value_pairs.append(encryption_mode)
         self.encryption_mark_config.save_configs(key_value_pairs)
 
     def clear_config(self):

--- a/VMEncryption/main/OnlineEncryptionHandler.py
+++ b/VMEncryption/main/OnlineEncryptionHandler.py
@@ -31,7 +31,7 @@ class OnlineEncryptionHandler:
                     msg = "Encrypting {0} file system is not supported for data-preserving encryption. Consider using the encrypt-format-all option.".format(device_fs)
                 else:
                     msg = "AzureDiskEncryption does not support the {0} file system".format(device_fs)
-                logger.log(msg=msg, level=CommonVariables.ErrorLevel)
+                self.logger.log(msg=msg, level=CommonVariables.ErrorLevel)
                 return device_item
 
             umount_status_code = CommonVariables.success

--- a/VMEncryption/main/OnlineEncryptionHandler.py
+++ b/VMEncryption/main/OnlineEncryptionHandler.py
@@ -1,0 +1,150 @@
+from queue import Queue
+import uuid
+import os
+import threading
+
+from DiskUtil import DiskUtil
+from CryptMountConfigUtil import CryptMountConfigUtil
+from BekUtil import BekUtil
+from Common import CommonVariables, CryptItem, DeviceItem
+from CommandExecutor import CommandExecutor
+from OnlineEncryptionResumer import OnlineEncryptionResumer
+
+
+class OnlineEncryptionItem:
+    def __init__(self, crypt_item, bek_file_path):
+        self.crypt_item = crypt_item
+        self.bek_file_path = bek_file_path
+
+class OnlineEncryptionHandler:
+    def __init__(self, logger):
+        self.devices = Queue()
+        self.logger = logger
+        self.command_executor = CommandExecutor(self.logger)
+
+    def handle(self, device_items_to_encrypt, passphrase_file, disk_util, crypt_mount_config_util, bek_util):
+        for device_item in device_items_to_encrypt:
+            self.logger.log("Setting up device " + device_item.name)
+            device_fs = device_item.file_system.lower()
+            if device_fs not in CommonVariables.inplace_supported_file_systems:
+                if device_fs in CommonVariables.format_supported_file_systems:
+                    msg = "Encrypting {0} file system is not supported for data-preserving encryption. Consider using the encrypt-format-all option.".format(device_fs)
+                else:
+                    msg = "AzureDiskEncryption does not support the {0} file system".format(device_fs)
+                logger.log(msg=msg, level=CommonVariables.ErrorLevel)
+                return device_item
+
+            umount_status_code = CommonVariables.success
+            if device_item.mount_point is not None and device_item.mount_point != "":
+                umount_status_code = disk_util.umount(device_item.mount_point)
+                if umount_status_code != CommonVariables.success:
+                    self.logger.log("error occured when do the umount for: {0} with code: {1}".format(device_item.mount_point, umount_status_code))
+                    return device_item
+            
+            device_dev_path = os.path.join('/dev/', device_item.name)
+            luks_header_size = disk_util.get_luks_header_size()
+            size_shrink_to = (device_item.size - luks_header_size) / CommonVariables.sector_size
+            chk_shrink_result = disk_util.check_shrink_fs(dev_path=device_dev_path, size_shrink_to=size_shrink_to)
+
+            if chk_shrink_result != CommonVariables.process_success:
+                self.logger.log(msg="check shrink fs failed with code {0} for {1}".format(chk_shrink_result, original_dev_path),
+                           level=CommonVariables.ErrorLevel)
+                self.logger.log(msg="Your file system may not have enough space to do the encryption or file System may not support resizing")
+                return device_item
+
+            mapper_name = str(uuid.uuid4())
+            init_status_code = self.command_executor.ExecuteInBash('cryptsetup reencrypt --encrypt --init-only --reduce-device-size {0} {1} {2} -d {3} -q'.format(CommonVariables.luks_header_sector_v2,
+                                                                                                                                                                  device_dev_path, mapper_name, passphrase_file))
+            if init_status_code != CommonVariables.success:
+                self.logger.log("Failed to setup encryption layer for device: " + device_item.name)
+                return device_item
+            
+            crypt_item = self.update_crypttab_and_fstab(disk_util, crypt_mount_config_util, mapper_name, device_dev_path, device_item.file_system, device_item.mount_point)
+
+            self.devices.put(OnlineEncryptionItem(crypt_item, passphrase_file))
+
+    def update_crypttab_and_fstab(self, disk_util, crypt_mount_config_util, mapper_name, device_dev_path, device_filesystem, device_mount_point):
+        crypt_item_to_update = CryptItem()
+        crypt_item_to_update.mapper_name = mapper_name
+        original_dev_name_path = device_dev_path
+        crypt_item_to_update.dev_path = disk_util.get_persistent_path_by_sdx_path(original_dev_name_path)
+        crypt_item_to_update.luks_header_path = None
+        crypt_item_to_update.file_system = device_filesystem
+        crypt_item_to_update.uses_cleartext_key = False
+        crypt_item_to_update.current_luks_slot = 0
+        # if the original mountpoint is empty, then leave
+        # it as None
+        mount_point = device_mount_point
+        if mount_point == "" or mount_point is None:
+            crypt_item_to_update.mount_point = "None"
+        else:
+            crypt_item_to_update.mount_point = mount_point
+        
+        device_mapper_path = os.path.join(CommonVariables.dev_mapper_root, mapper_name)
+
+        if crypt_item_to_update.mount_point != "None":
+            disk_util.mount_filesystem(device_mapper_path, crypt_item_to_update.mount_point)
+            backup_folder = os.path.join(crypt_item_to_update.mount_point, ".azure_ade_backup_mount_info/")
+            update_crypt_item_result = crypt_mount_config_util.add_crypt_item(crypt_item_to_update, backup_folder)
+        else:
+            logger.log("the crypt_item_to_update.mount_point is None, so we do not mount it.")
+            update_crypt_item_result = crypt_mount_config_util.add_crypt_item(crypt_item_to_update)
+
+        if not update_crypt_item_result:
+            self.logger.log(msg="update crypt item failed", level=CommonVariables.ErrorLevel)
+
+        if mount_point:
+            self.logger.log(msg="removing entry for unencrypted drive from fstab", level=CommonVariables.InfoLevel)
+            crypt_mount_config_util.modify_fstab_entry_encrypt(mount_point, device_mapper_path)
+        else:
+            self.logger.log(msg=original_dev_name_path + " is not defined in fstab, no need to update", level=CommonVariables.InfoLevel)
+
+        return crypt_item_to_update
+
+    def get_online_encryption_item(self, queue_lock, log_lock):
+        online_encryption_item = None
+        queue_lock.acquire()
+        try:
+            if not self.devices.empty():
+                online_encryption_item = self.devices.get()
+            else:
+                self.update_log("No more devices to encrypt.", log_lock)
+        except Exception:
+            self.update_log("Error while trying to get device to encrypt.", log_lock)
+            pass
+        finally:
+            queue_lock.release()
+        return online_encryption_item
+
+
+    def resume_encryption(self, disk_util, log_lock, queue_lock):
+        online_encryption_item = self.get_online_encryption_item(queue_lock, log_lock)
+        while online_encryption_item is not None:
+            self.update_log("Picked up device "+ online_encryption_item.crypt_item.dev_path, log_lock)
+            OnlineEncryptionResumer(online_encryption_item.crypt_item, disk_util, online_encryption_item.bek_file_path, self.logger, None).begin_resume(False, log_lock)
+            online_encryption_item = self.get_online_encryption_item(queue_lock, log_lock)
+        self.devices.task_done()
+
+    def update_log(self, msg, log_lock):
+        log_lock.acquire()
+        self.logger.log(msg)
+        log_lock.release()
+
+
+    def handle_resume_encryption(self, disk_util):
+        max_threads = self.devices.qsize() #For now there will be a thread for each volume
+        threads = []
+        log_lock = threading.Lock()
+        queue_lock = threading.Lock()
+        for thr in range(max_threads):
+            thread = threading.Thread(target=self.resume_encryption, args=(disk_util, log_lock, queue_lock))
+            threads.append(thread)
+            threads[thr].start()
+
+        for thr in range(max_threads):
+            threads[thr].join()
+
+
+
+
+

--- a/VMEncryption/main/OnlineEncryptionResumer.py
+++ b/VMEncryption/main/OnlineEncryptionResumer.py
@@ -20,6 +20,7 @@ import subprocess
 import os
 import os.path
 from time import sleep
+from threading import Lock
 
 from Common import CommonVariables
 
@@ -34,19 +35,33 @@ class OnlineEncryptionResumer:
         self.hutil = hutil
 
     def _get_status_file(self):
-        return self.disk_util.encryption_environment.resume_daemon_status_file_path
+        return self.disk_util.encryption_environment.resume_daemon_status_file_path + self.crypt_item.mapper_name + ".txt"
 
-    def begin_resume(self):
+    def update_log(self, msg, lock):
+        if lock is None:
+            self.logger.log(msg)
+            return
+        else:
+            lock.acquire()
+            self.logger.log(msg)
+            lock.release()
+
+    def begin_resume(self, log_status=True, lock=None):
+        self.logger.log("Starting background resume encrytion for device: " + self.crypt_item.dev_path)
         mapper_path = os.path.join(CommonVariables.dev_mapper_root, self.crypt_item.mapper_name)
         if not os.path.exists(mapper_path):
-            self.logger.log("{0} does not exist. Exiting Resume encryption daemon.".format(mapper_path))
+            self.update_log("{0} does not exist. Exiting Resume encryption daemon.".format(mapper_path), lock)
             return
 
         if not self.disk_util.luks_check_reencryption(self.crypt_item.dev_path, self.crypt_item.luks_header_path):
-            self.logger.log("{0} is not in reencryption.".format(mapper_path))
+            self.update_log("{0} is not in reencryption.".format(mapper_path), lock)
             return
 
-        resume_cmd = "cryptsetup reencrypt --resume-only --active-name {0} --header {1} -d {2} --resilience journal".format(self.crypt_item.mapper_name, self.crypt_item.luks_header_path or self.crypt_item.dev_path, self.bek_file_path)
+        resume_cmd = None
+        if self.crypt_item.luks_header_path is None:
+            resume_cmd = "cryptsetup reencrypt --resume-only --active-name {0} -d {1} --resilience journal".format(self.crypt_item.mapper_name, self.bek_file_path)
+        else:
+            resume_cmd = "cryptsetup reencrypt --resume-only --active-name {0} --header {1} -d {2} --resilience journal".format(self.crypt_item.mapper_name, self.crypt_item.luks_header_path, self.bek_file_path)
         status_file_path = self._get_status_file()
         with open(status_file_path, "wb") as status_file_write:
             args = shlex.split(resume_cmd)
@@ -63,15 +78,21 @@ class OnlineEncryptionResumer:
                         status_message = lines[-1].strip()
                 if status_message:
                     full_message = "Background encrypting {0} - {1}".format(self.crypt_item.dev_path, status_message)
+                    if log_status:
+                        self.hutil.do_status_report(operation='DataCopy',
+                                                    status=CommonVariables.extension_success_status,
+                                                    status_code=str(CommonVariables.success),
+                                                    message=full_message)
+                    else:
+                        self.update_log(full_message, lock)
+            if child.returncode == CommonVariables.success:
+                message = "Background encryption finished for {0}".format(self.crypt_item.dev_path)
+                if log_status:
                     self.hutil.do_status_report(operation='DataCopy',
                                                 status=CommonVariables.extension_success_status,
                                                 status_code=str(CommonVariables.success),
-                                                message=full_message)
-            if child.returncode == CommonVariables.success:
-                message = "Background encryption finished for {0}".format(self.crypt_item.dev_path)
-                self.hutil.do_status_report(operation='DataCopy',
-                                            status=CommonVariables.extension_success_status,
-                                            status_code=str(CommonVariables.success),
-                                            message=message)
+                                                message=message)
+                else:
+                    self.update_log(message, lock)
         # Let's clean up after ourselves
         os.remove(status_file_path)

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -361,7 +361,7 @@ def update_encryption_settings(extra_items_to_encrypt=[]):
             logger.log('Secret has already been updated')
             disk_util.log_lsblk_output()
 
-            if extension_parameter.passphrase and extension_parameter.passphrase != open(existing_passphrase_file,'r').read():
+            if extension_parameter.passphrase and extension_parameter.passphrase.decode("utf-8") != open(existing_passphrase_file,'r').read():
                 logger.log("The new passphrase has not been placed in BEK volume yet")
                 logger.log("Skipping removal of old passphrase")
                 exit_without_status_report()
@@ -369,7 +369,7 @@ def update_encryption_settings(extra_items_to_encrypt=[]):
             logger.log('Removing old passphrase')
 
             temp_oldkeyfile = tempfile.NamedTemporaryFile(delete=False)
-            temp_oldkeyfile.write(old_passphrase)
+            temp_oldkeyfile.write(old_passphrase.encode("utf-8"))
             temp_oldkeyfile.close()
 
             for crypt_item in crypt_mount_config_util.get_crypt_items():


### PR DESCRIPTION
Online encryption of data disk flow:
1. Unmount data volume and create encryption layer.
2. Update crypttab/fstab for the disk
3. Resume parallel encryption for the disks.

This PR is not on our dev branch.
The changes will be merged to dev branch when all the sub features are ready. 