### PR TITLE
Adding object_id to supported identifier-name for managed identity

### DIFF
--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -977,8 +977,8 @@ def get_managed_identity():
         identifier_name = managedIdentity.get("identifier-name")
         identifier_value = managedIdentity.get("identifier-value")
 
-        if identifier_name not in ["client_id", "mi_res_id"]:
-            return identifier_name, identifier_value, 'Invalid identifier-name provided; must be "client_id" or "mi_res_id"'
+        if identifier_name not in ["client_id", "mi_res_id", "object_id"]:
+            return identifier_name, identifier_value, 'Invalid identifier-name provided; must be "client_id" or "mi_res_id" or "object_id"'
 
         if not identifier_value:
             return identifier_name, identifier_value, 'Invalid identifier-value provided; cannot be empty'


### PR DESCRIPTION
Fix for bug 29033303 to accept object_id in supported identifier-name for managed identity. 

Testing: Ran uninstall (./shim.sh --disable and ./shim.sh --uninstall) and then install (./shim.sh --install and ./shim.sh --enable) using the updated agent.py on a VM with AMA. Didn't see any error in logs (extension and azuremonitoragent) and installation was successful. 