### PR TITLE
[AMA] Configure defaults in enable

### DIFF
--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -164,8 +164,6 @@ def main():
             operation = 'Update'
         elif re.match('^([-/]*)(metrics)', option):
             operation = 'Metrics'
-        elif re.match('^([-/]*)(arc)', option):
-            operation = 'Arc'
     except Exception as e:
         waagent_log_error(str(e))
 
@@ -356,7 +354,7 @@ def enable():
     global AMAServiceStartCommand, AMAServiceStatusCommand
 
     if HUtilObject:
-        if(HUtilObject.is_seq_smaller()):
+        if HUtilObject.is_seq_smaller():
             return 0, "Current sequence number, " + HUtilObject._context._seq_no + ", is not greater than the sequence number of the most recent executed configuration. Skipping enable"
 
     exit_if_vm_not_supported('Enable')
@@ -371,7 +369,7 @@ def enable():
         ("MDSD_SPOOL_DIRECTORY", "/var/opt/microsoft/azuremonitoragent"),
         ("MDSD_OPTIONS", "\"-A -c /etc/opt/microsoft/azuremonitoragent/mdsd.xml -d -r $MDSD_ROLE_PREFIX -S $MDSD_SPOOL_DIRECTORY/eh -L $MDSD_SPOOL_DIRECTORY/events\""),
         ("MDSD_USE_LOCAL_PERSISTENCY", "true"),
-        ("MDSD_TCMALLOC_RELEASE_FREQ_SEC", "1")
+        ("MDSD_TCMALLOC_RELEASE_FREQ_SEC", "1"),
         ("MONITORING_USE_GENEVA_CONFIG_SERVICE", "false"),
         ("ENABLE_MCS", "false")
     ])

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -355,7 +355,8 @@ def enable():
 
     if HUtilObject:
         if HUtilObject.is_seq_smaller():
-            return 0, "Current sequence number, " + HUtilObject._context._seq_no + ", is not greater than the sequence number of the most recent executed configuration. Skipping enable"
+            hutil_log_info("Current sequence number, " + HUtilObject._context._seq_no + ", is not greater than the sequence number of the most recent executed configuration. Skipping enable")
+            return 0, ""
 
     exit_if_vm_not_supported('Enable')
 
@@ -529,11 +530,11 @@ def enable():
 
     try:
         if os.path.isfile(config_file):
-            new_config = "\n".join(["export {0}={1}".format(key, value) for key, value in default_configs.items()])
+            new_config = "\n".join(["export {0}={1}".format(key, value) for key, value in default_configs.items()]) + "\n"
 
             with open(temp_config_file, "w") as f:
                 wrote_len = f.write(new_config)
-                config_updated = True if wrote_len is not None and len(wrote_len) > 0 else False
+                config_updated = True if wrote_len is not None and wrote_len > 0 else False
 
             if not config_updated or not os.path.isfile(temp_config_file):
                 log_and_exit("Enable", GenericErrorCode, "Error while updating environment variables in {0}".format(config_file))
@@ -553,11 +554,11 @@ def enable():
     service_name = get_service_name()
 
     # Start and enable systemd services so they are started after system reboot.
-    AMAServiceStartCommand = 'systemctl start {0} && systemctl enable {0}'.format(service_name)
+    AMAServiceStartCommand = 'systemctl restart {0} && systemctl enable {0}'.format(service_name)
     AMAServiceStatusCommand = 'systemctl status {0}'.format(service_name)
     if not is_systemd():
         hutil_log_info("The VM doesn't have systemctl. Using the init.d service to start {0}.".format(service_name))
-        AMAServiceStartCommand = '/etc/init.d/{0} start'.format(service_name)
+        AMAServiceStartCommand = '/etc/init.d/{0} restart'.format(service_name)
         AMAServiceStatusCommand = '/etc/init.d/{0} status'.format(service_name)
 
     hutil_log_info('Handler initiating onboarding.')
@@ -1581,7 +1582,7 @@ class ParameterMissingException(AzureMonitorAgentForLinuxException):
     error_code = MissingorInvalidParameterErrorCode
     def get_error_message(self, operation):
         return '{0} failed due to a missing parameter: {1}'.format(operation,
-                                                                   self)
+                                                                   self.error_code)
 
 if __name__ == '__main__' :
     main()

--- a/OmsAgent/omsagent.py
+++ b/OmsAgent/omsagent.py
@@ -1061,6 +1061,8 @@ def detect_multiple_connections(workspace_id):
         # default encoding in python is ascii in python < 3
         if sys.version_info < (3,):
             output = utfoutput.decode('utf8').encode('utf8')
+        else:
+            output = utfoutput
 
         if output.strip().lower() != 'no workspace':
             for line in output.split('\n'):


### PR DESCRIPTION
- The configuration of the defaults file should occur during `enable()` not `install()`, otherwise subsequent enables with new configuration after initial install (e.g. to add a proxy) will have no effect.
- I believe we should be creating a **fresh defaults file each enable**, rather than updating/appending to an existing file. With the update/append model, we aren't actually applying the desired state, and bugs could occur (imagine user specifies a managed identity, but then wants to go back to using the default identity; with the update/append model, we will leave the `MANAGED_IDENTITY` variable set wrongly). It will incur a small penalty in that any addition to the `azuremonitoragent.default` file in the main repo will need to be reflected here.
- Use an `OrderedDict` to make the generation logic for the defaults file much cleaner