### PR TITLE
Update VMAccess manifest.xml version to 1.5.16

### DIFF
--- a/VMAccess/manifest.xml
+++ b/VMAccess/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.OSTCExtensions</ProviderNameSpace>
   <Type>VMAccessForLinux</Type>
-  <Version>1.5.15</Version>
+  <Version>1.5.16</Version>
   <Label>Microsoft Azure VM Access Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>


### PR DESCRIPTION
This version has the following changes:
- Support for ED25519 format SSH keys (PR - https://github.com/Azure/azure-linux-extensions/pull/1759)
- New property to allow customers to remove prior SSH keys when adding a new one (PR - https://github.com/Azure/azure-linux-extensions/pull/1761)
    - This property is _remove_prior_keys_. This must be set to **true** when a value for _ssh_key_ is passed in.
- Support for Mariner distro (PR - https://github.com/Azure/azure-linux-extensions/pull/1762)