### PR TITLE
Fixed Compatibility issue with timestamp.total_seconds() method for python version <=2.6

### DIFF
--- a/VMBackup/main/hostsnapshotter.py
+++ b/VMBackup/main/hostsnapshotter.py
@@ -180,7 +180,8 @@ class HostSnapshotter(object):
                         except:
                             creationTimeObj = datetime.datetime.strptime(creationTimeString, "%Y-%m-%dT%H:%M:%SZ")
                         self.logger.log("Converting the creationTime string received in UTC format to UTC Ticks")
-                        timestamp = (creationTimeObj - epochTime).total_seconds()
+                        delta = creationTimeObj - epochTime
+                        timestamp = delta.days * 86400 + delta.seconds + delta.microseconds / 1e6
                         creationTimeUTCTicks = str(int(timestamp * 1000)) 
                         ddSnapshotIdentifierInfo = HostSnapshotObjects.DDSnapshotIdentifier(creationTimeUTCTicks , snapshot_info['ddSnapshotIdentifier']['id'], snapshot_info['ddSnapshotIdentifier']['token'])
                         self.logger.log("ddSnapshotIdentifier Information from Host- creationTime : {0}, id : {1}".format(ddSnapshotIdentifierInfo.creationTime, ddSnapshotIdentifierInfo.id))

--- a/VMBackup/main/hostsnapshotter.py
+++ b/VMBackup/main/hostsnapshotter.py
@@ -181,7 +181,7 @@ class HostSnapshotter(object):
                             creationTimeObj = datetime.datetime.strptime(creationTimeString, "%Y-%m-%dT%H:%M:%SZ")
                         self.logger.log("Converting the creationTime string received in UTC format to UTC Ticks")
                         delta = creationTimeObj - epochTime
-                        timestamp = delta.days * 86400 + delta.seconds + delta.microseconds / 1e6
+                        timestamp = self.get_total_seconds(self, delta)
                         creationTimeUTCTicks = str(int(timestamp * 1000)) 
                         ddSnapshotIdentifierInfo = HostSnapshotObjects.DDSnapshotIdentifier(creationTimeUTCTicks , snapshot_info['ddSnapshotIdentifier']['id'], snapshot_info['ddSnapshotIdentifier']['token'])
                         self.logger.log("ddSnapshotIdentifier Information from Host- creationTime : {0}, id : {1}".format(ddSnapshotIdentifierInfo.creationTime, ddSnapshotIdentifierInfo.id))
@@ -197,3 +197,11 @@ class HostSnapshotter(object):
             self.logger.log(errorMsg)
 
         return blobsnapshotinfo_array, all_failed
+    
+    def get_total_seconds(self, delta):
+        # Check if total_seconds method exists in current Python version
+        if hasattr(delta, 'total_seconds'):
+            return delta.total_seconds()
+        else:
+            self.logger.log("Calculating total seconds manually for version compatibility.")
+            return delta.days * 86400 + delta.seconds + delta.microseconds / 1e6

--- a/VMBackup/main/hostsnapshotter.py
+++ b/VMBackup/main/hostsnapshotter.py
@@ -181,7 +181,7 @@ class HostSnapshotter(object):
                             creationTimeObj = datetime.datetime.strptime(creationTimeString, "%Y-%m-%dT%H:%M:%SZ")
                         self.logger.log("Converting the creationTime string received in UTC format to UTC Ticks")
                         delta = creationTimeObj - epochTime
-                        timestamp = self.get_total_seconds(self, delta)
+                        timestamp = self.get_total_seconds(delta)
                         creationTimeUTCTicks = str(int(timestamp * 1000)) 
                         ddSnapshotIdentifierInfo = HostSnapshotObjects.DDSnapshotIdentifier(creationTimeUTCTicks , snapshot_info['ddSnapshotIdentifier']['id'], snapshot_info['ddSnapshotIdentifier']['token'])
                         self.logger.log("ddSnapshotIdentifier Information from Host- creationTime : {0}, id : {1}".format(ddSnapshotIdentifierInfo.creationTime, ddSnapshotIdentifierInfo.id))


### PR DESCRIPTION
This PR is regarding fix of Compatibility Issue with total_seconds() for python version <=2.6
There was a compatibility issue of total_seconds() whith python version < = 2.6, so updated it to use timedelta which is compatible for all versions of Python, including Python 2.6, 2.7, and 3.x. New implementation utilizes total_seconds() method if available, otherwise falls back to custom implementation that converts it using custom logic to calculate elapsed seconds (delta.days * 86400 + delta.seconds + delta.microseconds / 1e6)