### PR TITLE
fix imp python module for versions higher than 3.4

### DIFF
--- a/Utils/WAAgentUtil.py
+++ b/Utils/WAAgentUtil.py
@@ -17,9 +17,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import imp
 import os
 import os.path
+import sys
+
+# imp was deprecated in python 3.6
+if sys.version_info >= (3, 6):
+    import importlib as imp
+else:
+    import imp
 
 #
 # The following code will search and load waagent code and expose

--- a/Utils/WAAgentUtil.py
+++ b/Utils/WAAgentUtil.py
@@ -21,8 +21,8 @@ import os
 import os.path
 import sys
 
-# imp was deprecated in python 3.6
-if sys.version_info >= (3, 6):
+# imp was deprecated in python 3.4
+if sys.version_info >= (3, 4):
     import importlib as imp
 else:
     import imp


### PR DESCRIPTION
Based on https://docs.python.org/3.6/library/imp.html imp has been deprecated starting python version 3.4