### PR TITLE
Tweaking initrd/initramfs packing approach for Mariner

### DIFF
--- a/VMEncryption/main/oscrypto/rhel_81/encryptstates/PatchBootSystemState.py
+++ b/VMEncryption/main/oscrypto/rhel_81/encryptstates/PatchBootSystemState.py
@@ -87,9 +87,8 @@ class PatchBootSystemState(OSEncryptionState):
                                           '/etc/dracut.conf.d/ade.conf')
             self._add_kernelopts(["root=/dev/mapper/osencrypt"])
 
-        # Everything is ready, repack dracut. None of the changes above will take affect until this line is executed.
-        self.command_executor.ExecuteInBash('dracut -f -v --regenerate-all', True)
-        self.context.distro_patcher.patch_initial_root_fs()
+        # Everything is ready, repack using dracut/mkinitrd. None of the changes above will take affect until this line is executed.
+        self.context.distro_patcher.pack_initial_root_fs()
 
     def should_exit(self):
         self.context.logger.log("Verifying if machine should exit patch_boot_system state")

--- a/VMEncryption/main/patch/AbstractPatching.py
+++ b/VMEncryption/main/patch/AbstractPatching.py
@@ -73,7 +73,7 @@ class AbstractPatching(object):
     def patch_machine(self):
         pass
     
-    def patch_initial_root_fs(self):
+    def pack_initial_root_fs(self):
         pass
 
     def add_kernelopts(self, args_to_add):

--- a/VMEncryption/main/patch/marinerPatching.py
+++ b/VMEncryption/main/patch/marinerPatching.py
@@ -19,11 +19,8 @@ class marinerPatching(redhatPatching):
         self.min_version_online_encryption = '2.0'
         self.support_online_encryption = self.validate_online_encryption_support()
 
-    def patch_initial_root_fs(self):
-        boot_dir = "/boot/"
-        prev_n = "initramfs"
-        new_n = "initrd"
-        self.command_executor.ExecuteInBash("for file in {0}{1}*; do mv '$file' '${{file/{1}/{2}}}".format(boot_dir, prev_n, new_n))
+    def pack_initial_root_fs(self):
+        self.command_executor.ExecuteInBash('mkinitrd -f -v', True)
 
     def add_kernelopts(self, args_to_add):
         grub_cfg_path = "/boot/grub2/grub.cfg"

--- a/VMEncryption/main/patch/redhatPatching.py
+++ b/VMEncryption/main/patch/redhatPatching.py
@@ -224,3 +224,6 @@ class redhatPatching(AbstractPatching):
         for grub_cfg_path, grub_env_path in grub_cfg_paths:
             for arg in args_to_add:
                 self.command_executor.ExecuteInBash("grubby --args {0} --update-kernel ALL -c {1} --env={2}".format(arg, grub_cfg_path, grub_env_path))
+
+    def pack_initial_root_fs(self):
+        self.command_executor.ExecuteInBash('dracut -f -v --regenerate-all', True)


### PR DESCRIPTION
Rather than using the standard dracut command for all distros and patching the initramfs for Mariner, these changes move repacking logic into distro specific scripts. Redhat based distros will now use dracut to create an initramfs, mariner uses mkinitrd. 