### PR TITLE
Set password auth in 50-cloud-init.conf for CentOS and RHEL systems

### DIFF
--- a/VMAccess/vmaccess.py
+++ b/VMAccess/vmaccess.py
@@ -382,13 +382,12 @@ def _allow_password_auth():
     _set_sshd_config(config, "PasswordAuthentication", "yes")
     ext_utils.replace_file_with_contents_atomic(SshdConfigPath, "\n".join(config))
 
-    if isinstance(MyDistro, dist_utils.UbuntuDistro): #handle ubuntu 22.04 (sshd_config.d directory)
-        cloudInitConfigPath = "/etc/ssh/sshd_config.d/50-cloud-init.conf"
-        config = ext_utils.get_file_contents(cloudInitConfigPath)
-        if config is not None: #other versions of ubuntu don't contain this file
-            config = config.split("\n")
-            _set_sshd_config(config, "PasswordAuthentication", "yes")
-            ext_utils.replace_file_with_contents_atomic(cloudInitConfigPath, "\n".join(config))
+    cloudInitConfigPath = "/etc/ssh/sshd_config.d/50-cloud-init.conf"
+    config = ext_utils.get_file_contents(cloudInitConfigPath)
+    if config is not None:
+        config = config.split("\n")
+        _set_sshd_config(config, "PasswordAuthentication", "yes")
+        ext_utils.replace_file_with_contents_atomic(cloudInitConfigPath, "\n".join(config))
 
 def _set_sshd_config(config, name, val):
     notfound = True


### PR DESCRIPTION
Azure 'reset password' feature overrides the /etc/ssh/sshd_config file and sets the PasswordAuthentication to 'yes'. Unfortunately, cloud-init versions 22.3 and newer sets 'PasswordAuthentication' to 'no' in the /etc/ssh/sshd_config.d/50-cloud-init.conf which overrides the setting in /etc/ssh/sshd_config file. VMAccess handles this for Ubuntu by setting PasswordAuthentication to 'yes' additionally in /etc/ssh/sshd_config.d/50-cloud-init.conf file. This change extends the same method to include CentOS and RHEL systems.

Fixes: https://github.com/canonical/cloud-init/issues/4335