### PR TITLE
added change to config file for arm64 ME

### DIFF
--- a/LAD-AMA-Common/metrics_ext_utils/metrics_ext_handler.py
+++ b/LAD-AMA-Common/metrics_ext_utils/metrics_ext_handler.py
@@ -18,7 +18,7 @@
 
 # future imports have no effect on python 3 (verified in official docs)
 # importing from source causes import errors on python 3, lets skip import
-from platform import platform
+import platform
 import sys
 if sys.version_info[0] < 3:
     from future import standard_library

--- a/LAD-AMA-Common/metrics_ext_utils/metrics_ext_handler.py
+++ b/LAD-AMA-Common/metrics_ext_utils/metrics_ext_handler.py
@@ -18,6 +18,7 @@
 
 # future imports have no effect on python 3 (verified in official docs)
 # importing from source causes import errors on python 3, lets skip import
+from platform import platform
 import sys
 if sys.version_info[0] < 3:
     from future import standard_library
@@ -646,6 +647,11 @@ def setup_me(is_lad):
         me_monitoring_account = "CUSTOMMETRIC_"+ subscription_id + "_" +location
 
     custom_conf_path = me_config_dir + me_monitoring_account +"_MonitoringAccount_Configuration.json"
+
+    # Arm64 ME looks for lower case config file. Adding this until ME can update their code to look for config file with right casing.
+    if platform.machine() == "aarch64":
+        custom_conf_path = me_config_dir + me_monitoring_account.lower() +"_MonitoringAccount_Configuration.json"
+
     with open(custom_conf_path, "w") as f:
         f.write(custom_conf)
 


### PR DESCRIPTION
the ME binary for arm64 looks for a config file with lower casing and is unable to send data to LAW without this change. Long-term fix involves changes on the ME side to deal with this scenario.