### PR TITLE
Removing exception when events folder has over 1000 files

### DIFF
--- a/Utils/extensionutils.py
+++ b/Utils/extensionutils.py
@@ -315,7 +315,7 @@ class WALAEvent(object):
             os.mkdir(event_folder)
             os.chmod(event_folder, 0o700)
         if len(os.listdir(event_folder)) > 1000:
-            raise Exception("WriteToFolder:Too many file under " + event_folder + " exit")
+            logger.log("Warning: Too many files under " + event_folder)
 
         filename = os.path.join(event_folder, str(int(time.time() * 1000000)))
         with open(filename + ".tmp", 'wb+') as h_file:


### PR DESCRIPTION
Logging instead of throwing an exception when events folder has over 1000 files 