### PR TITLE
certificatePath and certificateKeyPath should be read as binary

### DIFF
--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -367,7 +367,7 @@ def install():
 
         if "certificatePath" in protected_settings:
             try:
-                with open(protected_settings.get("certificatePath"), 'r') as f:
+                with open(protected_settings.get("certificatePath"), 'rb') as f:
                     MONITORING_GCS_CERT_CERTFILE = f.read()
             except Exception as ex:
                 log_and_exit('Install', MissingorInvalidParameterErrorCode, 'Failed to read certificate {0}: {1}'.format(protected_settings.get("certificatePath"), ex))
@@ -378,7 +378,7 @@ def install():
 
         if "certificateKeyPath" in protected_settings:
             try:
-                with open(protected_settings.get("certificateKeyPath"), 'r') as f:
+                with open(protected_settings.get("certificateKeyPath"), 'rb') as f:
                     MONITORING_GCS_CERT_KEYFILE = f.read()
             except Exception as ex:
                 log_and_exit('Install', MissingorInvalidParameterErrorCode, 'Failed to read certificate key {0}: {1}'.format(protected_settings.get("certificateKeyPath"), ex))

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -347,7 +347,7 @@ def install():
 
         # check if required GCS params are available
         MONITORING_GCS_CERT_CERTFILE = None
-        if "certificate" in protected_settings:           
+        if "certificate" in protected_settings:
             MONITORING_GCS_CERT_CERTFILE = base64.standard_b64decode(protected_settings.get("certificate"))
 
         if "certificatePath" in protected_settings:

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -348,11 +348,27 @@ def install():
         # check if required GCS params are available
         MONITORING_GCS_CERT_CERTFILE = None
         if "certificate" in protected_settings:
-            MONITORING_GCS_CERT_CERTFILE = base64.standard_b64decode(protected_settings.get("certificate"))
+            certificate = protected_settings.get("certificate")
+            # Try to handle a local path first if url style is provider,
+            # then fallback as base64 encoded certificate payload
+            if certificate.startsWith('file:'):
+                certificate = certificate[5:]
+                with open(certificate, 'r') as f:
+                    MONITORING_GCS_CERT_CERTFILE = f.read()
+            else:
+                MONITORING_GCS_CERT_CERTFILE = base64.standard_b64decode(certificate)
 
         MONITORING_GCS_CERT_KEYFILE = None
         if "certificateKey" in protected_settings:
-            MONITORING_GCS_CERT_KEYFILE = base64.standard_b64decode(protected_settings.get("certificateKey"))
+            certificateKey = protected_settings.get("certificateKey")
+            # Try to handle a local path first if url style is provider,
+            # then fallback as base64 encoded certificate payload
+            if certificateKey.startsWith('file:'):
+                certificateKey = certificateKey[5:]
+                with open(certificateKey, 'r') as f:
+                    MONITORING_GCS_CERT_KEYFILE = f.read()
+            else:
+                MONITORING_GCS_CERT_KEYFILE = base64.standard_b64decode(certificateKey)
 
         MONITORING_GCS_ENVIRONMENT = ""
         if "monitoringGCSEnvironment" in protected_settings:

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -351,16 +351,23 @@ def install():
             MONITORING_GCS_CERT_CERTFILE = base64.standard_b64decode(protected_settings.get("certificate"))
 
         if "certificatePath" in protected_settings:
-            with open(protected_settings.get("certificatePath"), 'r') as f:
-                MONITORING_GCS_CERT_CERTFILE = f.read()
+            try:
+                with open(protected_settings.get("certificatePath"), 'r') as f:
+                    MONITORING_GCS_CERT_CERTFILE = f.read()
+            except Exception as ex:
+                log_and_exit('Install', MissingorInvalidParameterErrorCode, 'Failed to read certificate {0}: {1}'.format(protected_settings.get("certificatePath"), ex))
 
         MONITORING_GCS_CERT_KEYFILE = None
         if "certificateKey" in protected_settings:
             MONITORING_GCS_CERT_KEYFILE = base64.standard_b64decode(protected_settings.get("certificateKey"))
 
         if "certificateKeyPath" in protected_settings:
-            with open(protected_settings.get("certificateKeyPath"), 'r') as f:
-                MONITORING_GCS_CERT_CERTFILE = f.read()
+            try:
+                with open(protected_settings.get("certificateKeyPath"), 'r') as f:
+                    MONITORING_GCS_CERT_CERTFILE = f.read()
+            except Exception as ex:
+                log_and_exit('Install', MissingorInvalidParameterErrorCode, 'Failed to read certificate key {0}: {1}'.format(protected_settings.get("certificateKeyPath"), ex))
+
 
         MONITORING_GCS_ENVIRONMENT = ""
         if "monitoringGCSEnvironment" in protected_settings:

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -364,10 +364,9 @@ def install():
         if "certificateKeyPath" in protected_settings:
             try:
                 with open(protected_settings.get("certificateKeyPath"), 'r') as f:
-                    MONITORING_GCS_CERT_CERTFILE = f.read()
+                    MONITORING_GCS_CERT_KEYFILE = f.read()
             except Exception as ex:
                 log_and_exit('Install', MissingorInvalidParameterErrorCode, 'Failed to read certificate key {0}: {1}'.format(protected_settings.get("certificateKeyPath"), ex))
-
 
         MONITORING_GCS_ENVIRONMENT = ""
         if "monitoringGCSEnvironment" in protected_settings:

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -347,28 +347,20 @@ def install():
 
         # check if required GCS params are available
         MONITORING_GCS_CERT_CERTFILE = None
-        if "certificate" in protected_settings:
-            certificate = protected_settings.get("certificate")
-            # Try to handle a local path first if url style is provider,
-            # then fallback as base64 encoded certificate payload
-            if certificate.startsWith('file:'):
-                certificate = certificate[5:]
-                with open(certificate, 'r') as f:
-                    MONITORING_GCS_CERT_CERTFILE = f.read()
-            else:
-                MONITORING_GCS_CERT_CERTFILE = base64.standard_b64decode(certificate)
+        if "certificate" in protected_settings:           
+            MONITORING_GCS_CERT_CERTFILE = base64.standard_b64decode(protected_settings.get("certificate"))
+
+        if "certificatePath" in protected_settings:
+            with open(protected_settings.get("certificatePath"), 'r') as f:
+                MONITORING_GCS_CERT_CERTFILE = f.read()
 
         MONITORING_GCS_CERT_KEYFILE = None
         if "certificateKey" in protected_settings:
-            certificateKey = protected_settings.get("certificateKey")
-            # Try to handle a local path first if url style is provider,
-            # then fallback as base64 encoded certificate payload
-            if certificateKey.startsWith('file:'):
-                certificateKey = certificateKey[5:]
-                with open(certificateKey, 'r') as f:
-                    MONITORING_GCS_CERT_KEYFILE = f.read()
-            else:
-                MONITORING_GCS_CERT_KEYFILE = base64.standard_b64decode(certificateKey)
+            MONITORING_GCS_CERT_KEYFILE = base64.standard_b64decode(protected_settings.get("certificateKey"))
+
+        if "certificateKeyPath" in protected_settings:
+            with open(protected_settings.get("certificateKeyPath"), 'r') as f:
+                MONITORING_GCS_CERT_CERTFILE = f.read()
 
         MONITORING_GCS_ENVIRONMENT = ""
         if "monitoringGCSEnvironment" in protected_settings:


### PR DESCRIPTION
With latest version of the agent extension, I've tried to leverage the new certificatePath and certificateKeyPath to read existing certificate, and the extension fails in the following way. As we write them back with 'wb', we need to load them as bytes.

2021/11/16 17:45:24 ERROR:Install failed with error: a bytes-like object is required, not 'str'
2021/11/16 17:45:24 ERROR:Stacktrace: Traceback (most recent call last):
2021/11/16 17:45:24 ERROR:  File "./agent.py", line 189, in main
2021/11/16 17:45:24 ERROR:    exit_code, output = operations[operation]()
2021/11/16 17:45:24 ERROR:  File "./agent.py", line 452, in install
2021/11/16 17:45:24 ERROR:    fh.write(MONITORING_GCS_CERT_CERTFILE)
2021/11/16 17:45:24 ERROR:TypeError: a bytes-like object is required, not 'str'
2021/11/16 17:45:24 ERROR:
2021/11/16 17:45:24 ERROR:[Microsoft.Azure.Monitor.AzureMonitorLinuxAgent-1.14.5] Install failed with error: a bytes-lik
e object is required, not 'str'
2021/11/16 17:45:24 ERROR:Stacktrace: Traceback (most recent call last):
2021/11/16 17:45:24 ERROR:  File "./agent.py", line 189, in main
2021/11/16 17:45:24 ERROR:    exit_code, output = operations[operation]()
2021/11/16 17:45:24 ERROR:  File "./agent.py", line 452, in install
2021/11/16 17:45:24 ERROR:    fh.write(MONITORING_GCS_CERT_CERTFILE)
2021/11/16 17:45:24 ERROR:TypeError: a bytes-like object is required, not 'str'
2021/11/16 17:45:24 ERROR:
2021/11/16 17:45:24 [Microsoft.Azure.Monitor.AzureMonitorLinuxAgent-1.14.5] Install,failed,1,Install failed with error:
a bytes-like object is required, not 'str'
2021/11/16 17:45:24 Stacktrace: Traceback (most recent call last):
2021/11/16 17:45:24   File "./agent.py", line 189, in main
2021/11/16 17:45:24     exit_code, output = operations[operation]()
2021/11/16 17:45:24   File "./agent.py", line 452, in install
2021/11/16 17:45:24     fh.write(MONITORING_GCS_CERT_CERTFILE)
2021/11/16 17:45:24 TypeError: a bytes-like object is required, not 'str'