### PR TITLE
Fix unexpected keyword argument 'crypt_id' on FreeBSD 14.1

### DIFF
--- a/Utils/distroutils.py
+++ b/Utils/distroutils.py
@@ -281,7 +281,7 @@ class FreeBSDDistro(GenericDistro):
 
     # noinspection PyMethodOverriding
     def chpasswd(self, user, password, **kwargs):
-        return ext_utils.run_send_stdin(['pw', 'usermod', 'user', '-h', '0'], password, log_cmd=False)
+        return ext_utils.run_send_stdin(['pw', 'usermod', 'user', '-h', '0'], password.encode('utf-8'), log_cmd=False)
 
     def create_account(self, user, password, expiration, thumbprint, enable_nopasswd):
         """

--- a/Utils/distroutils.py
+++ b/Utils/distroutils.py
@@ -280,7 +280,7 @@ class FreeBSDDistro(GenericDistro):
 
 
     # noinspection PyMethodOverriding
-    def chpasswd(self, user, password):
+    def chpasswd(self, user, password, **kwargs):
         return ext_utils.run_send_stdin(['pw', 'usermod', 'user', '-h', '0'], password, log_cmd=False)
 
     def create_account(self, user, password, expiration, thumbprint, enable_nopasswd):


### PR DESCRIPTION
    fix(distroutils): encode cmd_input argument for ext_utils.run_send_stdin()
    
    The method ext_utils.run_send_stdin() (in extensionutils.py) requires
    the second argument, cmd_input, to be a bytes object, not a string
    object. This is due to the usage of: subprocess.Popen().communicate().
    Encode the password as utf-8 when passing to ext_utils.run_send_stdin().
----

    fix(distroutils): add **kwargs to FreeBSDDistro.chpasswd()
    
    When operating FreeBSD, the argument crypt_id is passed to an
    overridden method chpasswd() in the FreeBSDDistro class. The definition
    of this method does not contain an argument for 'crypt_id' or
    'salt_len'. To address this issue, add **kwargs to the definition of
    chpasswd() in the FreeBSDDistro class.

----

fixes: #1839