### PR TITLE
Arm64 support for AMA

### DIFF
--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -109,6 +109,8 @@ PackageManager = ''
 PackageManagerOptions = ''
 MdsdCounterJsonPath = '/etc/opt/microsoft/azuremonitoragent/config-cache/metricCounters.json'
 
+SupportedArch = set(['x86_64', 'aarch64'])
+
 # Commands
 AMAInstallCommand = ''
 AMAUninstallCommand = ''
@@ -959,13 +961,14 @@ def parse_context(operation):
 
 def set_os_arch():
     """
-    Checks if the system is x86 or aarch64 based and replaces package name 
-    from *x86_64 to *aarch64 accordingly
+    Checks if the current system architecture is present in the SupportedArch set and replaces 
+    the package name accordingly
     """
-    global BundleFileName
+    global BundleFileName, SupportedArch
+    current_arch = platform.machine()
 
-    if platform.machine() == 'aarch64':
-        BundleFileName = BundleFileName.replace('x86_64','aarch64')
+    if current_arch in SupportedArch:
+        BundleFileName = BundleFileName.replace('x86_64', current_arch)
 
 def find_package_manager(operation):
     """

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -963,11 +963,9 @@ def set_os_arch():
     from *x86_64 to *aarch64 accordingly
     """
     global BundleFileName
-    
+
     if platform.machine() == 'aarch64':
         BundleFileName = BundleFileName.replace('x86_64','aarch64')
-
-
 
 def find_package_manager(operation):
     """

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -962,6 +962,8 @@ def set_os_arch():
     Checks if the system is x86 or aarch64 based and replaces package name 
     from *x86_64 to *aarch64 accordingly
     """
+    global BundleFileName
+    
     if platform.machine() == 'aarch64':
         BundleFileName = BundleFileName.replace('x86_64','aarch64')
 

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -262,6 +262,7 @@ def install():
     global AMAInstallCommand
 
     find_package_manager("Install")
+    set_os_arch()
     exit_if_vm_not_supported('Install')
     vm_dist, vm_ver = find_vm_distro('Install')
 
@@ -955,6 +956,15 @@ def parse_context(operation):
                               '{0}'.format(e))
             raise ParameterMissingException
     return hutil
+
+def set_os_arch():
+    """
+    Checks if the system is x86 or aarch64 based and replaces package name 
+    from *x86_64 to *aarch64 accordingly
+    """
+    if platform.machine() == 'aarch64':
+        BundleFileName = BundleFileName.replace('x86_64','aarch64')
+
 
 
 def find_package_manager(operation):


### PR DESCRIPTION
Added code to check for aarch64 machines and replace the package bundle name. aarch64 packages are included in the /package directory in the build pipeline.