### PR TITLE
Correct console device path (Fix #1690)

### DIFF
--- a/VMEncryption/main/Utils/HandlerUtil.py
+++ b/VMEncryption/main/Utils/HandlerUtil.py
@@ -405,7 +405,7 @@ class HandlerUtility:
 
     def _change_log_file(self):
         #self.log("Logging to " + self._context._log_file)
-        waagent.LoggerInit(self._context._log_file,'/dev/stdout')
+        waagent.LoggerInit(self._context._log_file,'/dev/console')
         self._log = waagent.Log
         self._error = waagent.Error
 


### PR DESCRIPTION
Current code initialize self.con_path as /dev/stdout by waagent.LoggerInit(). If self.con_path is /dev/stdout, stdout is broken by WriteToConsole() in main/Utils/waagent because WriteToConsole is a function for write message to /dev/console. This patch fix the issue.