### PR TITLE
Update typo in wget instructions

### DIFF
--- a/AzureMonitorAgent/ama_tst/AMA-Troubleshooting-Tool.md
+++ b/AzureMonitorAgent/ama_tst/AMA-Troubleshooting-Tool.md
@@ -17,7 +17,7 @@ The Azure Monitor Linux Agent Troubleshooter currently can collect logs on a VM 
 
 The AMA Linux Troubleshooter can be downloaded and run by following the steps below.
 
-1. Copy the troubleshooter bundle onto your machine: `wget https://github.com/Azure/azure-linux-extensions/master/AzureMonitorAgent/ama_tst/ama_tst.tgz`
+1. Copy the troubleshooter bundle onto your machine: `wget https://github.com/Azure/azure-linux-extensions/raw/master/AzureMonitorAgent/ama_tst/ama_tst.tgz`
 2. Unpack the bundle: `tar -xzvf ama_tst.tar.gz`
 3. Run the troubleshooter: `sudo sh ama_troubleshooter.sh`
 


### PR DESCRIPTION
The original URL downloads the webpage the TST bundle is hosted on and puts it under the name of ama_tst.tgz, but under the hood it’s still a webpage. This would lead to an error stating the downloaded file was not in gzip format. Changing the URL to be the raw bundle itself.