### PR TITLE
Fix incorrect strftime expressions (fixes #1573)

### DIFF
--- a/TestHandlerLinux/bin/disable.py
+++ b/TestHandlerLinux/bin/disable.py
@@ -28,8 +28,8 @@ waagent.Log(name+" - disable.py starting.")
 
 logfile=waagent.Log
 
-hutil.doStatusReport(name,seqNo,version,status_file,time.strftime("%Y-%M-%dT%H:%M:%SZ", time.gmtime()),
-                     time.strftime("%Y-%M-%dT%H:%M:%SZ", time.gmtime()),name,
+hutil.doStatusReport(name,seqNo,version,status_file,time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                     time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),name,
                      'Disable', 'transitioning', '0', 'Disabling', 'Process Config', 'transitioning', '0', 'Parsing ' + settings_file)
 hutil.doHealthReport(heartbeat_file,'NotReady','0','Proccessing Settings')
 
@@ -40,8 +40,8 @@ if not os.path.isfile(pidfile):
     error_string += pidfile +" is missing."
     error_string = "Error: " + error_string
     waagent.Error(error_string)
-    hutil.doStatusReport(name,seqNo,version,status_file,time.strftime("%Y-%M-%dT%H:%M:%SZ", time.gmtime()),
-                     time.strftime("%Y-%M-%dT%H:%M:%SZ", time.gmtime()),name,
+    hutil.doStatusReport(name,seqNo,version,status_file,time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                     time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),name,
                      'Disable', 'transitioning', '0', 'Disabling', 'Process Config', 'transitioning', '0', 'Parsing ' + settings_file)
 else:
     pid = waagent.GetFileContents(pidfile)

--- a/TestHandlerLinux/bin/enable.py
+++ b/TestHandlerLinux/bin/enable.py
@@ -29,8 +29,8 @@ waagent.Log(name+" - enable.py starting.")
 
 logfile=waagent.Log
 
-hutil.doStatusReport(name,seqNo,version,status_file,time.strftime("%Y-%M-%dT%H:%M:%SZ", time.gmtime()),
-                     time.strftime("%Y-%M-%dT%H:%M:%SZ", time.gmtime()),name,'Enable', 'NotReady', '0', 'Enabling',
+hutil.doStatusReport(name,seqNo,version,status_file,time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                     time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),name,'Enable', 'NotReady', '0', 'Enabling',
                      'Process Config', 'NotReady', '0', 'Parsing ' + settings_file)
 pub=""
 priv = ""
@@ -112,8 +112,8 @@ waagent.SetFileContents('./service_pid.txt',str(pid))
 # report ready 
 waagent.Log(name+" enabled.")
 
-hutil.doStatusReport(name,seqNo,version,status_file,time.strftime("%Y-%M-%dT%H:%M:%SZ", time.gmtime()),
-                     time.strftime("%Y-%M-%dT%H:%M:%SZ", time.gmtime()),name,'Enable','Ready','0',
+hutil.doStatusReport(name,seqNo,version,status_file,time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                     time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),name,'Enable','Ready','0',
                      'Enable service Succeed.', 'Exit Successfull', 'Ready', '0', 'Enable Completed.')
 
 #Spawn heartbeat.py if required.

--- a/TestHandlerLinux/bin/update.py
+++ b/TestHandlerLinux/bin/update.py
@@ -32,7 +32,7 @@ waagent.Log(name+" - update.py starting.")
 
 logfile=waagent.Log
 
-hutil.doStatusReport(name,seqNo,version,status_file,time.strftime("%Y-%M-%dT%H:%M:%SZ", time.gmtime()),time.strftime("%Y-%M-%dT%H:%M:%SZ", time.gmtime()),name,
+hutil.doStatusReport(name,seqNo,version,status_file,time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),name,
                'Update', 'transitioning', '0', 'Updating', 'Process Config', 'transitioning', '0', 'Parsing ' + settings_file)
 hutil.doHealthReport(heartbeat_file,'NotReady','0','Proccessing Settings')
 

--- a/TestHandlerLinux/installer/install.py
+++ b/TestHandlerLinux/installer/install.py
@@ -27,7 +27,7 @@ waagent.Log(name+" - install.py starting.")
 
 logfile=waagent.Log
 
-hutil.doStatusReport(name,seqNo,version,status_file,time.strftime("%Y-%M-%dT%H:%M:%SZ", time.gmtime()),time.strftime("%Y-%M-%dT%H:%M:%SZ", time.gmtime()),name,
+hutil.doStatusReport(name,seqNo,version,status_file,time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),name,
                'Install', 'transitioning', '0', 'Installing', 'Process Config', 'transitioning', '0', 'Parsing ' + settings_file)
 hutil.doHealthReport(heartbeat_file,'NotReady','0','Proccessing Settings')
 pub=""

--- a/TestHandlerLinux/installer/uninstall.py
+++ b/TestHandlerLinux/installer/uninstall.py
@@ -23,7 +23,7 @@ waagent.Log(name+" - uninstall.py starting.")
 
 logfile=waagent.Log
 
-hutil.doStatusReport(name,seqNo,version,status_file,time.strftime("%Y-%M-%dT%H:%M:%SZ", time.gmtime()),time.strftime("%Y-%M-%dT%H:%M:%SZ", time.gmtime()),name,
+hutil.doStatusReport(name,seqNo,version,status_file,time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),name,
                'Uninstall', 'transitioning', '0', 'Uninstalling', 'Process Config', 'transitioning', '0', 'Parsing ' + settings_file)
 hutil.doHealthReport(heartbeat_file,'NotReady','0','Proccessing Settings')
 

--- a/TestHandlerLinux/resources/HandlerUtil.py
+++ b/TestHandlerLinux/resources/HandlerUtil.py
@@ -201,7 +201,7 @@ def doHealthReport(heartbeat_file,status,code,message):
         waagent.Error('Unable to wite heartbeat info to ' + heartbeat_file)    
 
 def doExit(name,seqNo,version,exit_code,status_file,heartbeat_file,operation,status,code,message,sub_operation,sub_status,sub_code,sub_message,health_state,health_code,health_message):
-    doStatusReport(name,seqNo,version,status_file,time.strftime("%Y-%M-%dT%H:%M:%SZ", time.gmtime()),time.strftime("%Y-%M-%dT%H:%M:%SZ", time.gmtime()),name,
+    doStatusReport(name,seqNo,version,status_file,time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),name,
                    operation,status,code,message,sub_operation,sub_status,sub_code,sub_message)
     doHealthReport(heartbeat_file,'NotReady','1','Exiting')
     sys.exit(exit_code)


### PR DESCRIPTION
This PR makes changes to strftime expressions, which are currently broken, including "minutes" twice instead of month/minute.

[Reference](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes)