### PR TITLE
Supporting RHEL type in supported_dists to support Python > 3.7

### DIFF
--- a/DSC/dsc.py
+++ b/DSC/dsc.py
@@ -158,6 +158,7 @@ def check_supported_OS():
     supported_dists = {'redhat' : ['7', '8'], # CentOS
                        'centos' : ['7', '8'], # CentOS
                        'red hat' : ['7', '8'], # Redhat
+                       'rhel' : ['7', '8'], # Redhat
                        'debian' : ['8', '9', '10'], # Debian
                        'ubuntu' : ['14.04', '16.04', '18.04', '20.04'], # Ubuntu
                        'oracle' : ['7'], # Oracle


### PR DESCRIPTION
RHEL 8 is using `rhel` as ID, so adding support for that in the list.

The function platform.dist & platform.linux_distribution are been [removed in python 3.7](https://docs.python.org/3.5/library/platform.html#unix-platforms). So the DSC will use the [Fallback to use /etc/os-release.](https://github.com/Azure/azure-linux-extensions/blob/master/DSC/dsc.py#L158) This is working fine, only that RHEL is using a other name as is then is listed in the suppored_list

```
# cat /etc/os-release 

NAME="Red Hat Enterprise Linux"
VERSION="8.6 (Ootpa)"
ID="rhel"
ID_LIKE="fedora"
VERSION_ID="8.6"
```

Issue related: https://github.com/Azure/azure-linux-extensions/issues/1612