### PR TITLE
Onboard Ubuntu 24.04 to online encryption and add support for RHEL 9.3

### DIFF
--- a/VMEncryption/main/SupportedOS.json
+++ b/VMEncryption/main/SupportedOS.json
@@ -44,6 +44,14 @@
     ],
     "Ubuntu" : [
         {
+          "Version" : "24.04",
+          "MinSupportedVersion" : "24.04"
+        },   
+        {
+          "Version" : "23.10",
+          "MinSupportedVersion" : "23.10"
+        },
+        {
           "Version" : "16.04"
         },
         {

--- a/VMEncryption/main/Utils/waagentloader.py
+++ b/VMEncryption/main/Utils/waagentloader.py
@@ -17,16 +17,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import imp
+try:
+    import imp
+except ModuleNotFoundError:
+    import importlib.util
+    import importlib.machinery
 import os
 
 def load_waagent(path=None):
     if path is None:
         pwd = os.path.dirname(os.path.abspath(__file__))
         path = os.path.join(pwd, 'waagent')
-    waagent = imp.load_source('waagent', path)
+    try:
+        waagent = imp.load_source('waagent', path)
+    except NameError:
+        waagent = load_source('waagent', path)
     waagent.LoggerInit('/var/log/waagent.log','/dev/stdout')
     waagent.MyDistro = waagent.GetMyDistro()
     waagent.Config = waagent.ConfigurationProvider(None)
     return waagent
 
+def load_source(modname, filename):
+    loader = importlib.machinery.SourceFileLoader(modname, filename)
+    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module

--- a/VMEncryption/main/oscrypto/91adeOnlineUbu/crypt-ade-boot
+++ b/VMEncryption/main/oscrypto/91adeOnlineUbu/crypt-ade-boot
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -x
+
+# init-premount script for ADE
+# uses cryptsetup to open encrypted root device /dev/mapper/osencrypt
+# prerequisites:
+#   - /usr/share/initramfs-tools/hooks/crypt-ade-hook has run
+#   - /etc/fstab file has been copied to initramfs
+#   - /etc/fstab includes an entry to mount /boot
+#   - /etc/fstab includes an entry to mount /mnt/azure_bek_disk
+#   - hook script will append cryptsetup and exit command
+
+PREREQS="udev"
+
+prereqs()
+{
+        echo $PREREQS
+}
+
+mount -a
+cryptsetup luksOpen /dev/disk/by-partuuid/ROOTPARTUUID osencrypt --header /boot/luks/osluksheader -d /mnt/azure_bek_disk/LinuxPassPhraseFileName
+
+exit 0

--- a/VMEncryption/main/oscrypto/91adeOnlineUbu/crypt-ade-hook
+++ b/VMEncryption/main/oscrypto/91adeOnlineUbu/crypt-ade-hook
@@ -1,0 +1,33 @@
+#!/bin/sh
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+#set -x
+
+PREREQS=""
+
+prereqs() { echo "$PREREQS"; }
+
+case "$1" in
+    prereqs)
+    prereqs
+    exit 0
+    ;;
+esac
+
+. /usr/share/initramfs-tools/hook-functions
+
+# this hook script prepares the various boot script prerequisites
+# /usr/share/initramfs-tools/scripts/init-premount/crypt-ade-boot
+
+# add /etc/fstab entries and mount point directories
+mkdir -p $DESTDIR/boot
+mkdir -p $DESTDIR/mnt/azure_bek_disk
+BOOTUUID=$(findmnt -fn -o UUID /boot)
+echo "/dev/disk/by-uuid/$BOOTUUID /boot auto defaults 0 0" >> "$DESTDIR/etc/fstab"
+echo "/dev/disk/by-label/BEK\\x20VOLUME /mnt/azure_bek_disk auto defaults 0 0" >> "$DESTDIR/etc/fstab"
+
+# inject luks header
+mkdir -p ${DESTDIR}/boot/luks
+copy_exec /boot/luks/osluksheader /boot/luks
+
+exit 0

--- a/VMEncryption/main/oscrypto/OSEncryptionState.py
+++ b/VMEncryption/main/oscrypto/OSEncryptionState.py
@@ -99,7 +99,7 @@ class OSEncryptionState(object):
             self.bootfs_block_device = '/dev/sda1'
         elif self.rootfs_sdx_path == '/dev/mapper/osencrypt' or self.rootfs_sdx_path.startswith('/dev/dm-'):
             self.rootfs_block_device = '/dev/mapper/osencrypt'
-            bootfs_uuid = self._parse_uuid_from_fstab('/boot')
+            bootfs_uuid = self._get_boot_uuid()
             self.context.logger.log("bootfs_uuid: {0}".format(bootfs_uuid))
             self.bootfs_block_device = self.disk_util.query_dev_sdx_path_by_uuid(bootfs_uuid)
         elif self.rootfs_sdx_path.startswith(CommonVariables.nvme_device_identifier):

--- a/VMEncryption/main/patch/AbstractPatching.py
+++ b/VMEncryption/main/patch/AbstractPatching.py
@@ -80,6 +80,10 @@ class AbstractPatching(object):
     def add_kernelopts(self, args_to_add):
         pass
 
+    def add_args_to_default_grub(self, args_to_add):
+        self.append_contents_to_file('\nGRUB_CMDLINE_LINUX+=" {0} "\n'.format(" ".join(args_to_add)),
+                                      '/etc/default/grub')
+
     def install_and_enable_ade_online_enc(self, root_partuuid, boot_uuid, rootfs_disk, is_os_disk_lvm):
         pass
 

--- a/VMEncryption/main/patch/AbstractPatching.py
+++ b/VMEncryption/main/patch/AbstractPatching.py
@@ -18,6 +18,7 @@
 #
 
 import os
+import io
 import sys
 import base64
 import re
@@ -78,3 +79,15 @@ class AbstractPatching(object):
 
     def add_kernelopts(self, args_to_add):
         pass
+
+    def install_and_enable_ade_online_enc(self, root_partuuid, boot_uuid, rootfs_disk, is_os_disk_lvm):
+        pass
+
+    def append_contents_to_file(self, contents, path):
+        # Python 3.x strings are Unicode by default and do not use decode
+        if sys.version_info[0] < 3:
+            if isinstance(contents, str):
+                contents = contents.decode('utf-8')
+
+        with io.open(path, 'a') as f:
+            f.write(contents)

--- a/VMEncryption/main/patch/UbuntuPatching.py
+++ b/VMEncryption/main/patch/UbuntuPatching.py
@@ -223,9 +223,6 @@ class UbuntuPatching(AbstractPatching):
             self.logger.log(message)
             raise Exception(message)
 
-        # once hook and boot scripts are ready, update initramfs
-        #self.command_executor.Execute('update-initramfs -u -k all', True)
-
         # prior to updating grub, do the following: 
         # - remove the 40-force-partuuid.cfg file added by cloudinit, since it references the old boot partition
         # - set grub cmdline to use root=/dev/mapper/osencrypt

--- a/VMEncryption/main/patch/marinerPatching.py
+++ b/VMEncryption/main/patch/marinerPatching.py
@@ -26,6 +26,8 @@ class marinerPatching(redhatPatching):
         self.command_executor.ExecuteInBash('mkinitrd -f -v', True)
 
     def add_kernelopts(self, args_to_add):
+        self._append_contents_to_file('\nGRUB_CMDLINE_LINUX+=" {0} "\n'.format(" ".join(args_to_add)),
+                                      '/etc/default/grub')
         grub_cfg_paths = filter(lambda path_pair: os.path.exists(path_pair[0]) and os.path.exists(path_pair[1]), self.grub_cfg_paths)
 
         for grub_cfg_path, grub_env_path in grub_cfg_paths:

--- a/VMEncryption/main/patch/marinerPatching.py
+++ b/VMEncryption/main/patch/marinerPatching.py
@@ -26,8 +26,7 @@ class marinerPatching(redhatPatching):
         self.command_executor.ExecuteInBash('mkinitrd -f -v', True)
 
     def add_kernelopts(self, args_to_add):
-        self._append_contents_to_file('\nGRUB_CMDLINE_LINUX+=" {0} "\n'.format(" ".join(args_to_add)),
-                                      '/etc/default/grub')
+        self.add_args_to_default_grub(args_to_add)
         grub_cfg_paths = filter(lambda path_pair: os.path.exists(path_pair[0]) and os.path.exists(path_pair[1]), self.grub_cfg_paths)
 
         for grub_cfg_path, grub_env_path in grub_cfg_paths:

--- a/VMEncryption/setup.py
+++ b/VMEncryption/setup.py
@@ -217,6 +217,7 @@ final_folder_path = target_zip_file_location + target_folder_name
 copy2(main_folder+'/SupportedOS.json', final_folder_path+'/'+main_folder )
 copy2(main_folder+'/common_parameters.json', final_folder_path+'/'+main_folder )
 copytree(main_folder+'/oscrypto/ubuntu_2004/encryptscripts/', final_folder_path+'/'+main_folder+'/oscrypto/ubuntu_2004/encryptscripts/')
+copytree(main_folder+'/oscrypto/91adeOnlineUbu/', final_folder_path+'/'+main_folder+'/oscrypto/91adeOnlineUbu/')
 #copy SKR app TODO: folder structure. 
 copy2('./AzureAttestSKR', final_folder_path+'/' )
 #temp VNS changes: folder structure. 


### PR DESCRIPTION
Ubuntu now has sperate boot partition that enables ADE to onboard it to online encryption path. 

Currently tested with Ubuntu 23.10.

