### PR TITLE
add input parameter check

### DIFF
--- a/Utils/HandlerUtil.py
+++ b/Utils/HandlerUtil.py
@@ -172,6 +172,8 @@ class HandlerUtility:
         return redacted
 
     def _parse_config(self, ctxt):
+        if ctxt == "":
+            return None
         config = None
         try:
             config = json.loads(ctxt)


### PR DESCRIPTION
Add empty string check to avoid unnecessary error logging, as an empty string is not a valid JSON string and not needed to parse.