### PR TITLE
MDC Recommendation updates for unsupported scenarios

### DIFF
--- a/VMEncryption/mdc-recommendation/helper-scripts/MdcHandler.py
+++ b/VMEncryption/mdc-recommendation/helper-scripts/MdcHandler.py
@@ -76,9 +76,14 @@ def detect_encryption_status(imds_metadata):
     confidential_vm_status = VerifyVMSupport.is_confidential_vm(imds_metadata)
 
     if (confidential_vm_status is True):
-        is_vm_compliant = False
-        policy_reasons['code'] = "ConfidentialVMNotSupported"
+        is_vm_compliant = True
+        policy_reasons['code'] = "Compliant"
         policy_reasons['phrase'] = "Confidential VMs are not supported by this recommendation."
+
+        ##TO DO: As a temporary fix to report Confidential VMs as compliant, the below block has been commented. The  machine will be marked as compliant.
+        #is_vm_compliant = False
+        #policy_reasons['code'] = "ConfidentialVMNotSupported"
+        #policy_reasons['phrase'] = "Confidential VMs are not supported by this recommendation."
     else:
         is_vm_hbe_encrypted = check_hbe_encryption(imds_metadata)
         is_vm_ade_encrypted = check_ade_encryption(imds_metadata)        
@@ -86,7 +91,7 @@ def detect_encryption_status(imds_metadata):
         if (is_vm_hbe_encrypted is True):
             is_vm_compliant = True
             policy_reasons['code'] = "Compliant"
-            policy_reasons['phrase'] = "VM is encryption compliant with Host Based Encryption."            
+            policy_reasons['phrase'] = "VM is encryption compliant with EncryptionAtHost."
         elif(is_vm_ade_encrypted is True):
             is_vm_compliant = True
             policy_reasons['code'] = "Compliant"
@@ -95,14 +100,19 @@ def detect_encryption_status(imds_metadata):
             vm_support_dict = VerifyVMSupport.check_vm_supportability(imds_metadata)
 
             if vm_support_dict['is_vm_not_supported'] is True:
-                is_vm_compliant = False
-                policy_reasons['code'] = vm_support_dict['code']
+                is_vm_compliant = True
+                policy_reasons['code'] = "Compliant"
                 policy_reasons['phrase'] = vm_support_dict['phrase']
+
+                ##TO DO: As a temporary fix to report unsupported scenarios as compliant, the below block has been commented. The  machine will be marked as compliant.
+                #is_vm_compliant = False
+                #policy_reasons['code'] = vm_support_dict['code']
+                #policy_reasons['phrase'] = vm_support_dict['phrase']
             else:
                 is_vm_compliant = False
                 if (policy_reasons['code'] == "" and policy_reasons['phrase'] == ""):
                     policy_reasons['code'] = "MissingADEandHBE"
-                    policy_reasons['phrase'] = "VM is not encrypted. VM should be encrypted with Host Based Encryption or Azure Disk Encryption."
+                    policy_reasons['phrase'] = "VM is not encrypted. VM should be encrypted with EncryptionAtHost or Azure Disk Encryption."
 
     return is_vm_compliant
 

--- a/VMEncryption/mdc-recommendation/helper-scripts/MdcHandler.py
+++ b/VMEncryption/mdc-recommendation/helper-scripts/MdcHandler.py
@@ -78,8 +78,7 @@ def detect_encryption_status(imds_metadata):
     if (confidential_vm_status is True):
         is_vm_compliant = True
         policy_reasons['code'] = "Compliant"
-        policy_reasons['phrase'] = "Confidential VMs are not supported by this recommendation."
-
+        policy_reasons['phrase'] = "Confidential VMs are not supported by this recommendation. The machine will be marked as compliant."
         ##TO DO: As a temporary fix to report Confidential VMs as compliant, the below block has been commented. The  machine will be marked as compliant.
         #is_vm_compliant = False
         #policy_reasons['code'] = "ConfidentialVMNotSupported"
@@ -102,8 +101,7 @@ def detect_encryption_status(imds_metadata):
             if vm_support_dict['is_vm_not_supported'] is True:
                 is_vm_compliant = True
                 policy_reasons['code'] = "Compliant"
-                policy_reasons['phrase'] = vm_support_dict['phrase']
-
+                policy_reasons['phrase'] = vm_support_dict['phrase'] + " The machine will be marked as compliant."
                 ##TO DO: As a temporary fix to report unsupported scenarios as compliant, the below block has been commented. The  machine will be marked as compliant.
                 #is_vm_compliant = False
                 #policy_reasons['code'] = vm_support_dict['code']
@@ -142,7 +140,7 @@ def main():
     try:
         exception_found = False
 
-        json_output_file_path = sys.argv[2]
+        json_output_file_path =  sys.argv[2]
         imds_metadata = ImdsHelper.get_imds_metadata()
         if imds_metadata is None:
             msg = "Python helper failed in fetching IMDS metadata"

--- a/VMEncryption/mdc-recommendation/helper-scripts/VerifyVMSupport.py
+++ b/VMEncryption/mdc-recommendation/helper-scripts/VerifyVMSupport.py
@@ -141,21 +141,20 @@ def check_vm_supportability(imds_metadata):
         vm_support_dict['phrase'] = "VM OS details are missing in IMDS metadata for verification"
         return vm_support_dict
 
-    else:
-        if is_kubernetes_vm(imds_metadata):
-            is_vm_not_supported = True
-            reasons_code = "KubernetesVirtualMachine"
-            reasons_phrase_str += "Azure Kubernetes VM is not supported by Azure Disk Encryption and EncryptionAtHost."
+    if is_kubernetes_vm(imds_metadata):
+        is_vm_not_supported = True
+        reasons_code = "KubernetesVirtualMachine"
+        reasons_phrase_str += "Azure Kubernetes VM is not supported by Azure Disk Encryption and EncryptionAtHost."
 
-        if is_databricks_vm(imds_metadata):
-            is_vm_not_supported = True
-            reasons_code = "DatabrickVirtualMachine"
-            reasons_phrase_str += "Azure Databricks VM is not supported by Azure Disk Encryption and EncryptionAtHost."
+    if is_databricks_vm(imds_metadata):
+        is_vm_not_supported = True
+        reasons_code = "DatabrickVirtualMachine"
+        reasons_phrase_str += "Azure Databricks VM is not supported by Azure Disk Encryption and EncryptionAtHost."
 
-        if is_os_vmsize_unsupported(imds_metadata):
-            is_vm_not_supported = True
-            reasons_code = "UnsupportedOsVirtualMachine"
-            reasons_phrase_str += "VM OS Image Sku is not supported by Azure Disk Encryption. VM Size Sku is not supported by EncryptionAtHost."
+    if is_os_vmsize_unsupported(imds_metadata):
+        is_vm_not_supported = True
+        reasons_code = "UnsupportedOsVirtualMachine"
+        reasons_phrase_str += "VM OS Image Sku is not supported by Azure Disk Encryption. VM Size Sku is not supported by EncryptionAtHost."
 
     vm_support_dict['is_vm_not_supported'] = is_vm_not_supported
     vm_support_dict['code'] = reasons_code

--- a/VMEncryption/mdc-recommendation/helper-scripts/VerifyVMSupport.py
+++ b/VMEncryption/mdc-recommendation/helper-scripts/VerifyVMSupport.py
@@ -15,7 +15,7 @@ cvm_metadata_value = "confidentialvm"
 # Prefix for VM using Classic Compute provider, Kubernetes or Databricks
 classic_compute_prefix = "classiccompute"
 microsoft_databrick_image_publisher = "azuredatabricks"
-microsoft_aks_image_publisher = "microsoft-aks"    
+microsoft_aks_image_publisher = "microsoft-aks"
 aks_prefix = "aks"
 
 def verify_vm_os_sku_completeness(imds_metadata):
@@ -26,11 +26,11 @@ def verify_vm_os_sku_completeness(imds_metadata):
     if vm_image_publisher is None or vm_image_sku is None or vm_os_offer is None:
         return False
 
-    return True    
+    return True
 
 def is_confidential_vm(imds_metadata):
     cvm_status = imds_metadata['compute']['securityProfile']['securityType']
-    is_confidential_vm = False    
+    is_confidential_vm = False
     
     if cvm_status is not None:
         cvm_status = str(cvm_status).lower()
@@ -39,7 +39,7 @@ def is_confidential_vm(imds_metadata):
         
     return is_confidential_vm
 
-def is_basic_vm(imds_metadata):    
+def is_basic_vm(imds_metadata):
     vm_size = imds_metadata['compute']['vmSize']
     is_vm_size_unsupported = False
     
@@ -49,7 +49,7 @@ def is_basic_vm(imds_metadata):
         
     return is_vm_size_unsupported
 
-def is_classic_vm(imds_metadata):    
+def is_classic_vm(imds_metadata):
     vm_type = imds_metadata['compute']['provider']
     
     is_vm_type_unsupported = False
@@ -63,13 +63,13 @@ def is_classic_vm(imds_metadata):
 
 def is_kubernetes_vm(imds_metadata):
     vm_image_publisher = imds_metadata['compute']['storageProfile']['imageReference']['publisher']
-    vm_image_sku = imds_metadata['compute']['storageProfile']['imageReference']['sku']    
-    is_kubernetes_vm = False 
+    vm_image_sku = imds_metadata['compute']['storageProfile']['imageReference']['sku']
+    is_kubernetes_vm = False
 
     if (microsoft_aks_image_publisher in vm_image_publisher) or (vm_image_sku.startswith(aks_prefix)):
             is_kubernetes_vm = True
     elif (microsoft_databrick_image_publisher in vm_image_publisher):
-        is_kubernetes_vm = True                   
+        is_kubernetes_vm = True
 
     return is_kubernetes_vm
 
@@ -82,11 +82,11 @@ def is_databricks_vm(imds_metadata):
         is_databricks_vm = True
         reasons_phrase_str += "Databricks VM is not supported for ADE or HBE encryption."
     elif (microsoft_databrick_image_publisher in vm_image_publisher):
-        is_databricks_vm = True                    
+        is_databricks_vm = True
 
     return is_databricks_vm
 
-def is_vm_using_ultra_disks(imds_metadata):    
+def is_vm_using_ultra_disks(imds_metadata):
     vm_data_disks = imds_metadata['compute']['storageProfile']['dataDisks']
     is_vm_using_ultra_disk = False
 
@@ -94,7 +94,7 @@ def is_vm_using_ultra_disks(imds_metadata):
         for disk in vm_data_disks:
             ultra_disk_flag = disk['isUltraDisk']
             if (ultra_disk_flag is not None) and ("true" in str(ultra_disk_flag).lower()):
-                is_vm_using_ultra_disk = True                
+                is_vm_using_ultra_disk = True
                 break
   
     return is_vm_using_ultra_disk
@@ -105,35 +105,35 @@ def is_os_vmsize_unsupported(imds_metadata):
     vm_os_offer = imds_metadata['compute']['storageProfile']['imageReference']['offer']
     vm_os_sku = imds_metadata['compute']['storageProfile']['imageReference']['sku']
     vm_image_tuple = tuple((vm_os_offer, vm_os_sku))
-    vm_size = imds_metadata['compute']['vmSize']    
+    vm_size = imds_metadata['compute']['vmSize']
 
     if vm_size is not None:
         if (vm_image_tuple not in supported_ade_image_list) and (vm_size in unsupported_vm_sku_hbe_encryption):
-            unsupported_os_and_vm_size = True           
+            unsupported_os_and_vm_size = True
         
     return unsupported_os_and_vm_size
     
 def check_vm_supportability(imds_metadata):
-    #check if VM is supported for ADE or HBE encryption    
+    #check if VM is supported for ADE or HBE encryption
     is_vm_not_supported = False
     reasons_code = ""
-    reasons_phrase_str = ""    
+    reasons_phrase_str = ""
     vm_support_dict = {}
     
     if is_basic_vm(imds_metadata):
         is_vm_not_supported = True
         reasons_code = "BasicSizedVirtualMachine"
-        reasons_phrase_str += "VM size is not supported by Azure Disk Encryption and Host Based Encryption."    
+        reasons_phrase_str += "VM size is not supported by Azure Disk Encryption and EncryptionAtHost."
 
     if is_classic_vm(imds_metadata):
         is_vm_not_supported = True
         reasons_code = "ClassicVirtualMachine"
-        reasons_phrase_str += "Classic VM is not supported by Azure Disk Encryption and Host Based Encryption."
+        reasons_phrase_str += "Classic VM is not supported by Azure Disk Encryption and EncryptionAtHost."
 
     if is_vm_using_ultra_disks(imds_metadata):
         is_vm_not_supported = True
         reasons_code = "UltraDisksVirtualMachine"
-        reasons_phrase_str += "VM is using ultra disks which is currently not supported by Azure Disk Encryption and Host Based Encryption."
+        reasons_phrase_str += "VM is using ultra disks which is currently not supported by Azure Disk Encryption and EncryptionAtHost."
 
     if verify_vm_os_sku_completeness(imds_metadata) is False:
         vm_support_dict['is_vm_not_supported'] = True
@@ -145,17 +145,17 @@ def check_vm_supportability(imds_metadata):
         if is_kubernetes_vm(imds_metadata):
             is_vm_not_supported = True
             reasons_code = "KubernetesVirtualMachine"
-            reasons_phrase_str += "Azure Kubernetes VM is not supported by Azure Disk Encryption and Host Based Encryption."
+            reasons_phrase_str += "Azure Kubernetes VM is not supported by Azure Disk Encryption and EncryptionAtHost."
 
         if is_databricks_vm(imds_metadata):
             is_vm_not_supported = True
             reasons_code = "DatabrickVirtualMachine"
-            reasons_phrase_str += "Azure Databricks VM is not supported by Azure Disk Encryption and Host Based Encryption."
+            reasons_phrase_str += "Azure Databricks VM is not supported by Azure Disk Encryption and EncryptionAtHost."
 
         if is_os_vmsize_unsupported(imds_metadata):
             is_vm_not_supported = True
             reasons_code = "UnsupportedOsVirtualMachine"
-            reasons_phrase_str += "VM OS Image Sku is not supported by Azure Disk Encryption. VM Size Sku is not supported by Host Based Encryption."    
+            reasons_phrase_str += "VM OS Image Sku is not supported by Azure Disk Encryption. VM Size Sku is not supported by EncryptionAtHost."
 
     vm_support_dict['is_vm_not_supported'] = is_vm_not_supported
     vm_support_dict['code'] = reasons_code


### PR DESCRIPTION
Added updates to mark VMs unsupported by ADE and HBE as Compliant. 

Previously, these VMs were reported as Non-Compliant along with a reason for why the machine is not supported. Currently, MDC's custom logic to detect unsupported scenarios does not categorize the VMs correctly. The updates are a temporary work around to unblock for Public Preview. 

Also, updated "Host Based Encryption" feature name to "EncryptionAtHost" to align with customer facing documentation. 