### PR TITLE
fix ama troubleshooter to run option 2 with python 2.7

### DIFF
--- a/AzureMonitorAgent/ama_tst/modules/connect/connect.py
+++ b/AzureMonitorAgent/ama_tst/modules/connect/connect.py
@@ -8,6 +8,11 @@ from helpers           import general_info, is_metrics_configured, find_dcr_work
 from .check_endpts     import check_internet_connect, check_ama_endpts
 from .check_imds       import check_imds_api
 
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
+
 def check_parameters():
     global general_info
     try:

--- a/AzureMonitorAgent/ama_tst/modules/helpers.py
+++ b/AzureMonitorAgent/ama_tst/modules/helpers.py
@@ -13,6 +13,11 @@ try:
     input = raw_input
 except NameError:
     pass
+    
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
 
 # backwards compatible devnull variable for Python 3.3 vs earlier
 try:


### PR DESCRIPTION
Before the fix: 
If perf counters are not enabled, the tool crashes with "'FileNotFoundError' is not defined". Output log when running the tool with option2:

 Please select an option: 2
--------------------------------------------------------------------------------
The troubleshooter can be run in two different modes.
  - Silent Mode runs through with no input required
  - Interactive Mode includes extra checks that require input
 Do you want to run the troubleshooter in silent (s) or interactive (i) mode?: s
Running troubleshooter in silent mode...
================================================================================
CHECKING CONNECTION...
Checking AMA parameters in /etc/default/azuremonitoragent...
Checking DCR...
Traceback (most recent call last):
  File "./modules/main.py", line 234, in <module>
    run_troubleshooter()
  File "./modules/main.py", line 212, in run_troubleshooter
    success = section(interactive=interactive_mode)
  File "/var/lib/waagent/Microsoft.Azure.Monitor.AzureMonitorLinuxAgent-1.27.5/ama_tst/modules/connect/connect.py", line 70, in check_connection
    checked_workspace = check_workspace()
  File "/var/lib/waagent/Microsoft.Azure.Monitor.AzureMonitorLinuxAgent-1.27.5/ama_tst/modules/connect/connect.py", line 26, in check_workspace
    wkspc_id, wkspc_region, e = find_dcr_workspace()
  File "/var/lib/waagent/Microsoft.Azure.Monitor.AzureMonitorLinuxAgent-1.27.5/ama_tst/modules/helpers.py", line 256, in find_dcr_workspace
    except (FileNotFoundError, AttributeError, KeyError) as e:
NameError: global name 'FileNotFoundError' is not defined

After the fix:
CHECKING CONNECTION...
Checking AMA parameters in /etc/default/azuremonitoragent...
Checking DCR...
Traceback (most recent call last):
  File "./modules/main.py", line 234, in <module>
    run_troubleshooter()
  File "./modules/main.py", line 212, in run_troubleshooter
    success = section(interactive=interactive_mode)
  File "/var/lib/waagent/Microsoft.Azure.Monitor.AzureMonitorLinuxAgent-1.27.5/ama_tst/modules/connect/connect.py", line 70, in check_connection
    checked_workspace = check_workspace()
  File "/var/lib/waagent/Microsoft.Azure.Monitor.AzureMonitorLinuxAgent-1.27.5/ama_tst/modules/connect/connect.py", line 26, in check_workspace
    wkspc_id, wkspc_region, e = find_dcr_workspace()
  File "/var/lib/waagent/Microsoft.Azure.Monitor.AzureMonitorLinuxAgent-1.27.5/ama_tst/modules/helpers.py", line 231, in find_dcr_workspace
    for file in os.listdir(CONFIG_DIR):
OSError: [Errno 2] No such file or directory: '/etc/opt/microsoft/azuremonitoragent/config-cache/configchunks'