### PR TITLE
Add 'ol' as a valid distro name

### DIFF
--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -699,22 +699,6 @@ def handle_mcs_config(public_settings, protected_settings, default_configs):
         else:
             set_proxy(default_configs["MDSD_PROXY_ADDRESS"], "", "")
     
-    
-    # is this Arc? If so, check for proxy     
-    if os.path.isfile(ArcSettingsFile):
-        f = open(ArcSettingsFile, "r")
-        data = f.read()
-
-        if (data != ''):
-            json_data = json.loads(data)
-            if json_data is not None and "proxy.url" in json_data:
-                url = json_data["proxy.url"]
-                # only non-authenticated proxy config is supported
-                if url != '':
-                    default_configs["MDSD_PROXY_ADDRESS"] = url
-                    set_proxy(default_configs["MDSD_PROXY_ADDRESS"], "", "")
-                    
-
     # is this Arc? If so, check for proxy     
     if os.path.isfile(ArcSettingsFile):
         f = open(ArcSettingsFile, "r")

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -699,6 +699,22 @@ def handle_mcs_config(public_settings, protected_settings, default_configs):
         else:
             set_proxy(default_configs["MDSD_PROXY_ADDRESS"], "", "")
     
+    
+    # is this Arc? If so, check for proxy     
+    if os.path.isfile(ArcSettingsFile):
+        f = open(ArcSettingsFile, "r")
+        data = f.read()
+
+        if (data != ''):
+            json_data = json.loads(data)
+            if json_data is not None and "proxy.url" in json_data:
+                url = json_data["proxy.url"]
+                # only non-authenticated proxy config is supported
+                if url != '':
+                    default_configs["MDSD_PROXY_ADDRESS"] = url
+                    set_proxy(default_configs["MDSD_PROXY_ADDRESS"], "", "")
+                    
+
     # is this Arc? If so, check for proxy     
     if os.path.isfile(ArcSettingsFile):
         f = open(ArcSettingsFile, "r")
@@ -1427,7 +1443,7 @@ def find_package_manager(operation):
     dist, _ = find_vm_distro(operation)
 
     dpkg_set = set(["debian", "ubuntu"])
-    rpm_set = set(["oracle", "redhat", "centos", "red hat", "suse", "sles", "opensuse", "cbl-mariner", "mariner", "rhel", "rocky", "alma", "amzn"])
+    rpm_set = set(["oracle", 'ol', "redhat", "centos", "red hat", "suse", "sles", "opensuse", "cbl-mariner", "mariner", "rhel", "rocky", "alma", "amzn"])
     for dpkg_dist in dpkg_set:
         if dist.startswith(dpkg_dist):
             PackageManager = "dpkg"
@@ -1499,6 +1515,7 @@ def is_vm_supported_for_extension(operation):
                        'centos' : ['7', '8'], # CentOS
                        'red hat' : ['7', '8', '9'], # Oracle, RHEL
                        'oracle' : ['7', '8'], # Oracle
+                       'ol' : ['7', '8'], # Oracle Linux
                        'debian' : ['9', '10', '11'], # Debian
                        'ubuntu' : ['16.04', '18.04', '20.04', '22.04'], # Ubuntu
                        'suse' : ['12'], 'sles' : ['15'], # SLES
@@ -1585,7 +1602,7 @@ def get_ssl_cert_info(operation):
         if distro.startswith(name):
             return 'SSL_CERT_DIR', '/etc/ssl/certs'
 
-    for name in ['centos', 'redhat', 'red hat', 'oracle', 'cbl-mariner', 'mariner', 'rhel', 'rocky', 'alma', 'amzn']:
+    for name in ['centos', 'redhat', 'red hat', 'oracle', 'ol', 'cbl-mariner', 'mariner', 'rhel', 'rocky', 'alma', 'amzn']:
         if distro.startswith(name):
             return 'SSL_CERT_FILE', '/etc/pki/tls/certs/ca-bundle.crt'
 


### PR DESCRIPTION
Fix the bug that python 3.8+ doesn't have function platform.linux_distribution() and platform.dist(), and manaul parsing doesn't catch 'ol' as a supported distro.