### PR TITLE
Add Support for Redhat 8, Rocky 8, AlmaLinux 8, and Centos 8

### DIFF
--- a/Diagnostic/DistroSpecific.py
+++ b/Diagnostic/DistroSpecific.py
@@ -321,6 +321,14 @@ class CentosActions(RedhatActions):
         return self.install_extra_packages(('policycoreutils-python',), True)
 
 
+class Centos8Actions(RedhatActions):
+    def __init__(self, logger):
+        RedhatActions.__init__(self, logger)
+
+    def install_required_packages(self):
+        return self.install_extra_packages(('policycoreutils-python-utils', 'tar'), True)
+
+
 DistroMap = {
     'debian': CredativActions,  # Credative Debian Linux took the 'debian' platform name with the curl deficiency,
                                 # when all other Debian-based distros have curl, so is this strange mapping...
@@ -331,11 +339,13 @@ DistroMap = {
     'redhat': RedhatActions,
     'redhat:8': Redhat8Actions,
     'centos': CentosActions,
+    'centos:8':Centos8Actions,
     'oracle': RedhatActions,
     'suse:12': Suse12Actions,
     'suse': Suse12Actions,
     'sles:15': Suse12Actions,
-    'opensuse:15':Suse12Actions
+    'opensuse:15':Suse12Actions,
+    'almalinux':Redhat8Actions
 }
 
 


### PR DESCRIPTION
Note that Rocky 8 shows up as "Centos 8" according to how we check for distros (`platform.dist()`).

All 4 distros have been tested and confirmed to have data flowing, assuming python2 has been installed and aliased to `python` (noted in our docs already).