### PR TITLE
Install insserv-compat pkg on SUSE 15 VMs

### DIFF
--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -268,10 +268,10 @@ def install():
 
     # Check if SUSE 15 VMs have /sbin/insserv package (required for AMA 1.14.4+)
     if (vm_dist.lower().startswith('suse') or vm_dist.lower().startswith('sles')) and vm_ver.startswith('15'):
-        check_insserv = os.system("which insserv")
+        check_insserv, _ = run_command_and_log("which insserv")
         if check_insserv != 0:
             hutil_log_info("'insserv-compat' package missing from SUSE 15 machine, installing to allow AMA to run.")
-            insserv_exit_code, insserv_output = run_command_and_log("zypper install --non-interactive insserv-compat")
+            insserv_exit_code, insserv_output = run_command_and_log("zypper --non-interactive install insserv-compat")
             if insserv_exit_code != 0:
                 return insserv_exit_code, insserv_output
 
@@ -288,7 +288,7 @@ def install():
     exit_code, output = run_command_with_retries_output(AMAInstallCommand, retries = 15,
                                          retry_check = retry_if_dpkg_locked,
                                          final_check = final_check_if_dpkg_locked)
-    
+
     # Set task limits to max of 65K in suse 12
     # Based on Task 9764411: AMA broken after 1.7 in sles 12 - https://dev.azure.com/msazure/One/_workitems/edit/9764411
     if vm_dist.lower().startswith('suse'):


### PR DESCRIPTION
For AMA 1.14.4 and onward, when enabling AMA, enable() will call `systemctl enable azuremonitoragent` in order to ensure services start after reboot (original PR for the change here: https://github.com/Azure/azure-linux-extensions/pull/1446). Unfortunately, for SUSE/SLES 15 VMs, this command breaks due to a missing requirement - the insserv-compat package. This fix manually installs the insserv-compat package onto SUSE/SLES 15 VMs if it doesn't exist upon install time.