### PR TITLE
Remove object_id MI specifier in AMA

### DIFF
--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -704,8 +704,8 @@ def get_managed_identity():
         identifier_name = managedIdentity.get("identifier-name")
         identifier_value = managedIdentity.get("identifier-value")
 
-        if identifier_name not in ["object_id", "client_id", "mi_res_id"]:
-            return identifier_name, identifier_value, 'Invalid identifier-name provided; must be "object_id", "client_id", or "mi_res_id"'
+        if identifier_name not in ["client_id", "mi_res_id"]:
+            return identifier_name, identifier_value, 'Invalid identifier-name provided; must be "client_id" or "mi_res_id"'
 
         if not identifier_value:
             return identifier_name, identifier_value, 'Invalid identifier-value provided; cannot be empty'


### PR DESCRIPTION
UAI feature is not yet released, so no risk to remove param option. 

Removing this in 3P case to avoid customer confusion; SAI has an object id, but IMDS will not return a token for the SAI if an object id (even the object id of the SAI itself) is specified. The only way to get token for SAI is to make the "default" call when there is only SAI (no UAI) assigned to the machine. For UAI, customers can still use `client_id` and `mi_res_id` to specify the UAI they want used.

This does not remove the capability for 1P single or multitenant, which is configured otherwise (not through extension settings).