### PR TITLE
VMAccess support for ED25519 format SSH keys

### DIFF
--- a/VMAccess/vmaccess.py
+++ b/VMAccess/vmaccess.py
@@ -293,7 +293,7 @@ def _set_user_account_pub_key(protect_settings, hutil):
     # Reset ssh key with the new public key passed in or reuse old public key.
     if cert_txt:
         # support for SSH2-compatible format for public keys in addition to OpenSSH-compatible format
-        if (cert_txt.strip().startswith(BeginSSHTag)):
+        if cert_txt.strip().startswith(BeginSSHTag):
             ext_utils.set_file_contents("temp.pub", cert_txt.strip())
             retcode, output = ext_utils.run_command_get_output(['ssh-keygen', '-i', '-f', 'temp.pub'])
             if retcode > 0:
@@ -302,7 +302,7 @@ def _set_user_account_pub_key(protect_settings, hutil):
             cert_txt = output
             os.remove("temp.pub")
 
-        if cert_txt and (cert_txt.strip().lower().startswith("ssh-rsa") or cert_txt.strip().lower().startswith("ssh-ed25519")):
+        if cert_txt.strip().lower().startswith("ssh-rsa") or cert_txt.strip().lower().startswith("ssh-ed25519"):
             no_convert = True
         try:
             pub_path = os.path.join('/home/', user_name, '.ssh',


### PR DESCRIPTION
ED25519 keys are the industry standard for SSH authentication in the modern world and are generally considered to be more secure. Currently, VMAccess does not support adding such keys to the authorized_keys file.

These changes will allow customers to choose ED25519 format keys when generating key pairs or submitting public keys for authentication.