### PR TITLE
Add Mariner 2.0 support to AMA

### DIFF
--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -1194,7 +1194,8 @@ def is_vm_supported_for_extension(operation):
                        'debian' : ['9', '10'], # Debian
                        'ubuntu' : ['16.04', '18.04', '20.04'], # Ubuntu
                        'suse' : ['12'], 'sles' : ['15'], # SLES
-                       'cbl-mariner' : ['1'] # Mariner
+                       'cbl-mariner' : ['1'], # Mariner 1.0
+                       'mariner' : ['2.0'] # Mariner 2.0
     }
 
     vm_supported = False
@@ -1258,7 +1259,7 @@ def get_ssl_cert_info(operation):
         if distro.startswith(name):
             return 'SSL_CERT_DIR', '/etc/ssl/certs'
 
-    for name in ['centos', 'redhat', 'red hat', 'oracle', 'cbl-mariner', "rhel"]:
+    for name in ['centos', 'redhat', 'red hat', 'oracle', 'cbl-mariner', 'mariner', 'rhel']:
         if distro.startswith(name):
             return 'SSL_CERT_FILE', '/etc/pki/tls/certs/ca-bundle.crt'
 

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -1195,7 +1195,7 @@ def is_vm_supported_for_extension(operation):
                        'ubuntu' : ['16.04', '18.04', '20.04'], # Ubuntu
                        'suse' : ['12'], 'sles' : ['15'], # SLES
                        'cbl-mariner' : ['1'], # Mariner 1.0
-                       'mariner' : ['2.0'] # Mariner 2.0
+                       'mariner' : ['2'] # Mariner 2.0
     }
 
     vm_supported = False


### PR DESCRIPTION
I tested AMA 1.17.5 with these changes manually on Mariner 2.0, and was able to get logs to flow successfully. Adding official support for Mariner 2.0 for the next release of AMA.