### PR TITLE
Fix AMA HandlerManifest.json syntax

### DIFF
--- a/AzureMonitorAgent/HandlerManifest.json
+++ b/AzureMonitorAgent/HandlerManifest.json
@@ -16,26 +16,26 @@
     "resourceLimits": {
       "services": [
         {
-          "name": "azuremonitoragent"
+          "name": "azuremonitoragent",
           "cpuQuotaPercentage": 250
         },
         {
           "name": "azuremonitoragentmgr"
         },
         {
-          "name": "azuremonitor-agentlauncher"
+          "name": "azuremonitor-agentlauncher",
           "cpuQuotaPercentage": 4
         },
         {
-          "name": "azuremonitor-coreagent"
+          "name": "azuremonitor-coreagent",
           "cpuQuotaPercentage": 200
         },
         {
-          "name": "metrics-extension"
+          "name": "metrics-extension",
           "cpuQuotaPercentage": 5
         },
         {
-          "name": "metrics-sourcer"
+          "name": "metrics-sourcer",
           "cpuQuotaPercentage": 10
         }
       ]

--- a/AzureMonitorAgent/packaging.sh
+++ b/AzureMonitorAgent/packaging.sh
@@ -43,6 +43,9 @@ cp $input_path/azuremonitoragent-$AGENT_VERSION* packages/
 # remove dynamic ssl packages
 rm -f packages/*dynamicssl*
 
+# validate HandlerManifest.json syntax
+cat HandlerManifest.json | json_pp -f json -t null
+
 mkdir -p tmp
 cp $input_path/azuremonitoragent_$AGENT_VERSION*dynamicssl_x86_64.deb tmp/
 AMA_DEB_PACKAGE_NAME=$(find tmp/ -type f -name "azuremonitoragent_*x86_64.deb" -printf "%f\\n" | head -n 1)


### PR DESCRIPTION
`json_pp` and `jq` both present in mariner build container for extension packaging step. per some research, json_pp has more helpful error messages and tends to be stricter / closer to JSON spec when validating. Example with previously-incorrect HandlerManifest.json:
> , or } expected while parsing object/hash, at character offset 583 (before ""cpuQuotaPercentage"...") at /usr/bin/json_pp line 59.