### PR TITLE
Fallback to platform-python on RHEL 8.0

### DIFF
--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -741,7 +741,7 @@ def start_metrics_process():
 
     # Start metrics watcher
     ama_path = os.path.join(os.getcwd(), 'agent.py')
-    args = ['python{0}'.format(sys.version_info[0]), ama_path, '-metrics']
+    args = [sys.executable, ama_path, '-metrics']
     log = open(os.path.join(os.getcwd(), 'daemon.log'), 'w')
     hutil_log_info('start watcher process '+str(args))
     subprocess.Popen(args, stdout=log, stderr=log)
@@ -945,7 +945,7 @@ def start_arc_process():
 
     #start arc watcher
     ama_path = os.path.join(os.getcwd(), 'agent.py')
-    args = ['python{0}'.format(sys.version_info[0]), ama_path, '-arc']
+    args = [sys.executable, ama_path, '-arc']
     log = open(os.path.join(os.getcwd(), 'daemon.log'), 'w')
     hutil_log_info('start watcher process '+str(args))
     subprocess.Popen(args, stdout=log, stderr=log)

--- a/AzureMonitorAgent/shim.sh
+++ b/AzureMonitorAgent/shim.sh
@@ -21,7 +21,7 @@ function find_python() {
         eval ${future_path}="${PWD}/ext/future:"
     elif command -v /usr/libexec/platform-python >/dev/null 2>&1 ; then
         # If a user-installed python isn't available, check for a platform-python. This is typically only used in RHEL 8.0.
-        echo "User-installed python not found. Using /usr/libexec/platform-python as the python interpreter." >&1
+        echo "User-installed python not found. Using /usr/libexec/platform-python as the python interpreter."
         eval ${python_exec_command}="/usr/libexec/platform-python"
         # do not set future_path; future seems to cause interference with preexisting packages in python 3 environment
     fi

--- a/AzureMonitorAgent/shim.sh
+++ b/AzureMonitorAgent/shim.sh
@@ -21,7 +21,7 @@ function find_python() {
         eval ${future_path}="${PWD}/ext/future:"
     elif command -v /usr/libexec/platform-python >/dev/null 2>&1 ; then
         # If a user-installed python isn't available, check for a platform-python. This is typically only used in RHEL 8.0.
-        echo "User-installed python not found. Using /usr/libexec/platform-python as the python interpreter." >&2
+        echo "User-installed python not found. Using /usr/libexec/platform-python as the python interpreter." >&1
         eval ${python_exec_command}="/usr/libexec/platform-python"
         # do not set future_path; future seems to cause interference with preexisting packages in python 3 environment
     fi

--- a/AzureMonitorAgent/shim.sh
+++ b/AzureMonitorAgent/shim.sh
@@ -21,6 +21,7 @@ function find_python() {
         eval ${future_path}="${PWD}/ext/future:"
     elif command -v /usr/libexec/platform-python >/dev/null 2>&1 ; then
         # If a user-installed python isn't available, check for a platform-python. This is typically only used in RHEL 8.0.
+        echo "User-installed python not found. Using /usr/libexec/platform-python as the python interpreter." >&2
         eval ${python_exec_command}="/usr/libexec/platform-python"
         # do not set future_path; future seems to cause interference with preexisting packages in python 3 environment
     fi

--- a/AzureMonitorAgent/shim.sh
+++ b/AzureMonitorAgent/shim.sh
@@ -19,6 +19,10 @@ function find_python() {
     elif command -v python2 >/dev/null 2>&1 ; then
         eval ${python_exec_command}="python2"
         eval ${future_path}="${PWD}/ext/future:"
+    elif command -v /usr/libexec/platform-python >/dev/null 2>&1 ; then
+        # If a user-installed python isn't available, check for a platform-python. This is typically only used in RHEL 8.0.
+        eval ${python_exec_command}="/usr/libexec/platform-python"
+        # do not set future_path; future seems to cause interference with preexisting packages in python 3 environment
     fi
 }
 


### PR DESCRIPTION
On RHEL 8.0, fallback to use platform-python if a user-installed python version is not present on the machine.