### PR TITLE
update policycoreutils-python

### DIFF
--- a/Diagnostic/DistroSpecific.py
+++ b/Diagnostic/DistroSpecific.py
@@ -318,7 +318,7 @@ class CentosActions(RedhatActions):
 
     def install_required_packages(self):
         # policycoreutils-python missing on CentOS (still needed to manipulate SELinux policy)
-        return self.install_extra_packages(('policycoreutils-python',), True)
+        return self.install_extra_packages(('policycoreutils-python-utils',), True)
 
 
 DistroMap = {

--- a/Diagnostic/DistroSpecific.py
+++ b/Diagnostic/DistroSpecific.py
@@ -246,7 +246,7 @@ class RedhatActions(CommonActions):
     def install_required_packages(self):
         # policycoreutils-python missing on Oracle Linux (still needed to manipulate SELinux policy).
         # tar is really missing on Oracle Linux 7!
-        return self.install_extra_packages(('policycoreutils-python', 'tar'), True)
+        return self.install_extra_packages(('policycoreutils-python-utils', 'tar'), True)
 
     def is_package_handler(self, package_manager):
         return package_manager == "rpm"


### PR DESCRIPTION
update to policycoreutils-python-utils for class RedhatActions(CommonActions): to fix  Diagnostics extension install for RedHat.
