### PR TITLE
Align SSH public key location with default home folder configuration

### DIFF
--- a/VMAccess/vmaccess.py
+++ b/VMAccess/vmaccess.py
@@ -297,7 +297,7 @@ def _set_user_account_pub_key(protect_settings, hutil):
         if cert_txt.strip().lower().startswith("ssh-rsa") or cert_txt.strip().lower().startswith("ssh-ed25519"):
             no_convert = True
         try:
-            pub_path = os.path.join('/home/', user_name, '.ssh',
+            pub_path = os.path.join('$HOME', user_name, '.ssh',
                                     'authorized_keys')
             ovf_env.UserName = user_name
             if no_convert:


### PR DESCRIPTION
The default home folder of new user can be configured in `/etc/default/useradd`.

However, the VMAccess extension always assumes that the SSH public key is under `/home/<user_name>/.ssh/authorized_keys`. Location of the SSH public key must be aligned with the user's home folder. Otherwise, SSH authentcation would fail.

For example, if "HOME=/data/home" is configured in /etc/defaults/useradd, then home folder of new user would be "/data/home/<user_name>".

The problem is that SSH public key provided by user would be put in "/home/<user_name>/.ssh/authorized_keys". Then the new user cannot authentication by SSH key.

The code for specifying SSH public key location:
```
            pub_path = os.path.join('/home/', user_name, '.ssh',
                                    'authorized_keys')
```

This change updated the hardcoded "/home" to "$HOME". The subsequent code for preparing dir will replace "$HOME" string with the actual default home folder location:
```
                    pub_path = ovf_env.prepare_dir(pub_path, MyDistro)
```