### PR TITLE
Revert "testing ext rollback purpose only-should be reverted (#1575)"

### DIFF
--- a/OmsAgent/omsagent.py
+++ b/OmsAgent/omsagent.py
@@ -456,10 +456,6 @@ def install():
     """
     exit_if_vm_not_supported('Install')
 
-    vm_supp, vm_dist, _ = is_vm_supported_for_extension()
-    if (vm_supp and (vm_dist.lower().startswith('debian'))):
-        log_and_exit("Install", 1, "Testing extension auto rollback for debian system...")
-        
     public_settings, protected_settings = get_settings()
     if public_settings is None:
         raise ParameterMissingException('Public configuration must be ' \


### PR DESCRIPTION
This reverts commit bebe5bca62558557555a39a1f94a1732c41bf4e3 to recover from bad test build.