### PR TITLE
VMAccess support for CBL-Mariner distro

### DIFF
--- a/Utils/distroutils.py
+++ b/Utils/distroutils.py
@@ -538,6 +538,7 @@ class SuSEDistro(GenericDistro):
         self.ssh_service_name = 'sshd'
         self.distro_name = "SuSE"
 
+
 class MarinerDistro(GenericDistro):
     def __init__(self, config):
         super(MarinerDistro, self).__init__(config)


### PR DESCRIPTION
Currently, restarting the SSH service using VMAccess fails in Mariner. This PR corrects this issue, allowing customers to use VMAccess properly for all operations involving restarting the SSH service.

Bug (identified in LISA test results): https://microsoft.visualstudio.com/OS/_workitems/edit/45595424