### PR TITLE
Fix Ubuntu 22 xfs and partuuid errors.

### DIFF
--- a/VMEncryption/main/Common.py
+++ b/VMEncryption/main/Common.py
@@ -121,6 +121,7 @@ class CommonVariables:
     cloud_symlinks_dir = '/dev/disk/cloud'
     disk_by_id_root = '/dev/disk/by-id'
     disk_by_uuid_root = '/dev/disk/by-uuid'
+    disk_by_partuuid_root = '/dev/disk/by-partuuid'
     nvme_device_identifier = '/dev/nvme'
     nvme_device_name_identifier = 'nvme'
 

--- a/VMEncryption/main/oscrypto/ubuntu_2004/encryptstates/EncryptBlockDeviceState.py
+++ b/VMEncryption/main/oscrypto/ubuntu_2004/encryptstates/EncryptBlockDeviceState.py
@@ -54,7 +54,7 @@ class EncryptBlockDeviceState(OSEncryptionState):
                                             status_code=str(CommonVariables.success),
                                             message='OS disk encryption started')
 
-        self.command_executor.Execute('dd if={0} of=/dev/mapper/osencrypt conv=sparse bs=64K'.format(self.rootfs_block_device), True)
+        self.command_executor.Execute('dd if={0} of=/dev/mapper/osencrypt conv=sparse bs=16M'.format(self.rootfs_block_device), True)
 
     def should_exit(self):
         self.context.logger.log("Verifying if machine should exit encrypt_block_device state")


### PR DESCRIPTION
This PR fixes below issues:
1. OS encryption failure on Ubuntu 22
    For some reason, blkid or lsblk is not returning root partition's PARTUUID at the time we request it. The cause is still unclear.
    Updated the logic to not rely on the command ans use partuuid symlinks to get root partition's PARTUUID.

2. XFS module corruption after OS disk encryption on Ubuntu 22
    conv=sparse and bs=64K seems to be skipping some required blocks encryption causing the module corruption.
    Update bs to 16M so that blocks are not skipped.