### PR TITLE
Add support for Arm64 Metrics Extension

### DIFF
--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -1030,13 +1030,28 @@ def parse_context(operation):
 def set_os_arch():
     """
     Checks if the current system architecture is present in the SupportedArch set and replaces 
-    the package name accordingly
+    the package names accordingly
     """
     global BundleFileName, SupportedArch
     current_arch = platform.machine()
 
     if current_arch in SupportedArch:
+
+        # Replace the AMA package name according to architecture
         BundleFileName = BundleFileName.replace('x86_64', current_arch)
+
+        # Rename the Arch appropriate metrics extension binary to MetricsExtension
+        MetricsExtensionDir = os.path.join(os.getcwd(), 'MetricsExtensionBin')
+        SupportedMEPath = os.path.join(MetricsExtensionDir, 'MetricsExtension_'+current_arch)
+
+        if os.path.exists(SupportedMEPath):
+            os.replace(SupportedMEPath, os.path.join(MetricsExtensionDir, 'MetricsExtension'))
+
+        # Cleanup unused ME binaries
+        for f in os.listdir(MetricsExtensionDir):
+            if f != 'MetricsExtension':
+                os.remove(os.path.join(MetricsExtensionDir, f))
+    
 
 def find_package_manager(operation):
     """

--- a/AzureMonitorAgent/packaging.sh
+++ b/AzureMonitorAgent/packaging.sh
@@ -38,7 +38,7 @@ mkdir -p packages MetricsExtensionBin ext/future amaCoreAgentBin agentLauncherBi
 
 # copy shell bundle to packages/
 cp $input_path/azuremonitoragent_$AGENT_VERSION* packages/
-cp $input_path/MetricsExtension MetricsExtensionBin/
+cp $input_path/MetricsExtension* MetricsExtensionBin/
 cp $input_path/amacoreagent amaCoreAgentBin/
 cp $input_path/agentlauncher agentLauncherBin/
 


### PR DESCRIPTION
This PR is related to changes made here - 
[Pull Request 5771163](https://dev.azure.com/msazure/One/_git/Compute-Runtime-Tux/pullrequest/5771163): Arm64 Metrics Extension
The pipeline will download both x86 and arm64 versions of ME and agent.py will determine which binary to use during installation.