### PR TITLE
VMAccess support for restoring SSH config

### DIFF
--- a/VMAccess/vmaccess.py
+++ b/VMAccess/vmaccess.py
@@ -388,7 +388,7 @@ def _backup_and_update_sshd_config(hutil, attr_name, attr_value):
 
     hutil.log(f"Setting {attr_name} to {attr_value} in sshd_config.")
     
-    _backup_sshd_config()
+    _backup_sshd_config(hutil)
     _set_sshd_config(config, attr_name, attr_value)
     ext_utils.replace_file_with_contents_atomic(SshdConfigPath, "\n".join(config))
 
@@ -491,14 +491,14 @@ def _reset_sshd_config(hutil, restore_backup_ssh):
         MyDistro.restart_ssh_service()
 
 
-def _backup_sshd_config():
+def _backup_sshd_config(hutil):
     backup_file_name = f"{ExtensionCacheDir}/backup"
     if os.path.exists(SshdConfigPath) and not os.path.exists(backup_file_name):
         # Create VMAccess cache folder if doesn't exist
         if not os.path.exists(os.path.dirname(backup_file_name)):
             os.makedirs(os.path.dirname(backup_file_name))
 
-        # Create backup config file
+        hutil.log("Create backup ssh config file")
         open(backup_file_name, 'a').close()
         
         # When copying, make sure to preserve permissions and ownership.


### PR DESCRIPTION
Currently, when a user runs the reset_ssh action with VMAccess, it copies a stock resource file from the internal resources directory and replaces sshd_config with that file. The issue, for some of our customers, with this is that their VMs are left in a state that differs from their original configuration.

These changes fix the above issue and make related improvements by:
- Altering the backup logic to create a new backup only if ChallengeResponseAuthentication or PasswordAuthentication have been modified, or if no backup exists
- Create a new backup in /var/cache/vmaccess, instead of the internal resources directory
- Having a new parameter, restore_backup_ssh, in addition to reset_ssh
- If restore_backup_ssh == True, restore the backup in /var/cache/vmaccess to sshd_config, allowing our customers to preserve their original configuration that complies with their security requirements, rather than using the VMAccess default config files

Work Item: https://msazure.visualstudio.com/One/_sprints/taskboard/CPlat%20Runtime%20Extensions/One/Gallium/CY23Q3/2Wk/2Wk09%20(Jul%2016%20-%20Jul%2029)?workitem=13384139