### PR TITLE
Check if PID file is empty before reading

### DIFF
--- a/OmsAgent/omsagent.py
+++ b/OmsAgent/omsagent.py
@@ -369,7 +369,7 @@ def stop_telemetry_process():
             for pid in f.readlines():
                 # Verify the pid actually belongs to omsagent.
                 cmd_file = os.path.join("/proc", str(pid.strip("\n")), "cmdline")
-                if os.path.exists(cmd_file):
+                if os.path.exists(cmd_file) and (os.path.getsize(cmd_file) > 0):
                     with open(cmd_file, "r") as pidf:
                         cmdline = pidf.readlines()
                         if cmdline[0].find("omsagent.py") >= 0 and cmdline[0].find("-telemetry") >= 0:


### PR DESCRIPTION
If the PID cmdline file exists but is empty, then readlines() returns an empty list `[]`, which will cause the `cmdline[0]` checks to fail saying "list index out of range". This verifies that the file both exists and has contents when doing this check, which should cover this edge case.