### PR TITLE
Extension auto rollback testing purpose only - should be reverted

### DIFF
--- a/OmsAgent/omsagent.py
+++ b/OmsAgent/omsagent.py
@@ -456,6 +456,10 @@ def install():
     """
     exit_if_vm_not_supported('Install')
 
+    vm_supp, vm_dist, _ = is_vm_supported_for_extension()
+    if (vm_supp and (vm_dist.lower().startswith('debian'))):
+        log_and_exit("Install", 1, "Testing extension auto rollback for debian system...")
+        
     public_settings, protected_settings = get_settings()
     if public_settings is None:
         raise ParameterMissingException('Public configuration must be ' \


### PR DESCRIPTION
Create dummy extension package that will always fail for debian VM. It is needed to test oms extension auto rollback feature and will be reverted right after pipeline creates extension package. This change will be deployed only in one canary region.