### PR TITLE
Add resourceLimits to AMA HandlerManifest

### DIFF
--- a/AzureMonitorAgent/HandlerManifest.json
+++ b/AzureMonitorAgent/HandlerManifest.json
@@ -12,6 +12,28 @@
       "reportHeartbeat": false,
       "updateMode": "UpdateWithInstall",
       "continueOnUpdateFailure": "true"
+    },
+    "resourceLimits": {
+      "services": [
+        {
+          "name": "azuremonitoragent"
+        },
+        {
+          "name": "azuremonitoragentmgr"
+        },
+        {
+          "name": "azuremonitor-agentlauncher"
+        },
+        {
+          "name": "azuremonitor-coreagent"
+        },
+        {
+          "name": "metrics-extension"
+        },
+        {
+          "name": "metrics-sourcer"
+        }
+      ]
     }
   }
 ]


### PR DESCRIPTION
Step 1, in 1.28 release specify services to track so we can get eyes on real-world resource usage. Step 2 will be setting the limits.

**Note** that due to way that waagent has implemented the tracking (specifically, they begin tracking specified services only at enable time), `metrics-extension`/`metrics-sourcer` will not be reported on (since we start these later, when metrics watcher detects metrics content in downloaded DCR(s)).