### PR TITLE
log imds url to improve diagnosability

### DIFF
--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -495,7 +495,7 @@ def enable():
     ssl_cert_var_name, ssl_cert_var_value = get_ssl_cert_info('Enable')
     default_configs[ssl_cert_var_name] = ssl_cert_var_value
 
-    _, _, _, az_environment, _ = me_handler.get_imds_values(is_lad=False)
+    _, _, _, az_environment, _ = me_handler.get_imds_values(is_lad=False, HUtilObj=HUtilObject)
     if az_environment.lower() == me_handler.ArcACloudName:
         _, mcs_endpoint = me_handler.get_arca_endpoints_from_himds()
         default_configs["customRegionalEndpoint"] = mcs_endpoint

--- a/LAD-AMA-Common/metrics_ext_utils/metrics_ext_handler.py
+++ b/LAD-AMA-Common/metrics_ext_utils/metrics_ext_handler.py
@@ -580,7 +580,7 @@ def get_handler_vars():
     return logFolder, configFolder
 
 
-def get_imds_values(is_lad):
+def get_imds_values(is_lad, HUtilObj=None):
     """
     Query imds to get required values for MetricsExtension config for this VM
     """
@@ -599,6 +599,12 @@ def get_imds_values(is_lad):
             is_arc = True
         else:
             imds_url = "http://169.254.169.254/metadata/instance?api-version=2019-03-11"
+
+    message = "IMDS url to query: " + imds_url
+    if HUtilObj is not None:
+        HUtilObj.log(message)
+    else:
+        print('Info: {0}'.format(message))
 
     data = None
     while retries <= max_retries:


### PR DESCRIPTION
we have seen a few incidents (Arc and Cloud) where due to hardening or firewall rules customer used to see failure from python code but not able to determine the actual url that ama is querying  post ama auto upgrade/during enable calls. With this change ama will  log imds url info for easy troubleshooting.