### PR TITLE
Updated python installation path search in VmSnapshotLinux for FreeBSD

### DIFF
--- a/VMBackup/main/handle.sh
+++ b/VMBackup/main/handle.sh
@@ -58,9 +58,9 @@ do
 	if [ ! -f "${cmnd}" ]
 	then
 		cmnd="/usr/local/bin/${pythonVersion}"
-    fi
+	fi
 	if [ -f "${cmnd}" ]
-    then
+	then
 		echo "`date -u`- ${pythonVersion} path exists" >> $logfile
 		$cmnd main/handle.py -$configSeqNo -$1
 		rc=$?

--- a/VMBackup/main/handle.sh
+++ b/VMBackup/main/handle.sh
@@ -57,7 +57,7 @@ do
 	cmnd="/usr/bin/${pythonVersion}"
 	if [ ! -f "${cmnd}" ]
 	then
-        cmnd="/usr/local/bin/${pythonVersion}"
+		cmnd="/usr/local/bin/${pythonVersion}"
     fi
 	if [ -f "${cmnd}" ]
     then

--- a/VMBackup/main/handle.sh
+++ b/VMBackup/main/handle.sh
@@ -55,6 +55,10 @@ pythonVersionList="python3.8 python3.7 python3.6 python3.5 python3.4 python3.3 p
 for pythonVersion in ${pythonVersionList};
 do
 	cmnd="/usr/bin/${pythonVersion}"
+	if [ ! -f "${cmnd}" ]
+	then
+        cmnd="/usr/local/bin/${pythonVersion}"
+    fi
 	if [ -f "${cmnd}" ]
     then
 		echo "`date -u`- ${pythonVersion} path exists" >> $logfile


### PR DESCRIPTION
Application consistent Restore Point for Free BSD Linux distro was not working because of the way VmSnapshotLinux extension looks for python installation. On FreeBSD python is installed into `/usr/local/bin` whereas the current implementation was looking for python installation only in /usr/bin/ path.
So modified the script to check into /usr/local/bin if it is not there at /usr/bin.