### PR TITLE
Change mktemp() to NamedTemporaryFile() in test_extensionutils_code_injection.py

### DIFF
--- a/Utils/test/test_extensionutils_code_injection.py
+++ b/Utils/test/test_extensionutils_code_injection.py
@@ -16,7 +16,8 @@ class TestCodeInjection(unittest.TestCase):
     test_dir = "./test_output"
 
     def get_random_filename(self):
-        return tempfile.mktemp(dir=TestCodeInjection.test_dir)
+        f = tempfile.NamedTemporaryFile(dir=TestCodeInjection.test_dir, delete=False)
+        return f.name
 
     def cleanup(self):
         shutil.rmtree(TestCodeInjection.test_dir)


### PR DESCRIPTION
mktemp() is insecure, updating to NamedTemporaryFile() which is identical in practice but more secure.