### PR TITLE
[BugFix] Handled cases when eventLoggingFolder is not provided in HandlerEnvironment

### DIFF
--- a/VMBackup/main/Utils/HandlerUtil.py
+++ b/VMBackup/main/Utils/HandlerUtil.py
@@ -295,8 +295,13 @@ class HandlerUtility:
             self.logging_file=self._context._log_file
             self._context._shell_log_file = os.path.join(handler_env['handlerEnvironment']['logFolder'],'shell.log')
             self._change_log_file()
-            self._context._event_dir = handler_env['handlerEnvironment']['eventsFolder']
-            self.event_dir = self._context._event_dir
+            try:
+                if(self.get_intvalue_from_configfile("disable_logging", 0) == 0):
+                    self._context._event_dir = handler_env['handlerEnvironment']['eventsFolder']
+                    self.event_dir = self._context._event_dir
+            except Exception as e:
+                errorMsg = "The 'eventsFolder' field is missing in handlerEnvironment.json file. Hence skipping event logging! %s" % (str(e), traceback.format_exc())
+                self.log(errorMsg, 'Error')
             self._context._status_dir = handler_env['handlerEnvironment']['statusFolder']
             self._context._heartbeat_file = handler_env['handlerEnvironment']['heartbeatFile']
             if seqNo != -1:

--- a/VMBackup/main/handle.py
+++ b/VMBackup/main/handle.py
@@ -79,7 +79,7 @@ def main():
         configSeqNo = -1
         hutil.try_parse_context(configSeqNo)
         disable_event_logging = hutil.get_intvalue_from_configfile("disable_logging", 0)
-        if disable_event_logging == 0:
+        if disable_event_logging == 0 or hutil.event_dir is not None :
             eventlogger = EventLogger.GetInstance(backup_logger, hutil.event_dir, hutil.severity_level)
         else:
             eventlogger = None


### PR DESCRIPTION
When the eventLoggingFolder parameter is unavailable in HandlerEnvironment.json file, currently the backups are failing with the below logs

```
Unable to parse context, error: 'eventsFolder', stack trace: Traceback (most recent call last):
  File "/var/lib/waagent/Microsoft.Azure.RecoveryServices.VMSnapshotLinux-1.0.9213.0/main/Utils/HandlerUtil.py", line 298, in try_parse_context
    self._context._event_dir = handler_env['handlerEnvironment']['eventsFolder']
KeyError: 'eventsFolder'
```
Added handling for the above. 