### PR TITLE
Adding CVM detection to MDC recommendation

### DIFF
--- a/VMEncryption/mdc-recommendation/helper-scripts/ImdsHelper.py
+++ b/VMEncryption/mdc-recommendation/helper-scripts/ImdsHelper.py
@@ -1,9 +1,6 @@
 import time
 import datetime
 import traceback
-"""import shlex
-import subprocess
-from subprocess import * """
 import json
 
 try:
@@ -16,7 +13,9 @@ except ImportError:
     import httplib as httpclient #python2
 
 # define IMDS uri and header
-imds_uri = 'http://169.254.169.254/metadata/instance?api-version=2021-11-01'
+# IMDS api-version=2021-11-01 is the minimum required version where HBE property 'compute.securityProfile.encryptionAtHost' was added.
+# IMDS api-version=2021-12-13 is the minimum required version where CVM property 'compute.securityProfile.securityType' was added.
+imds_uri = 'http://169.254.169.254/metadata/instance?api-version=2021-12-13'
 imds_header = {
     "Metadata":"true"
 }

--- a/VMEncryption/mdc-recommendation/helper-scripts/MdcHandler.py
+++ b/VMEncryption/mdc-recommendation/helper-scripts/MdcHandler.py
@@ -137,7 +137,6 @@ def main():
         if imds_metadata is None:
             msg = "Python helper failed in fetching IMDS metadata"
             raise Exception(msg)
-        
         is_vm_compliant = detect_encryption_status(imds_metadata)
 
     except Exception as e:

--- a/VMEncryption/mdc-recommendation/helper-scripts/VerifyVMSupport.py
+++ b/VMEncryption/mdc-recommendation/helper-scripts/VerifyVMSupport.py
@@ -9,6 +9,9 @@ supported_ade_image_list = SupportedSkus.supported_ade_image_list
 # List of VM Sizes unsupported by ADE and HBE (Basic and A series VMs)
 unsupported_vm_size_list = ["basic", "standard_a0", "standard_a1"]
 
+# JSON property value for Confidential VM security type in IMDS metadata
+cvm_metadata_value = "confidentialvm"
+
 # Prefix for VM using Classic Compute provider, Kubernetes or Databricks
 classic_compute_prefix = "classiccompute"
 microsoft_databrick_image_publisher = "azuredatabricks"
@@ -24,6 +27,17 @@ def verify_vm_os_sku_completeness(imds_metadata):
         return False
 
     return True    
+
+def is_confidential_vm(imds_metadata):
+    cvm_status = imds_metadata['compute']['securityProfile']['securityType']
+    is_confidential_vm = False    
+    
+    if cvm_status is not None:
+        cvm_status = str(cvm_status).lower()
+        if cvm_metadata_value in cvm_status:
+            is_confidential_vm = True
+        
+    return is_confidential_vm
 
 def is_basic_vm(imds_metadata):    
     vm_size = imds_metadata['compute']['vmSize']


### PR DESCRIPTION
- Updates to recognize Confidential VMs as NotSupported in the MDC recommendation for ADE + HBE.
- IMDS metadata is being used to detect the presence of CVM security type in VM profile.
- All CVMs will be categorized as NotSupported until data disk encryption is supported in CVMs.