### PR TITLE
AMA CIS hardening

### DIFF
--- a/Diagnostic/services/metrics-extension.service
+++ b/Diagnostic/services/metrics-extension.service
@@ -3,7 +3,7 @@ Description=Metrics Extension service for Linux Agent metrics sourcing
 After=network.target
 
 [Service]
-ExecStart=%ME_BIN% -TokenSource MSI -Input influxdb_udp -InfluxDbUdpPort %ME_INFLUX_PORT% -DataDirectory %ME_DATA_DIRECTORY% -LocalControlChannel -MonitoringAccount %ME_MONITORING_ACCOUNT% -LogLevel Error
+ExecStart=%ME_BIN% -TokenSource MSI -Input influxdb_udp -InfluxDbHost 127.0.0.1 -InfluxDbUdpPort %ME_INFLUX_PORT% -DataDirectory %ME_DATA_DIRECTORY% -LocalControlChannel -MonitoringAccount %ME_MONITORING_ACCOUNT% -LogLevel Error
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartForceExitStatus=SIGPIPE

--- a/LAD-AMA-Common/metrics_ext_utils/metrics_ext_handler.py
+++ b/LAD-AMA-Common/metrics_ext_utils/metrics_ext_handler.py
@@ -369,7 +369,7 @@ def start_metrics(is_lad):
 
         metrics_pid_path = me_config_dir + "metrics_pid.txt"
 
-        binary_exec_command = "{0} -TokenSource MSI -Input influxdb_udp -InfluxDbUdpPort {1} -DataDirectory {2} -LocalControlChannel -MonitoringAccount {3} -LogLevel Error".format(metrics_ext_bin, me_influx_port, me_config_dir, monitoringAccount)
+        binary_exec_command = "{0} -TokenSource MSI -Input influxdb_udp -InfluxDbHost 127.0.0.1 -InfluxDbUdpPort {1} -DataDirectory {2} -LocalControlChannel -MonitoringAccount {3} -LogLevel Error".format(metrics_ext_bin, me_influx_port, me_config_dir, monitoringAccount)
         proc = subprocess.Popen(binary_exec_command.split(" "), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         time.sleep(3) #sleeping for 3 seconds before checking if the process is still running, to give it ample time to relay crash info
         p = proc.poll()


### PR DESCRIPTION
Changes to ensure that Azure CIS-hardened image with AMA deployed still meets the pre-AMA benchmark score and does not cause the system to become out of compliance with the CIS benchmark. In this case, ME was listening on all interfaces, because if you don't specify the host, it will listen on 0.0.0.0. This was causing us to fail a benchmark rule requiring non-local ports to have iptables rules associated. With this change we ensure ME is only opening a port on localhost interface.

- Set `InfluxDbHost` to prevent CIS benchmark violation `3.4.3.2.3 Ensure iptables rules exist for all open ports`