### PR TITLE
Add Amazon 2 Linux Support

### DIFF
--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -374,6 +374,7 @@ def uninstall():
     Note: uninstall operation times out from WAAgent at 5 minutes
     """
 
+    exit_if_vm_not_supported('Uninstall')
     find_package_manager("Uninstall")
     if PackageManager == "dpkg":
         AMAUninstallCommand = "dpkg -P azuremonitoragent"

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -296,9 +296,9 @@ def install():
     wait longer.
     """
 
+    exit_if_vm_not_supported('Install')
     find_package_manager("Install")
     set_os_arch('Install')
-    exit_if_vm_not_supported('Install')
     vm_dist, vm_ver = find_vm_distro('Install')
 
     # Check if SUSE 15 VMs have /sbin/insserv package (required for AMA 1.14.4+)
@@ -1190,7 +1190,6 @@ def find_package_manager(operation):
             break
 
     if PackageManager == "":
-        exit_if_vm_not_supported(operation)
         log_and_exit(operation, UnsupportedOperatingSystem, "The OS has neither rpm nor dpkg" )
 
 
@@ -1341,7 +1340,6 @@ def get_ssl_cert_info(operation):
             elif version.startswith('15'):
                 return 'SSL_CERT_DIR', '/etc/ssl/certs'
 
-    exit_if_vm_not_supported(operation)
     log_and_exit(operation, GenericErrorCode, 'Unable to determine values for SSL_CERT_DIR or SSL_CERT_FILE')
 
 

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -1171,7 +1171,7 @@ def find_package_manager(operation):
     dist, _ = find_vm_distro(operation)
 
     dpkg_set = set(["debian", "ubuntu"])
-    rpm_set = set(["oracle", "redhat", "centos", "red hat", "suse", "sles", "opensuse", "cbl-mariner", "mariner", "rhel", "rocky", "alma"])
+    rpm_set = set(["oracle", "redhat", "centos", "red hat", "suse", "sles", "opensuse", "cbl-mariner", "mariner", "rhel", "rocky", "alma", "amzn"])
     for dpkg_dist in dpkg_set:
         if dist.startswith(dpkg_dist):
             PackageManager = "dpkg"
@@ -1250,7 +1250,8 @@ def is_vm_supported_for_extension(operation):
                        'mariner' : ['2'], # Mariner 2.0
                        'rocky' : ['8'], # Rocky
                        'alma' : ['8'], # Alma
-                       'opensuse' : ['15'] # openSUSE
+                       'opensuse' : ['15'], # openSUSE
+                       'amzn' : ['2'] # Amazon Linux 2
     }
 
     supported_dists_aarch64 = {'red hat' : ['8'], # Rhel
@@ -1328,7 +1329,7 @@ def get_ssl_cert_info(operation):
         if distro.startswith(name):
             return 'SSL_CERT_DIR', '/etc/ssl/certs'
 
-    for name in ['centos', 'redhat', 'red hat', 'oracle', 'cbl-mariner', 'mariner', 'rhel', 'rocky', 'alma']:
+    for name in ['centos', 'redhat', 'red hat', 'oracle', 'cbl-mariner', 'mariner', 'rhel', 'rocky', 'alma', 'amzn']:
         if distro.startswith(name):
             return 'SSL_CERT_FILE', '/etc/pki/tls/certs/ca-bundle.crt'
 

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -1190,6 +1190,7 @@ def find_package_manager(operation):
             break
 
     if PackageManager == "":
+        exit_if_vm_not_supported(operation)
         log_and_exit(operation, UnsupportedOperatingSystem, "The OS has neither rpm nor dpkg" )
 
 
@@ -1340,6 +1341,7 @@ def get_ssl_cert_info(operation):
             elif version.startswith('15'):
                 return 'SSL_CERT_DIR', '/etc/ssl/certs'
 
+    exit_if_vm_not_supported(operation)
     log_and_exit(operation, GenericErrorCode, 'Unable to determine values for SSL_CERT_DIR or SSL_CERT_FILE')
 
 


### PR DESCRIPTION
Verified that AMA works on Amazon 2 Linux VMs installed via Arc, adding official support. In addition, currently if the OS isn't supported, the error message seen by the cx will be "The OS has neither rpm or dpkg" - added the VM support check in a few common unintuitive failure locations to make it clearer when the issue is due to an unsupported OS.