### PR TITLE
Install GPG if not on VM + Debian 10 Support

### DIFF
--- a/OmsAgent/omsagent.py
+++ b/OmsAgent/omsagent.py
@@ -1024,9 +1024,12 @@ def exit_if_gpg_unavailable(operation):
     """
     check_exit_code, _ = run_get_output('which gpg', True, False)
     if check_exit_code is not 0:
+        hutil_log_info('GPG not found, attempting to install')
         exit_code, output = run_get_output(InstallExtraPackageCommand.format('gpg'))
         if exit_code is not 0:
             log_and_exit(operation, UnsupportedGpg, 'GPG could not be installed: {0}'.format(output))
+        else:
+            hutil_log_info('GPG successfully installed')
     return 0
 
 

--- a/OmsAgent/omsagent.py
+++ b/OmsAgent/omsagent.py
@@ -921,7 +921,7 @@ def is_vm_supported_for_extension():
     supported_dists = {'redhat' : ['6', '7', '8'], 'red hat' : ['6', '7', '8'], 'rhel' : ['6', '7', '8'], # Red Hat
                        'centos' : ['6', '7', '8'], # CentOS
                        'oracle' : ['6', '7', '8'], 'ol': ['6', '7', '8'], # Oracle
-                       'debian' : ['8', '9'], # Debian
+                       'debian' : ['8', '9', '10'], # Debian
                        'ubuntu' : ['14.04', '16.04', '18.04', '20.04'], # Ubuntu
                        'suse' : ['12', '15'], 'sles' : ['12', '15'], # SLES
                        'amzn' : ['2'] # AWS

--- a/OmsAgent/omsagent.py
+++ b/OmsAgent/omsagent.py
@@ -142,6 +142,7 @@ EnableErrorResolvingHost = 7
 EnableErrorOnboarding = 8
 EnableCalledBeforeSuccessfulInstall = 52 # since install is a missing dependency
 UnsupportedOpenSSL = 55 #60, temporary as it excludes from SLA
+UnsupportedGpg = 55
 # OneClick error codes
 OneClickErrorCode = 40
 ManagedIdentityExtMissingErrorCode = 41
@@ -283,6 +284,8 @@ def main():
     if exit_code is not 0:
         message = '{0} failed due to low disk space'.format(operation)
         log_and_exit(operation, exit_code, message)
+        
+    exit_if_gpg_unavailable(operation)
 
     # Invoke operation
     try:
@@ -1007,6 +1010,17 @@ def exit_if_openssl_unavailable(operation):
     exit_code, output = run_get_output('which openssl', True, False)
     if exit_code is not 0:
         log_and_exit(operation, UnsupportedOpenSSL, 'OpenSSL is not available')
+    return 0
+
+
+def exit_if_gpg_unavailable(operation):
+    """
+    Check if gpg is available to use
+    If not, throw error to return UnsupportedGpg error code
+    """
+    exit_code, output = run_get_output('which gpg', True, False)
+    if exit_code is not 0:
+        log_and_exit(operation, UnsupportedGpg, 'GPG is not available')
     return 0
 
 


### PR DESCRIPTION
We need GPG to validate the signature of the bundle before it's installed, adding a check for GPG to try and install it if it doesn't exist.

In addition, adding Debian 10 support, as this is the only blocker for Debian 10 (data verified to flow without issue if GPG is on VM).

(Note: PR also made in shell bundle code to attempt to install GPG at shell bundle step, https://github.com/microsoft/OMS-Agent-for-Linux/pull/1460, but as GPG is needed to validate the signature before the shell bundle, we need to have this check here as well.)