### PR TITLE
Bamuir/mhsm

### DIFF
--- a/VMEncryption/main/Common.py
+++ b/VMEncryption/main/Common.py
@@ -114,6 +114,13 @@ class CommonVariables:
     MigrateValue = 'Migrate'
 
     """
+    value for KeyStoreTypeKey could be ManagedHSM
+    This is a value for ManagedHSM testing, and should be removed before public release
+    """
+    KeyStoreTypeKey = 'KeyStoreType'
+    KeyStoreTypeManagedHSM = 'ManagedHSM'
+
+    """
     value for VolumeType could be Data
     """
     VolumeTypeKey = 'VolumeType'

--- a/VMEncryption/main/Common.py
+++ b/VMEncryption/main/Common.py
@@ -114,10 +114,10 @@ class CommonVariables:
     MigrateValue = 'Migrate'
 
     """
-    value for PrivatePreviewKeyStoreTypeKey could be ManagedHSM
+    value for KeyStoreTypeKey could be ManagedHSM
     This is a value for ManagedHSM testing, and should be removed before public release
     """
-    PrivatePreviewKeyStoreTypeKey = 'KeyStoreType'
+    KeyStoreTypeKey = 'KeyStoreType'
     KeyStoreTypeManagedHSM = 'ManagedHSM'
 
     """

--- a/VMEncryption/main/Common.py
+++ b/VMEncryption/main/Common.py
@@ -114,10 +114,10 @@ class CommonVariables:
     MigrateValue = 'Migrate'
 
     """
-    value for KeyStoreTypeKey could be ManagedHSM
+    value for PrivatePreviewKeyStoreTypeKey could be ManagedHSM
     This is a value for ManagedHSM testing, and should be removed before public release
     """
-    KeyStoreTypeKey = 'KeyStoreType'
+    PrivatePreviewKeyStoreTypeKey = 'KeyStoreType'
     KeyStoreTypeManagedHSM = 'ManagedHSM'
 
     """

--- a/VMEncryption/main/Common.py
+++ b/VMEncryption/main/Common.py
@@ -119,6 +119,7 @@ class CommonVariables:
     """
     KeyStoreTypeKey = 'KeyStoreType'
     KeyStoreTypeManagedHSM = 'ManagedHSM'
+    KeyStoreTypeKeyVault = 'KeyVault'
 
     """
     value for VolumeType could be Data

--- a/VMEncryption/main/EncryptionSettingsUtil.py
+++ b/VMEncryption/main/EncryptionSettingsUtil.py
@@ -41,8 +41,6 @@ class EncryptionSettingsUtil(object):
         self.logger = logger
         self._DISK_ENCRYPTION_DATA_VERSION_V4 = "4.0"
         self._DISK_ENCRYPTION_DATA_VERSION_V5 = "5.0"
-
-        # BAM: Do i want this initialized to KeyVault or None? Choosing None in case of bad parameters
         self._DISK_ENCRYPTION_KEY_SOURCE = None
 
     def get_index(self):

--- a/VMEncryption/main/EncryptionSettingsUtil.py
+++ b/VMEncryption/main/EncryptionSettingsUtil.py
@@ -206,6 +206,7 @@ class EncryptionSettingsUtil(object):
             cutil.check_mhsm_url(kek_url, "A ManagedHSM URL is specified, but it is invalid for ManagedHSM.")
             cutil.check_mhsm_id(kek_kv_id, "A ManagedHSM ID is required, but is missing or invalid.")
             cutil.check_mhsm_name(kek_kv_id, kek_url, "A ManagedHSM ID and ManagedHSM URL were provided, but their ManagedHSM names did not match")
+            # for private preview data collection, set key source to MHSM
             self._DISK_ENCRYPTION_KEY_SOURCE = CommonVariables.KeyStoreTypeManagedHSM
         elif keystoretype_flag_exists:
             raise Exception("The expected flag name and value to enable ManagedHSM is 'KeyStoreType':'{0}'. " +
@@ -223,6 +224,8 @@ class EncryptionSettingsUtil(object):
             else:
                 if kek_kv_id:
                     raise Exception("The KEK KeyVault ID was specified but the KEK URL was missing")
+            # for private preview data collection, set key source to KeyVault
+            self._DISK_ENCRYPTION_KEY_SOURCE = CommonVariables.KeyStoreTypeKeyVault
 
         # create encryption settings object
         self.logger.log("Creating encryption settings object")

--- a/VMEncryption/main/EncryptionSettingsUtil.py
+++ b/VMEncryption/main/EncryptionSettingsUtil.py
@@ -190,7 +190,7 @@ class EncryptionSettingsUtil(object):
         cutil = CheckUtil(self.logger)
 
         # Perform algorithm check regaurdless of ManagedHSM or Keyvault
-        if kek_algorithm not in CommonVariables.encryption_algorithms:
+        if kek_url and kek_algorithm not in CommonVariables.encryption_algorithms:
                     if kek_algorithm:
                         raise Exception("The KEK encryption algorithm requested was not recognized")
                     else:

--- a/VMEncryption/main/EncryptionSettingsUtil.py
+++ b/VMEncryption/main/EncryptionSettingsUtil.py
@@ -461,12 +461,8 @@ class EncryptionSettingsUtil(object):
         data_disks_settings_data = [controller_id_and_lun_to_settings_data(scsi_controller, lun_number)
                                     for (scsi_controller, lun_number) in data_disk_controller_ids_and_luns]
 
-        if self._DISK_ENCRYPTION_KEY_SOURCE == CommonVariables.KeyStoreTypeManagedHSM:
-            data_version = self._DISK_ENCRYPTION_DATA_VERSION_V5
-        else:
-            data_version = self._DISK_ENCRYPTION_DATA_VERSION_V4
-
-        data = {"DiskEncryptionDataVersion": data_version,
+        # Send version 4.0 for disable in KeyVault and ManagedHSM Scenarios 
+        data = {"DiskEncryptionDataVersion": self._DISK_ENCRYPTION_DATA_VERSION_V4,
                 "DiskEncryptionOperation": "DisableEncryption",
                 "Disks": data_disks_settings_data,
                 "KekAlgorithm": "",

--- a/VMEncryption/main/ExtensionParameter.py
+++ b/VMEncryption/main/ExtensionParameter.py
@@ -56,7 +56,7 @@ class ExtensionParameter(object):
         self.KeyVaultURL = public_settings.get(CommonVariables.KeyVaultURLKey)
         self.KeyVaultResourceId = public_settings.get(CommonVariables.KeyVaultResourceIdKey)
         self.KekVaultResourceId = public_settings.get(CommonVariables.KekVaultResourceIdKey)
-        self.KeyStoreType = public_settings.get(CommonVariables.PrivatePreviewKeyStoreTypeKey)
+        self.KeyStoreType = public_settings.get(CommonVariables.KeyStoreTypeKey)
 
         keyEncryptionAlgorithm = public_settings.get(CommonVariables.KeyEncryptionAlgorithmKey)
         if keyEncryptionAlgorithm is not None and keyEncryptionAlgorithm !="":
@@ -109,7 +109,7 @@ class ExtensionParameter(object):
         return self.params_config.get_config(CommonVariables.DiskFormatQuerykey)
        
     def get_keystore_type(self):
-        return self.params_config.get_config(CommonVariables.PrivatePreviewKeyStoreTypeKey)
+        return self.params_config.get_config(CommonVariables.KeyStoreTypeKey)
 
     def get_bek_filename(self):
         return self.DiskEncryptionKeyFileName
@@ -141,7 +141,7 @@ class ExtensionParameter(object):
         DiskFormatQuery = ConfigKeyValuePair(CommonVariables.DiskFormatQuerykey, self.DiskFormatQuery)
         key_value_pairs.append(DiskFormatQuery)
 
-        KeyStoreType = ConfigKeyValuePair(CommonVariables.PrivatePreviewKeyStoreTypeKey, self.KeyStoreType)
+        KeyStoreType = ConfigKeyValuePair(CommonVariables.KeyStoreTypeKey, self.KeyStoreType)
         key_value_pairs.append(KeyStoreType)
 
         self.params_config.save_configs(key_value_pairs)

--- a/VMEncryption/main/ExtensionParameter.py
+++ b/VMEncryption/main/ExtensionParameter.py
@@ -56,6 +56,7 @@ class ExtensionParameter(object):
         self.KeyVaultURL = public_settings.get(CommonVariables.KeyVaultURLKey)
         self.KeyVaultResourceId = public_settings.get(CommonVariables.KeyVaultResourceIdKey)
         self.KekVaultResourceId = public_settings.get(CommonVariables.KekVaultResourceIdKey)
+        self.KeyStoreType = public_settings.get(CommonVariables.KeyStoreTypeKey)
 
         keyEncryptionAlgorithm = public_settings.get(CommonVariables.KeyEncryptionAlgorithmKey)
         if keyEncryptionAlgorithm is not None and keyEncryptionAlgorithm !="":
@@ -106,6 +107,9 @@ class ExtensionParameter(object):
 
     def get_disk_format_query(self):
         return self.params_config.get_config(CommonVariables.DiskFormatQuerykey)
+       
+    def get_keystore_type(self):
+        return self.params_config.get_config(CommonVariables.KeyStoreTypeKey)
 
     def get_bek_filename(self):
         return self.DiskEncryptionKeyFileName
@@ -136,6 +140,9 @@ class ExtensionParameter(object):
 
         DiskFormatQuery = ConfigKeyValuePair(CommonVariables.DiskFormatQuerykey, self.DiskFormatQuery)
         key_value_pairs.append(DiskFormatQuery)
+
+        KeyStoreType = ConfigKeyValuePair(CommonVariables.KeyStoreTypeKey, self.KeyStoreType)
+        key_value_pairs.append(KeyStoreType)
 
         self.params_config.save_configs(key_value_pairs)
 
@@ -198,6 +205,11 @@ class ExtensionParameter(object):
         if (self.KeyEncryptionAlgorithm or self.get_kek_algorithm()) and \
            (self.KeyEncryptionAlgorithm != self.get_kek_algorithm()):
             self.logger.log('Current config KeyEncryptionAlgorithm {0} differs from effective config KeyEncryptionAlgorithm {1}'.format(self.KeyEncryptionAlgorithm, self.get_kek_algorithm()))
+            return True
+
+        if (self.KeyStoreType or self.get_keystore_type()) and \
+           (self.KeyStoreType != self.get_keystore_type()):
+            self.logger.log('Current config KeyStoreType {0} differs from effective config KeyStoreType {1}'.format(self.KeyStoreType, self.get_keystore_type()))
             return True
 
         bek_passphrase_file_name = self.bek_util.get_bek_passphrase_file(self.encryption_config)

--- a/VMEncryption/main/ExtensionParameter.py
+++ b/VMEncryption/main/ExtensionParameter.py
@@ -56,7 +56,7 @@ class ExtensionParameter(object):
         self.KeyVaultURL = public_settings.get(CommonVariables.KeyVaultURLKey)
         self.KeyVaultResourceId = public_settings.get(CommonVariables.KeyVaultResourceIdKey)
         self.KekVaultResourceId = public_settings.get(CommonVariables.KekVaultResourceIdKey)
-        self.KeyStoreType = public_settings.get(CommonVariables.KeyStoreTypeKey)
+        self.KeyStoreType = public_settings.get(CommonVariables.PrivatePreviewKeyStoreTypeKey)
 
         keyEncryptionAlgorithm = public_settings.get(CommonVariables.KeyEncryptionAlgorithmKey)
         if keyEncryptionAlgorithm is not None and keyEncryptionAlgorithm !="":
@@ -109,7 +109,7 @@ class ExtensionParameter(object):
         return self.params_config.get_config(CommonVariables.DiskFormatQuerykey)
        
     def get_keystore_type(self):
-        return self.params_config.get_config(CommonVariables.KeyStoreTypeKey)
+        return self.params_config.get_config(CommonVariables.PrivatePreviewKeyStoreTypeKey)
 
     def get_bek_filename(self):
         return self.DiskEncryptionKeyFileName
@@ -141,7 +141,7 @@ class ExtensionParameter(object):
         DiskFormatQuery = ConfigKeyValuePair(CommonVariables.DiskFormatQuerykey, self.DiskFormatQuery)
         key_value_pairs.append(DiskFormatQuery)
 
-        KeyStoreType = ConfigKeyValuePair(CommonVariables.KeyStoreTypeKey, self.KeyStoreType)
+        KeyStoreType = ConfigKeyValuePair(CommonVariables.PrivatePreviewKeyStoreTypeKey, self.KeyStoreType)
         key_value_pairs.append(KeyStoreType)
 
         self.params_config.save_configs(key_value_pairs)

--- a/VMEncryption/main/check_util.py
+++ b/VMEncryption/main/check_util.py
@@ -226,7 +226,7 @@ class CheckUtil(object):
                 return
             else: 
                 raise Exception("The expected flag name and value to enable ManagedHSM is 'KeyStoreType':'{0}'. " +
-                    "Please correct the flag name and value and retry enabling ManagedHSM, or remove the flag for KeyVault use.".format(CommonVariables.KeyStoreTypeManagedHSM)")
+                    "Please correct the flag name and value and retry enabling ManagedHSM, or remove the flag for KeyVault use.".format(CommonVariables.KeyStoreTypeManagedHSM))
 
     def validate_volume_type(self, public_settings, DistroPatcher=None):
         encryption_operation = public_settings.get(CommonVariables.EncryptionEncryptionOperationKey)

--- a/VMEncryption/main/check_util.py
+++ b/VMEncryption/main/check_util.py
@@ -193,7 +193,7 @@ class CheckUtil(object):
         kek_kv_id = public_settings.get(CommonVariables.KekVaultResourceIdKey)
         kek_algorithm = public_settings.get(CommonVariables.KeyEncryptionAlgorithmKey)
        
-        has_keystore_flag = CommonVariables.PrivatePreviewKeyStoreTypeKey in public_settings
+        has_keystore_flag = CommonVariables.KeyStoreTypeKey in public_settings
 
         if not has_keystore_flag:
             self.check_kv_id(kv_id, "A KeyVault ID is required, but is missing or invalid")
@@ -215,7 +215,7 @@ class CheckUtil(object):
                         "The KEK KeyVault ID was specified but the KEK URL was missing")
         else:
             self.logger.log("validate_key_vault_params: KeyStoryType flag present, validating ManagedHSM Parameters")
-            key_store_type = public_settings.get(CommonVariables.PrivatePreviewKeyStoreTypeKey)
+            key_store_type = public_settings.get(CommonVariables.KeyStoreTypeKey)
             if key_store_type and key_store_type.lower() == CommonVariables.KeyStoreTypeManagedHSM.lower():
                 if kv_url or kv_id:
                     raise Exception("KeyvaultUrl or KeyvaultresourceId are not empty, and 'KeyStoreType' parameter is set to ManagedHSM. Please remove KeyvaultUrl KeyvaultresourceId for ManagedHSM.")

--- a/VMEncryption/main/check_util.py
+++ b/VMEncryption/main/check_util.py
@@ -102,7 +102,7 @@ class CheckUtil(object):
     def check_mhsm_url(self, test_mhsm_url, message):
         """basic sanity check of the MHSM url"""
         expected = "https://{managedhsm-name}.{managedhsm}.{vault-endpoint}/keys/{object-name}/{object-version}"
-        pattern = re.compile(r'^https://([a-zA-Z0-9\-]+)[\.]+(managedhsm)+([a-zA-Z0-9\-\.]+)(:443)?/keys/([a-zA-Z0-9\-]+)/([a-zA-Z0-9]+)([/]?)$', re.IGNORECASE)
+        pattern = re.compile(r'^https://([a-zA-Z0-9\-]+)[\.](managedhsm)+([a-zA-Z0-9\-\.]+)(:443)?/keys/([a-zA-Z0-9\-]+)/([a-zA-Z0-9]+)([/]?)$', re.IGNORECASE)
         if not (test_mhsm_url and pattern.match(test_mhsm_url)):
             raise Exception('\n' + message + '\nActual: ' + test_mhsm_url + '\nExpected: ' + expected + "\n")
         return
@@ -132,7 +132,7 @@ class CheckUtil(object):
         return
     
     def get_mhsm_id_name(self, mhsm_id):
-        """extract key vault name from KV ID"""
+        """extract MHSM name from MHSM ID"""
         if mhsm_id:
             match = re.search(r'^/subscriptions/([a-zA-Z0-9\-]+)/resourceGroups/([-\w\._\(\)]+)/providers/Microsoft.KeyVault/managedHSM/([a-zA-Z0-9\-\_]+)(/)?$', mhsm_id, re.IGNORECASE)
             if match:

--- a/VMEncryption/main/check_util.py
+++ b/VMEncryption/main/check_util.py
@@ -193,7 +193,7 @@ class CheckUtil(object):
         kek_kv_id = public_settings.get(CommonVariables.KekVaultResourceIdKey)
         kek_algorithm = public_settings.get(CommonVariables.KeyEncryptionAlgorithmKey)
        
-        has_keystore_flag = CommonVariables.KeyStoreTypeKey in public_settings
+        has_keystore_flag = CommonVariables.PrivatePreviewKeyStoreTypeKey in public_settings
 
         if not has_keystore_flag:
             self.check_kv_id(kv_id, "A KeyVault ID is required, but is missing or invalid")
@@ -215,7 +215,7 @@ class CheckUtil(object):
                         "The KEK KeyVault ID was specified but the KEK URL was missing")
         else:
             self.logger.log("validate_key_vault_params: KeyStoryType flag present, validating ManagedHSM Parameters")
-            key_store_type = public_settings.get(CommonVariables.KeyStoreTypeKey)
+            key_store_type = public_settings.get(CommonVariables.PrivatePreviewKeyStoreTypeKey)
             if key_store_type and key_store_type.lower() == CommonVariables.KeyStoreTypeManagedHSM.lower():
                 if kv_url or kv_id:
                     raise Exception("KeyvaultUrl or KeyvaultresourceId are not empty, and 'KeyStoreType' parameter is set to ManagedHSM. Please remove KeyvaultUrl KeyvaultresourceId for ManagedHSM.")

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -179,7 +179,7 @@ def stamp_disks_with_settings(items_to_encrypt, encryption_config, encryption_ma
     current_passphrase_file = bek_util.get_bek_passphrase_file(encryption_config)
     public_settings = get_public_settings()
     extension_parameter = ExtensionParameter(hutil, logger, DistroPatcher, encryption_environment, get_protected_settings(), public_settings)
-    has_keystore_flag = CommonVariables.KeyStoreTypeKey in public_settings
+    has_keystore_flag = CommonVariables.PrivatePreviewKeyStoreTypeKey in public_settings
 
     # post new encryption settings via wire server protocol
     settings = EncryptionSettingsUtil(logger)

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -179,7 +179,7 @@ def stamp_disks_with_settings(items_to_encrypt, encryption_config, encryption_ma
     current_passphrase_file = bek_util.get_bek_passphrase_file(encryption_config)
     public_settings = get_public_settings()
     extension_parameter = ExtensionParameter(hutil, logger, DistroPatcher, encryption_environment, get_protected_settings(), public_settings)
-    has_keystore_flag = CommonVariables.PrivatePreviewKeyStoreTypeKey in public_settings
+    has_keystore_flag = CommonVariables.KeyStoreTypeKey in public_settings
 
     # post new encryption settings via wire server protocol
     settings = EncryptionSettingsUtil(logger)

--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -177,7 +177,9 @@ def stamp_disks_with_settings(items_to_encrypt, encryption_config, encryption_ma
     crypt_mount_config_util = CryptMountConfigUtil(logger=logger, encryption_environment=encryption_environment, disk_util=disk_util)
     bek_util = BekUtil(disk_util, logger)
     current_passphrase_file = bek_util.get_bek_passphrase_file(encryption_config)
-    extension_parameter = ExtensionParameter(hutil, logger, DistroPatcher, encryption_environment, get_protected_settings(), get_public_settings())
+    public_settings = get_public_settings()
+    extension_parameter = ExtensionParameter(hutil, logger, DistroPatcher, encryption_environment, get_protected_settings(), public_settings)
+    has_keystore_flag = CommonVariables.KeyStoreTypeKey in public_settings
 
     # post new encryption settings via wire server protocol
     settings = EncryptionSettingsUtil(logger)
@@ -193,7 +195,9 @@ def stamp_disks_with_settings(items_to_encrypt, encryption_config, encryption_ma
         kek_algorithm=extension_parameter.KeyEncryptionAlgorithm,
         extra_device_items=items_to_encrypt,
         disk_util=disk_util,
-        crypt_mount_config_util=crypt_mount_config_util)
+        crypt_mount_config_util=crypt_mount_config_util,
+        key_store_type=extension_parameter.KeyStoreType,
+        keystoretype_flag_exists=has_keystore_flag)
 
     settings.post_to_wireserver(data)
 

--- a/VMEncryption/main/test/test_check_util.py
+++ b/VMEncryption/main/test/test_check_util.py
@@ -57,6 +57,22 @@ class TestCheckUtil(unittest.TestCase):
         self.assertRaises(Exception, self.cutil.check_kv_id, "/subscriptions/{subid}/resourceGroupssss/{rgname}/providers/Microsoft.KeyVault/vaults/{vaultname}", "")
         self.assertRaises(Exception, self.cutil.check_kv_id, "/subscriptions/{subid}/resourceGroups/{rgname}/providers/Microsoft.KeyVault/vaults/{vaultname}", "")
 
+    def test_is_mhsm_id(self):
+         # https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
+        self.cutil.check_mhsm_id("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adenszqtrrg/providers/Microsoft.KeyVault/managedHSM/adenszqtrkv", "")
+        self.cutil.check_mhsm_id("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/adenszqtrrg/providers/microsoft.keyvault/managedHSM/adenszqtrkv", "")
+
+        # invalid cases
+        self.assertRaises(Exception, self.cutil.check_mhsm_id, "////", "")
+        self.assertRaises(Exception, self.cutil.check_mhsm_id, "/subscriptions/{subid}/resourceGroups/{rgname}/providers/Microsoft.KeyVault/", "")
+        self.assertRaises(Exception, self.cutil.check_mhsm_id, "/subscriptions/{subid}/resourceGroups/{rgname}/providers/Microsoft.KeyVault////////", "")
+        self.assertRaises(Exception, self.cutil.check_mhsm_id, "/subscriptions/{subid}/resourceGroupssss/{rgname}/providers/Microsoft.KeyVault/vaults/{vaultname}", "")
+        self.assertRaises(Exception, self.cutil.check_mhsm_id, "/subscriptions/{subid}/resourceGroups/{rgname}/providers/Microsoft.KeyVault/vaults/{vaultname}", "")
+        self.assertRaises(Exception, self.cutil.check_mhsm_id, "/subscriptions/{subid}/resourceGroupssss/{rgname}/providers/Microsoft.KeyVault/managedHSM/{vaultname}", "")
+        self.assertRaises(Exception, self.cutil.check_mhsm_id, "/subscriptions/{subid}/resourceGroups/{rgname}/providers/Microsoft.KeyVault/managedHSM/{vaultname}", "")
+        self.assertRaises(Exception, self.cutil.check_mhsm_id, "/subscriptions/{subid}/resourceGroups/{rgname}/providers/Microsoft.ManagedHSM/managedHSM/{vaultname}", "")
+        self.assertRaises(Exception, self.cutil.check_mhsm_id, "/subscriptions/{subid}/resourceGroups/{rgname}/providers/Microsoft.ManagedHSM/vaults/{vaultname}", "")
+
     def test_is_kv_url(self):
         dns_suffix_list = ["vault.azure.net", "vault.azure.cn", "vault.usgovcloudapi.net", "vault.microsoftazure.de"]
 
@@ -69,6 +85,19 @@ class TestCheckUtil(unittest.TestCase):
             # self.assertRaises(Exception, self.cutil.check_kv_url, "https://https://testkv." + dns_suffix + "/", "")
             # self.assertRaises(Exception, self.cutil.check_kv_url, "https://testkv.testkv." + dns_suffix + "/", "")
         # self.assertRaises(Exception, self.cutil.check_kv_url, "https://testkv.vault.azure.com/", "")
+        self.assertRaises(Exception, self.cutil.check_kv_url, "https://", "")
+
+    def test_is_mhsm_url(self):
+        dns_suffix_list = ["vault.azure.net", "vault.azure.cn", "vault.usgovcloudapi.net", "vault.microsoftazure.de"]
+        
+        for dns_suffix in dns_suffix_list:
+            self.cutil.check_kv_url("https://testkv.managedhsm." + dns_suffix + "/", "")
+            self.cutil.check_kv_url("https://test-kv2.managedhsm." + dns_suffix + "/", "")
+            self.cutil.check_kv_url("https://test-kv2.managedhsm." + dns_suffix + ":443/", "")
+            self.cutil.check_kek_url("https://test-kv2.managedhsm." + dns_suffix + ":443/keys/keyencryptionkey/00000000000000000000000000000000", "")
+            self.assertRaises(Exception, self.cutil.check_kv_url, "http://testkv." + dns_suffix + "/", "")
+            self.assertRaises(Exception, self.cutil.check_kv_url, "https://test-kv2." + dns_suffix + ":443/keys/kekname/00000000000000000000000000000000", "")
+            self.assertRaises(Exception, self.cutil.check_kv_url, "http://testkv.managedhsm." + dns_suffix + "/", "")
         self.assertRaises(Exception, self.cutil.check_kv_url, "https://", "")
 
     @mock.patch('MetadataUtil.MetadataUtil.is_vmss')


### PR DESCRIPTION
Adding support for ManagedHSM on ADE for Linux. This introduces the concept of a KeyStoreType, which when set to ManagedHSM, causes the extension to send the new setting version (5.0) to host, and allows encryption of Linux VM's using a ManagedHSM key.

PR take 2 for a cleaner file diff, as I messed up a rebase on the other branch.

(Old PR: https://github.com/Azure/azure-linux-extensions/pull/1665)

Full Test Results: https://microsoft.sharepoint.com/teams/AzureSecurityCompliance/Security/_layouts/15/Doc.aspx?sourcedoc={c820c6d1-ba1e-45d8-bd74-5e103f5ac176}&action=edit&wd=target%28Dev.one%7Cd00dbe50-2249-48a0-9e60-77d8d2372b57%2FLinux%20MHSM%20Support%20Testing%7C0d396d54-9595-4b03-a232-eafce5f16eb9%2F%29&wdorigin=703