### PR TITLE
fix python syntax warning in waagent

### DIFF
--- a/Common/WALinuxAgent-2.0.16/waagent
+++ b/Common/WALinuxAgent-2.0.16/waagent
@@ -2575,7 +2575,7 @@ def RunSendStdin(cmd, input, chk_err=True, log_cmd=True, use_shell=True):
             Error('CalledProcessError.  Command string was ' + cmd)
             Error('CalledProcessError.  Command result was ' + output[0].decode('latin-1'))
             return 1, output[0].decode('latin-1')
-    if me.returncode is not 0 and chk_err is True and log_cmd:
+    if me.returncode != 0 and chk_err is True and log_cmd:
         Error('CalledProcessError.  Error Code is ' + str(me.returncode))
         Error('CalledProcessError.  Command string was ' + cmd)
         Error('CalledProcessError.  Command result was ' + output[0].decode('latin-1'))


### PR DESCRIPTION
Fix python syntax warning found in AMA Install telemetry showing that agent is logging in standard error stream.
Example from AMA install telemetry:

[stderr]
Running scope as unit: install_52ef8942-a5b1-459d-b201-5ca1bfb45c60.scope
/var/lib/waagent/Microsoft.Azure.Monitor.AzureMonitorLinuxAgent-1.24.2/waagent:2578: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if me.returncode is not 0 and chk_err is True and log_cmd: