### PR TITLE
Send Flags via Request To BHS, Xstore

### DIFF
--- a/VMBackup/main/Utils/HostSnapshotObjects.py
+++ b/VMBackup/main/Utils/HostSnapshotObjects.py
@@ -1,14 +1,15 @@
 import json
 
 class HostDoSnapshotRequestBody:
-    def __init__(self, taskId, diskIds, snapshotTaskToken, snapshotMetadata):
+    def __init__(self, taskId, diskIds, settings, snapshotTaskToken, snapshotMetadata):
         self.taskId = taskId
         self.diskIds = diskIds
         self.snapshotMetadata = snapshotMetadata
         self.snapshotTaskToken = snapshotTaskToken
+        self.settings = settings
 
     def convertToDictionary(self):
-        return dict(taskId = self.taskId, diskIds = self.diskIds, snapshotTaskToken = self.snapshotTaskToken, snapshotMetadata = self.snapshotMetadata)
+        return dict(taskId = self.taskId, diskIds = self.diskIds, settings = self.settings, snapshotTaskToken = self.snapshotTaskToken, snapshotMetadata = self.snapshotMetadata)
 
 class HostPreSnapshotRequestBody:
     def __init__(self, taskId, snapshotTaskToken):

--- a/VMBackup/main/common.py
+++ b/VMBackup/main/common.py
@@ -43,10 +43,8 @@ class CommonVariables:
     TempStatusFileName = 'tempStatusFile.status'
     onlyLocalFilesystems = 'onlyLocalFilesystems'
     isSnapshotTTLEnabled = 'isSnapshotTTLEnabled'
-    useMCCFForLAD = ' UseMCCFForLAD'
+    useMCCFForLAD = 'UseMCCFForLAD'
     useMCCFToFetchDSASForAllDisks = 'UseMCCFToFetchDSASForAllDisks'
-    settings = 'settings'
-
 
     snapshotTaskToken = 'snapshotTaskToken'
     snapshotCreator = 'snapshotCreator'

--- a/VMBackup/main/common.py
+++ b/VMBackup/main/common.py
@@ -42,6 +42,11 @@ class CommonVariables:
     statusBlobUploadError = 'statusBlobUploadError'
     TempStatusFileName = 'tempStatusFile.status'
     onlyLocalFilesystems = 'onlyLocalFilesystems'
+    isSnapshotTTLEnabled = 'isSnapshotTTLEnabled'
+    useMCCFForLAD = ' UseMCCFForLAD'
+    useMCCFToFetchDSASForAllDisks = 'UseMCCFToFetchDSASForAllDisks'
+    settings = 'settings'
+
 
     snapshotTaskToken = 'snapshotTaskToken'
     snapshotCreator = 'snapshotCreator'

--- a/VMBackup/main/common.py
+++ b/VMBackup/main/common.py
@@ -45,6 +45,10 @@ class CommonVariables:
     isSnapshotTtlEnabled = 'isSnapshotTtlEnabled'
     useMccfForLad = 'useMccfForLad'
     useMccfToFetchDsasForAllDisks = 'useMccfToFetchDsasForAllDisks'
+    key = 'Key'
+    value = 'Value'
+    headerPrefix = 'x-ms-snapshot-ttl-expiry-hours'
+
 
     snapshotTaskToken = 'snapshotTaskToken'
     snapshotCreator = 'snapshotCreator'

--- a/VMBackup/main/common.py
+++ b/VMBackup/main/common.py
@@ -47,8 +47,7 @@ class CommonVariables:
     useMccfToFetchDsasForAllDisks = 'useMccfToFetchDsasForAllDisks'
     key = 'Key'
     value = 'Value'
-    headerPrefix = 'x-ms-snapshot-ttl-expiry-hours'
-
+    snapshotTtlHeader = 'x-ms-snapshot-ttl-expiry-hours'
 
     snapshotTaskToken = 'snapshotTaskToken'
     snapshotCreator = 'snapshotCreator'

--- a/VMBackup/main/common.py
+++ b/VMBackup/main/common.py
@@ -42,9 +42,9 @@ class CommonVariables:
     statusBlobUploadError = 'statusBlobUploadError'
     TempStatusFileName = 'tempStatusFile.status'
     onlyLocalFilesystems = 'onlyLocalFilesystems'
-    isSnapshotTTLEnabled = 'isSnapshotTTLEnabled'
-    useMCCFForLAD = 'UseMCCFForLAD'
-    useMCCFToFetchDSASForAllDisks = 'UseMCCFToFetchDSASForAllDisks'
+    isSnapshotTtlEnabled = 'isSnapshotTtlEnabled'
+    useMccfForLad = 'useMccfForLad'
+    useMccfToFetchDsasForAllDisks = 'useMccfToFetchDsasForAllDisks'
 
     snapshotTaskToken = 'snapshotTaskToken'
     snapshotCreator = 'snapshotCreator'

--- a/VMBackup/main/guestsnapshotter.py
+++ b/VMBackup/main/guestsnapshotter.py
@@ -94,7 +94,7 @@ class GuestSnapshotter(object):
                         key = meta['Key']
                         value = meta['Value']
                         headers["x-ms-meta-" + key] = value
-                if(CommonVariables.isSnapshotTTLEnabled in settings and settings[CommonVariables.isSnapshotTTLEnabled]):
+                if(CommonVariables.isSnapshotTtlEnabled in settings and settings[CommonVariables.isSnapshotTtlEnabled]):
                     headers["x-ms-snapshot-ttl-expiry-hours"] = '1'
                 temp_logger = temp_logger + str(headers)
                 http_util = HttpUtil(self.logger)
@@ -150,7 +150,7 @@ class GuestSnapshotter(object):
                         key = meta['Key']
                         value = meta['Value']
                         headers["x-ms-meta-" + key] = value
-                if(CommonVariables.isSnapshotTTLEnabled in settings and settings[CommonVariables.isSnapshotTTLEnabled]):
+                if(CommonVariables.isSnapshotTtlEnabled in settings and settings[CommonVariables.isSnapshotTtlEnabled]):
                     headers["x-ms-snapshot-ttl-expiry-hours"] = '1'
                 self.logger.log(str(headers))
                 http_util = HttpUtil(self.logger)

--- a/VMBackup/main/guestsnapshotter.py
+++ b/VMBackup/main/guestsnapshotter.py
@@ -94,8 +94,8 @@ class GuestSnapshotter(object):
                         key = meta['Key']
                         value = meta['Value']
                         headers["x-ms-meta-" + key] = value
-                if(CommonVariables.isSnapshotTTLEnabled in settings):
-                    headers["x-ms-snapshot-ttl-expiry-hours"] = settings[CommonVariables.isSnapshotTTLEnabled]
+                if(CommonVariables.isSnapshotTTLEnabled in settings and settings[CommonVariables.isSnapshotTTLEnabled]):
+                    headers["x-ms-snapshot-ttl-expiry-hours"] = '1'
                 temp_logger = temp_logger + str(headers)
                 http_util = HttpUtil(self.logger)
                 sasuri_obj = urlparser.urlparse(sasuri + '&comp=snapshot')
@@ -150,8 +150,8 @@ class GuestSnapshotter(object):
                         key = meta['Key']
                         value = meta['Value']
                         headers["x-ms-meta-" + key] = value
-                if(CommonVariables.isSnapshotTTLEnabled in settings):
-                    headers["x-ms-snapshot-ttl-expiry-hours"] = settings[CommonVariables.isSnapshotTTLEnabled]
+                if(CommonVariables.isSnapshotTTLEnabled in settings and settings[CommonVariables.isSnapshotTTLEnabled]):
+                    headers["x-ms-snapshot-ttl-expiry-hours"] = '1'
                 self.logger.log(str(headers))
                 http_util = HttpUtil(self.logger)
                 sasuri_obj = urlparser.urlparse(sasuri + '&comp=snapshot')

--- a/VMBackup/main/guestsnapshotter.py
+++ b/VMBackup/main/guestsnapshotter.py
@@ -69,7 +69,7 @@ class GuestSnapshotter(object):
         self.configfile='/etc/azure/vmbackup.conf'
         self.hutil = hutil
 
-    def snapshot(self, sasuri, sasuri_index, meta_data, snapshot_result_error, snapshot_info_indexer_queue, global_logger, global_error_logger):
+    def snapshot(self, sasuri, sasuri_index, settings, meta_data, snapshot_result_error, snapshot_info_indexer_queue, global_logger, global_error_logger):
         temp_logger=''
         error_logger=''
         snapshot_error = SnapshotError()
@@ -94,6 +94,8 @@ class GuestSnapshotter(object):
                         key = meta['Key']
                         value = meta['Value']
                         headers["x-ms-meta-" + key] = value
+                if(CommonVariables.isSnapshotTTLEnabled in settings):
+                    headers["x-ms-snapshot-ttl-expiry-hours"] = settings[CommonVariables.isSnapshotTTLEnabled]
                 temp_logger = temp_logger + str(headers)
                 http_util = HttpUtil(self.logger)
                 sasuri_obj = urlparser.urlparse(sasuri + '&comp=snapshot')
@@ -125,7 +127,7 @@ class GuestSnapshotter(object):
         snapshot_result_error.put(snapshot_error)
         snapshot_info_indexer_queue.put(snapshot_info_indexer)
 
-    def snapshot_seq(self, sasuri, sasuri_index, meta_data):
+    def snapshot_seq(self, sasuri, sasuri_index, settings, meta_data):
         result = None
         snapshot_error = SnapshotError()
         snapshot_info_indexer = SnapshotInfoIndexerObj(sasuri_index, False, None, None)
@@ -148,6 +150,8 @@ class GuestSnapshotter(object):
                         key = meta['Key']
                         value = meta['Value']
                         headers["x-ms-meta-" + key] = value
+                if(CommonVariables.isSnapshotTTLEnabled in settings):
+                    headers["x-ms-snapshot-ttl-expiry-hours"] = settings[CommonVariables.isSnapshotTTLEnabled]
                 self.logger.log(str(headers))
                 http_util = HttpUtil(self.logger)
                 sasuri_obj = urlparser.urlparse(sasuri + '&comp=snapshot')
@@ -204,7 +208,7 @@ class GuestSnapshotter(object):
                     self.logger.log("index: " + str(blob_index) + " blobUri: " + str(blobUri))
                     blob_snapshot_info_array.append(HostSnapshotObjects.BlobSnapshotInfo(False, blobUri, None, 500))
                     try:
-                        mp_jobs.append(mp.Process(target=self.snapshot,args=(blob, blob_index, paras.backup_metadata, snapshot_result_error, snapshot_info_indexer_queue, global_logger, global_error_logger)))
+                        mp_jobs.append(mp.Process(target=self.snapshot,args=(blob, blob_index, paras.settings, paras.backup_metadata, snapshot_result_error, snapshot_info_indexer_queue, global_logger, global_error_logger)))
                     except Exception as e:
                         self.logger.log("multiprocess queue creation failed")
                         all_snapshots_failed = True
@@ -293,7 +297,7 @@ class GuestSnapshotter(object):
                     blobUri = blob.split("?")[0]
                     self.logger.log("index: " + str(blob_index) + " blobUri: " + str(blobUri))
                     blob_snapshot_info_array.append(HostSnapshotObjects.BlobSnapshotInfo(False, blobUri, None, 500))
-                    snapshotError, snapshot_info_indexer = self.snapshot_seq(blob, blob_index, paras.backup_metadata)
+                    snapshotError, snapshot_info_indexer = self.snapshot_seq(blob, blob_index, paras.settings, paras.backup_metadata)
                     if(snapshotError.errorcode != CommonVariables.success):
                         snapshot_result.errors.append(snapshotError)
                     # update blob_snapshot_info_array element properties from snapshot_info_indexer object

--- a/VMBackup/main/guestsnapshotter.py
+++ b/VMBackup/main/guestsnapshotter.py
@@ -95,7 +95,7 @@ class GuestSnapshotter(object):
                         value = meta['Value']
                         headers["x-ms-meta-" + key] = value
                 if(CommonVariables.isSnapshotTtlEnabled in settings and settings[CommonVariables.isSnapshotTtlEnabled]):
-                    headers["x-ms-snapshot-ttl-expiry-hours"] = '1'
+                    headers[CommonVariables.headerPrefix] = '1'
                 temp_logger = temp_logger + str(headers)
                 http_util = HttpUtil(self.logger)
                 sasuri_obj = urlparser.urlparse(sasuri + '&comp=snapshot')
@@ -151,7 +151,7 @@ class GuestSnapshotter(object):
                         value = meta['Value']
                         headers["x-ms-meta-" + key] = value
                 if(CommonVariables.isSnapshotTtlEnabled in settings and settings[CommonVariables.isSnapshotTtlEnabled]):
-                    headers["x-ms-snapshot-ttl-expiry-hours"] = '1'
+                    headers[CommonVariables.headerPrefix] = '1'
                 self.logger.log(str(headers))
                 http_util = HttpUtil(self.logger)
                 sasuri_obj = urlparser.urlparse(sasuri + '&comp=snapshot')

--- a/VMBackup/main/guestsnapshotter.py
+++ b/VMBackup/main/guestsnapshotter.py
@@ -95,7 +95,7 @@ class GuestSnapshotter(object):
                         value = meta['Value']
                         headers["x-ms-meta-" + key] = value
                 if(CommonVariables.isSnapshotTtlEnabled in settings and settings[CommonVariables.isSnapshotTtlEnabled]):
-                    headers[CommonVariables.headerPrefix] = '1'
+                    headers[CommonVariables.snapshotTtlHeader] = '1'
                 temp_logger = temp_logger + str(headers)
                 http_util = HttpUtil(self.logger)
                 sasuri_obj = urlparser.urlparse(sasuri + '&comp=snapshot')
@@ -151,7 +151,7 @@ class GuestSnapshotter(object):
                         value = meta['Value']
                         headers["x-ms-meta-" + key] = value
                 if(CommonVariables.isSnapshotTtlEnabled in settings and settings[CommonVariables.isSnapshotTtlEnabled]):
-                    headers[CommonVariables.headerPrefix] = '1'
+                    headers[CommonVariables.snapshotTtlHeader] = '1'
                 self.logger.log(str(headers))
                 http_util = HttpUtil(self.logger)
                 sasuri_obj = urlparser.urlparse(sasuri + '&comp=snapshot')

--- a/VMBackup/main/hostsnapshotter.py
+++ b/VMBackup/main/hostsnapshotter.py
@@ -69,7 +69,7 @@ class HostSnapshotter(object):
                 headers['Content-type'] = 'application/json'
                 if (paras.includeLunList != None and paras.includeLunList.count != 0):
                     diskIds = paras.includeLunList
-                hostDoSnapshotRequestBodyObj = HostSnapshotObjects.HostDoSnapshotRequestBody(taskId, diskIds, paras.settings, paras.snapshotTaskToken, meta_data)
+                hostDoSnapshotRequestBodyObj = HostSnapshotObjects.HostDoSnapshotRequestBody(taskId, diskIds, paras.wellKnownSettingFlags, paras.snapshotTaskToken, meta_data)
                 body_content = json.dumps(hostDoSnapshotRequestBodyObj, cls = HandlerUtil.ComplexEncoder)
                 self.logger.log('Headers : ' + str(headers))
                 self.logger.log('Host Request body : ' + str(body_content))

--- a/VMBackup/main/hostsnapshotter.py
+++ b/VMBackup/main/hostsnapshotter.py
@@ -69,7 +69,7 @@ class HostSnapshotter(object):
                 headers['Content-type'] = 'application/json'
                 if (paras.includeLunList != None and paras.includeLunList.count != 0):
                     diskIds = paras.includeLunList
-                hostDoSnapshotRequestBodyObj = HostSnapshotObjects.HostDoSnapshotRequestBody(taskId, diskIds, paras.snapshotTaskToken, meta_data)
+                hostDoSnapshotRequestBodyObj = HostSnapshotObjects.HostDoSnapshotRequestBody(taskId, diskIds, paras.settings, paras.snapshotTaskToken, meta_data)
                 body_content = json.dumps(hostDoSnapshotRequestBodyObj, cls = HandlerUtil.ComplexEncoder)
                 self.logger.log('Headers : ' + str(headers))
                 self.logger.log('Host Request body : ' + str(body_content))

--- a/VMBackup/main/parameterparser.py
+++ b/VMBackup/main/parameterparser.py
@@ -35,7 +35,7 @@ class ParameterParser(object):
         self.snapshotTaskToken = ''
         self.includedDisks = None
         self.settings = None
-        self.wellKnownSettingFlags = {'isSnapshotTTLEnabled','UseMCCFForLAD','UseMCCFToFetchDSASForAllDisks'}
+        self.wellKnownSettingFlags = {CommonVariables.isSnapshotTtlEnabled: False, CommonVariables.useMccfToFetchDsasForAllDisks: False, CommonVariables.useMccfForLad: False}
         self.includeLunList = []    #To be shared with HP
 
         """
@@ -111,4 +111,7 @@ class ParameterParser(object):
             for flag in self.settings.keys():
                 if(flag not in self.wellKnownSettingFlags):
                     backup_logger.log("The received " + str(flag) + " is not an expected setting name.", True)
+                else:
+                    self.wellKnownSettingFlags[flag] = self.settings[flag]
             backup_logger.log("settings received " + str(self.settings), True)
+            backup_logger.log("settings to be sent " + str(self.wellKnownSettingFlags), True)

--- a/VMBackup/main/parameterparser.py
+++ b/VMBackup/main/parameterparser.py
@@ -109,14 +109,13 @@ class ParameterParser(object):
         
         if(self.dynamicConfigsFromCRP != None):
             try:
-                for dictionary in self.dynamicConfigsFromCRP:
-                    self.settings[dictionary['Key']] = dictionary['Value']
-                backup_logger.log("settings received " + str(self.settings), True)
-                for flag in self.settings.keys():
-                    if(flag not in self.wellKnownSettingFlags):
-                        backup_logger.log("The received " + str(flag) + " is not an expected setting name.", True)
+                for config in self.dynamicConfigsFromCRP:
+                    self.settings[config['Key']] = config['Value']
+                    if(config['Key'] in self.wellKnownSettingFlags):
+                        self.wellKnownSettingFlags[config['Key']] = self.settings[config['Key']]
                     else:
-                        self.wellKnownSettingFlags[flag] = self.settings[flag]
+                        backup_logger.log("The received " + str(config['Key']) + " is not an expected setting name.", True)
+                backup_logger.log("settings received " + str(self.settings), True)
                 backup_logger.log("settings to be sent " + str(self.wellKnownSettingFlags), True)
             except Exception as e:
                 errorMsg = "Exception occurred while populating settings, Exception: %s" % (str(e))

--- a/VMBackup/main/parameterparser.py
+++ b/VMBackup/main/parameterparser.py
@@ -109,9 +109,7 @@ class ParameterParser(object):
         
         if(self.dynamicConfigsFromCRP != None):
             try:
-                dynamicConfigsFromCRP_str = json.dumps(self.dynamicConfigsFromCRP)
-                listOfSettings = json.loads(dynamicConfigsFromCRP_str)
-                for dictionary in listOfSettings:
+                for dictionary in self.dynamicConfigsFromCRP:
                     self.settings[dictionary['Key']] = dictionary['Value']
                 backup_logger.log("settings received " + str(self.settings), True)
                 for flag in self.settings.keys():

--- a/VMBackup/main/parameterparser.py
+++ b/VMBackup/main/parameterparser.py
@@ -35,7 +35,7 @@ class ParameterParser(object):
         self.snapshotTaskToken = ''
         self.includedDisks = None
         self.settings = None
-        self.wellKnownSettingFlags = ['isSnapshotTTLEnabled','UseMCCFForLAD','UseMCCFToFetchDSASForAllDisks']
+        self.wellKnownSettingFlags = {'isSnapshotTTLEnabled','UseMCCFForLAD','UseMCCFToFetchDSASForAllDisks'}
         self.includeLunList = []    #To be shared with HP
 
         """
@@ -77,8 +77,8 @@ class ParameterParser(object):
             self.snapshotTaskToken = protected_settings.get(CommonVariables.snapshotTaskToken)
         if(CommonVariables.includedDisks in self.public_config_obj.keys()):
             self.includedDisks = self.public_config_obj[CommonVariables.includedDisks]
-        if(CommonVariables.settings in self.public_config_obj.keys()):
-            self.settings = self.public_config_obj[CommonVariables.settings]
+        if("dynamicConfigsFromCRP" in self.public_config_obj.keys()):
+            self.settings = self.public_config_obj['dynamicConfigsFromCRP']
 
         """
         first get the protected configuration
@@ -109,10 +109,6 @@ class ParameterParser(object):
         
         if(self.settings != None):
             for flag in self.settings.keys():
-                foundFlag = False
-                for wellKnownFlag in self.wellKnownSettingFlags:
-                    if wellKnownFlag.lower() == flag.lower():
-                        foundFlag = True
-                        break
-                if(foundFlag != True):
-                    backup_logger.log("The flags passed through settings dictionary " + str(flag) +" is different from the expected one", True)
+                if(flag not in self.wellKnownSettingFlags):
+                    backup_logger.log("The received " + str(flag) + " is not an expected setting name.", True)
+            backup_logger.log("settings received " + str(self.settings), True)

--- a/VMBackup/main/parameterparser.py
+++ b/VMBackup/main/parameterparser.py
@@ -34,7 +34,6 @@ class ParameterParser(object):
         self.customSettings = None
         self.snapshotTaskToken = ''
         self.includedDisks = None
-        self.settings = {}
         self.dynamicConfigsFromCRP = None
         self.wellKnownSettingFlags = {CommonVariables.isSnapshotTtlEnabled: False, CommonVariables.useMccfToFetchDsasForAllDisks: False, CommonVariables.useMccfForLad: False}
         self.includeLunList = []    #To be shared with HP
@@ -110,12 +109,14 @@ class ParameterParser(object):
         if(self.dynamicConfigsFromCRP != None):
             try:
                 for config in self.dynamicConfigsFromCRP:
-                    self.settings[config['Key']] = config['Value']
-                    if(config['Key'] in self.wellKnownSettingFlags):
-                        self.wellKnownSettingFlags[config['Key']] = self.settings[config['Key']]
+                    if 'Key' in config and 'Value' in config:
+                        if(config['Key'] in self.wellKnownSettingFlags):
+                            self.wellKnownSettingFlags[config['Key']] = config['Value']
+                        else:
+                            backup_logger.log("The received " + str(config['Key']) + " is not an expected setting name.", True)
                     else:
-                        backup_logger.log("The received " + str(config['Key']) + " is not an expected setting name.", True)
-                backup_logger.log("settings received " + str(self.settings), True)
+                        backup_logger.log("The received dynamicConfigsFromCRP is not in expected format.", True)
+                backup_logger.log("settings received " + str(self.dynamicConfigsFromCRP), True)
                 backup_logger.log("settings to be sent " + str(self.wellKnownSettingFlags), True)
             except Exception as e:
                 errorMsg = "Exception occurred while populating settings, Exception: %s" % (str(e))

--- a/VMBackup/main/parameterparser.py
+++ b/VMBackup/main/parameterparser.py
@@ -115,4 +115,4 @@ class ParameterParser(object):
                         foundFlag = True
                         break
                 if(foundFlag != True):
-                    backup_logger.log("The flags passed through settings dictionary" + str(flag) +" is different from the expected one", True)
+                    backup_logger.log("The flags passed through settings dictionary " + str(flag) +" is different from the expected one", True)

--- a/VMBackup/main/parameterparser.py
+++ b/VMBackup/main/parameterparser.py
@@ -110,11 +110,11 @@ class ParameterParser(object):
             try:
                 backup_logger.log("settings received " + str(self.dynamicConfigsFromCRP), True)
                 for config in self.dynamicConfigsFromCRP:
-                    if 'Key' in config and 'Value' in config:
-                        if(config['Key'] in self.wellKnownSettingFlags):
-                            self.wellKnownSettingFlags[config['Key']] = config['Value']
+                    if CommonVariables.key in config and CommonVariables.value in config:
+                        if(config[CommonVariables.key] in self.wellKnownSettingFlags):
+                            self.wellKnownSettingFlags[config[CommonVariables.key]] = config[CommonVariables.value]
                         else:
-                            backup_logger.log("The received " + str(config['Key']) + " is not an expected setting name.", True)
+                            backup_logger.log("The received " + str(config[CommonVariables.key]) + " is not an expected setting name.", True)
                     else:
                         backup_logger.log("The received dynamicConfigsFromCRP is not in expected format.", True)
                 backup_logger.log("settings to be sent " + str(self.wellKnownSettingFlags), True)

--- a/VMBackup/main/parameterparser.py
+++ b/VMBackup/main/parameterparser.py
@@ -108,6 +108,7 @@ class ParameterParser(object):
         
         if(self.dynamicConfigsFromCRP != None):
             try:
+                backup_logger.log("settings received " + str(self.dynamicConfigsFromCRP), True)
                 for config in self.dynamicConfigsFromCRP:
                     if 'Key' in config and 'Value' in config:
                         if(config['Key'] in self.wellKnownSettingFlags):
@@ -116,7 +117,6 @@ class ParameterParser(object):
                             backup_logger.log("The received " + str(config['Key']) + " is not an expected setting name.", True)
                     else:
                         backup_logger.log("The received dynamicConfigsFromCRP is not in expected format.", True)
-                backup_logger.log("settings received " + str(self.dynamicConfigsFromCRP), True)
                 backup_logger.log("settings to be sent " + str(self.wellKnownSettingFlags), True)
             except Exception as e:
                 errorMsg = "Exception occurred while populating settings, Exception: %s" % (str(e))

--- a/VMBackup/main/parameterparser.py
+++ b/VMBackup/main/parameterparser.py
@@ -36,7 +36,7 @@ class ParameterParser(object):
         self.includedDisks = None
         self.settings = {}
         self.dynamicConfigsFromCRP = None
-        self.wellKnownSettingFlags = {'isSnapshotTtlEnabled': False, 'useMccfToFetchDsasForAllDisks': False, 'useMccfForLad': False}
+        self.wellKnownSettingFlags = {CommonVariables.isSnapshotTtlEnabled: False, CommonVariables.useMccfToFetchDsasForAllDisks: False, CommonVariables.useMccfForLad: False}
         self.includeLunList = []    #To be shared with HP
 
         """

--- a/VMBackup/main/parameterparser.py
+++ b/VMBackup/main/parameterparser.py
@@ -34,6 +34,8 @@ class ParameterParser(object):
         self.customSettings = None
         self.snapshotTaskToken = ''
         self.includedDisks = None
+        self.settings = None
+        self.wellKnownSettingFlags = ['isSnapshotTTLEnabled','UseMCCFForLAD','UseMCCFToFetchDSASForAllDisks']
         self.includeLunList = []    #To be shared with HP
 
         """
@@ -75,6 +77,8 @@ class ParameterParser(object):
             self.snapshotTaskToken = protected_settings.get(CommonVariables.snapshotTaskToken)
         if(CommonVariables.includedDisks in self.public_config_obj.keys()):
             self.includedDisks = self.public_config_obj[CommonVariables.includedDisks]
+        if(CommonVariables.settings in self.public_config_obj.keys()):
+            self.settings = self.public_config_obj[CommonVariables.settings]
 
         """
         first get the protected configuration
@@ -102,3 +106,13 @@ class ParameterParser(object):
         except Exception as e:
             errorMsg = "Exception occurred while populating includeLunList, Exception: %s" % (str(e))
             backup_logger.log(errorMsg, True)
+        
+        if(self.settings != None):
+            for flag in self.settings.keys():
+                foundFlag = False
+                for wellKnownFlag in self.wellKnownSettingFlags:
+                    if wellKnownFlag.lower() == flag.lower():
+                        foundFlag = True
+                        break
+                if(foundFlag != True):
+                    backup_logger.log("The flags passed through settings dictionary" + str(flag) +" is different from the expected one", True)


### PR DESCRIPTION
Need for Change:
We want to control the new feature rollout and since the dynamic Config is not there at BHS side, by passing flags received from CRP to BHS and XStore, we are trying to have a controlled rollout.
Made changes in
common.py
HostSnapshotObjects.py
Initializing the settings received
guestsnapshotter.py
appending the headers with ttl flag
hostsnapshotter.py
Sending the settings as part of request body, when a call is made for DoSnapshot.
parameterparser.py
fetching the settings passed from CRP and validating them with known setting flags.