### PR TITLE
Restore py2 compatibility

### DIFF
--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -1049,7 +1049,7 @@ def set_os_arch():
         SupportedMEPath = os.path.join(MetricsExtensionDir, 'MetricsExtension_'+current_arch)
 
         if os.path.exists(SupportedMEPath):
-            os.replace(SupportedMEPath, os.path.join(MetricsExtensionDir, 'MetricsExtension'))
+            os.rename(SupportedMEPath, os.path.join(MetricsExtensionDir, 'MetricsExtension'))
 
         # Cleanup unused ME binaries
         for f in os.listdir(MetricsExtensionDir):


### PR DESCRIPTION
change os.replace() to os.rename() to restore compatibility with distros that only have python2. 
The replace call isn't supported in python2 and causes install failures.