### PR TITLE
[AMA] Move enable short-circuit to after defaults generation

### DIFF
--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -393,12 +393,7 @@ def enable():
     public_settings, protected_settings = get_settings()
 
     if (protected_settings is None or len(protected_settings) == 0) or (public_settings is not None and "proxy" in public_settings and "mode" in public_settings.get("proxy") and public_settings.get("proxy").get("mode") == "application"):
-        start_metrics_process()        
-
-    if HUtilObject:
-        if HUtilObject.is_seq_smaller():
-            hutil_log_info("Current sequence number, " + HUtilObject._context._seq_no + ", is not greater than the sequence number of the most recent executed configuration. Skipping enable")
-            return 0, ""
+        start_metrics_process()
 
     exit_if_vm_not_supported('Enable')
 
@@ -591,6 +586,13 @@ def enable():
             log_and_exit("Enable", GenericErrorCode, "Could not find the file {0}".format(config_file))
     except Exception as e:
         log_and_exit("Enable", GenericErrorCode, "Failed to add environment variables to {0}: {1}".format(config_file, e))
+
+    # Only restart AMA if we got new settings. But don't skip the above defaults content generation; otherwise, upon upgrading,
+    # the defaults content will be wiped but not regenerated (since sequence number does not increment with upgrade).
+    if HUtilObject:
+        if HUtilObject.is_seq_smaller():
+            hutil_log_info("Current sequence number, " + HUtilObject._context._seq_no + ", is not greater than the sequence number of the most recent executed configuration. Skipping enable")
+            return 0, ""
 
     service_name = get_service_name()
 


### PR DESCRIPTION
In upgrade scenario, waagent will do old disable > new update > old uninstall > new install > new enable. When AMA package is uninstalled it takes the /etc/default/azuremonitoragent file with it. After we added the enable short-circuit in #1403 as well as the config-in-enable changes in #1453, the upgrade scenario broke because we skipped the defaults file creation. This fixes that issue by only short-circuiting the service restart steps.