### PR TITLE
Expose skipDockerProviderInstall option for the extension install

### DIFF
--- a/OmsAgent/README.md
+++ b/OmsAgent/README.md
@@ -24,7 +24,8 @@ Schema for the public configuration file looks like this:
 ```json
 {
   "workspaceId": "<workspace-id (guid)>",
-  "stopOnMultipleConnections": true/false
+  "stopOnMultipleConnections": true/false,
+  "skipDockerProviderInstall": true/false
 }
 ```
 
@@ -115,7 +116,8 @@ $Version = '<version>'
 
 $PublicConf = '{
     "workspaceId": "<workspace id>",
-    "stopOnMultipleConnections": true/false
+    "stopOnMultipleConnections": true/false,
+    "skipDockerProviderInstall": true/false
 }'
 $PrivateConf = '{
     "workspaceKey": "<workspace key>",
@@ -149,7 +151,8 @@ $Version = '<version>'
 
 $PublicConf = '{
     "workspaceId": "<workspace id>",
-    "stopOnMultipleConnections": true/false
+    "stopOnMultipleConnections": true/false,
+    "skipDockerProviderInstall": true/false
 }'
 $PrivateConf = '{
     "workspaceKey": "<workspace key>",
@@ -180,7 +183,8 @@ Set-AzureVMExtension -ExtensionName $ExtensionName -VM $vm `
     "typeHandlerVersion": "1.4",
     "settings": {
       "workspaceId": "<workspace id>",
-      "stopOnMultipleConnections": true/false
+      "stopOnMultipleConnections": true/false,
+      "skipDockerProviderInstall": true/false
     },
     "protectedSettings": {
       "workspaceKey": "<workspace key>",
@@ -197,7 +201,8 @@ Set-AzureVMExtension -ExtensionName $ExtensionName -VM $vm `
 ```json
 {
   "workspaceId": "MyWorkspaceId",
-  "stopOnMultipleConnections": true
+  "stopOnMultipleConnections": true,
+  "skipDockerProviderInstall": true
 }
 ```
 ```json

--- a/OmsAgent/README.md
+++ b/OmsAgent/README.md
@@ -19,7 +19,8 @@ Schema for the public configuration file looks like this:
 
 * `workspaceId`: (required, string) the OMS workspace id to onboard to
 * `stopOnMultipleConnections`: (optional, true/false) warn and stop onboarding if the machine already has a workspace connection; defaults to false
- 
+* `skipDockerProviderInstall`: (optional, true/false) if the value is true, then skips the installation of the docker provider; default value is false
+
 ```json
 {
   "workspaceId": "<workspace-id (guid)>",
@@ -48,7 +49,7 @@ Schema for the protected configuration file looks like this:
 You can deploy it using Azure CLI, Azure Powershell and ARM template.
 
 
- 
+
 ### 2.1. Using [**Azure CLI**][azure-cli]
 Before deploying OmsAgent Extension, you should configure your `public.json` and `protected.json`
 (in section 1.1 and 1.2 above).
@@ -240,5 +241,5 @@ Additional error codes and troubleshooting information can be found on the [OMS-
 [azure-powershell]: https://azure.microsoft.com/en-us/documentation/articles/powershell-install-configure/
 [azure-cli-classic]: https://docs.microsoft.com/en-us/cli/azure/install-classic-cli
 [azure-cli]: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli
-[arm-template]: http://azure.microsoft.com/en-us/documentation/templates/ 
+[arm-template]: http://azure.microsoft.com/en-us/documentation/templates/
 [arm-overview]: https://azure.microsoft.com/en-us/documentation/articles/resource-group-overview/


### PR DESCRIPTION
This PR, exposes the optional skipDockerProviderInstall option to the extension Settings so that we can customer can disable container monitoring data collection.