### PR TITLE
VMAccess support for removing prior SSH keys

### DIFF
--- a/VMAccess/vmaccess.py
+++ b/VMAccess/vmaccess.py
@@ -318,7 +318,7 @@ def _set_user_account_pub_key(protect_settings, hutil):
 
                     if remove_prior_keys == True:
                         ext_utils.set_file_contents(pub_path, final_cert_txt)
-                        hutil.log("Removed prior ssh keys for user %s" % user_name)
+                        hutil.log("Removed prior ssh keys and added new key for user %s" % user_name)
                     else:
                         ext_utils.append_file_contents(pub_path, final_cert_txt)
         


### PR DESCRIPTION
The current behavior of VMAccess is to append the new public key text to the ~/.ssh/authorized_keys file. This PR adds functionality to remove prior SSH keys when adding a new one. 

This will be useful for our customers who have security requirements regarding resetting old SSH keys to new ones. They will have to set **remove_prior_keys** to **true**, and pass in a new SSH key, in protected settings in order to have the old keys removed.

Work Item: https://msazure.visualstudio.com/One/_sprints/taskboard/CPlat%20Runtime%20Extensions/One/Gallium/CY23Q3/2Wk/2Wk09%20(Jul%2016%20-%20Jul%2029)?workitem=17072808
