### PR TITLE
Fix incorrect conversion of DoSnapshot API 500 response to client error in Extension

### DIFF
--- a/VMBackup/main/ExtensionErrorCodeHelper.py
+++ b/VMBackup/main/ExtensionErrorCodeHelper.py
@@ -102,7 +102,6 @@ class ExtensionErrorCodeHelper:
             ExtensionErrorCodeEnum.error_http_failure : Status.ExtVmHealthStateEnum.red,
             ExtensionErrorCodeEnum.FailedRetryableSnapshotFailedRestrictedNetwork : Status.ExtVmHealthStateEnum.red,
             ExtensionErrorCodeEnum.FailedRetryableSnapshotFailedNoNetwork : Status.ExtVmHealthStateEnum.red,
-            ExtensionErrorCodeEnum.FailedHostSnapshotRemoteServerError : Status.ExtVmHealthStateEnum.red,
             ExtensionErrorCodeEnum.FailedSnapshotLimitReached : Status.ExtVmHealthStateEnum.red,
             ExtensionErrorCodeEnum.FailedGuestAgentInvokedCommandTooLate : Status.ExtVmHealthStateEnum.red,
             

--- a/VMBackup/main/ExtensionErrorCodeHelper.py
+++ b/VMBackup/main/ExtensionErrorCodeHelper.py
@@ -16,6 +16,7 @@ class ExtensionErrorCodeEnum():
     FailedInvalidDataDiskLunList = 17
 
     FailedRetryableSnapshotFailedNoNetwork = 76
+    FailedHostSnapshotRemoteServerError = 556
     FailedSnapshotLimitReached = 85
     FailedRetryableSnapshotRateExceeded = 173
     FailedRetryableSnapshotFailedRestrictedNetwork = 761
@@ -101,6 +102,7 @@ class ExtensionErrorCodeHelper:
             ExtensionErrorCodeEnum.error_http_failure : Status.ExtVmHealthStateEnum.red,
             ExtensionErrorCodeEnum.FailedRetryableSnapshotFailedRestrictedNetwork : Status.ExtVmHealthStateEnum.red,
             ExtensionErrorCodeEnum.FailedRetryableSnapshotFailedNoNetwork : Status.ExtVmHealthStateEnum.red,
+            ExtensionErrorCodeEnum.FailedHostSnapshotRemoteServerError : Status.ExtVmHealthStateEnum.red,
             ExtensionErrorCodeEnum.FailedSnapshotLimitReached : Status.ExtVmHealthStateEnum.red,
             ExtensionErrorCodeEnum.FailedGuestAgentInvokedCommandTooLate : Status.ExtVmHealthStateEnum.red,
             
@@ -158,6 +160,7 @@ class ExtensionErrorCodeHelper:
             ExtensionErrorCodeEnum.error_http_failure : "error_http_failure",
             ExtensionErrorCodeEnum.FailedRetryableSnapshotFailedRestrictedNetwork : "FailedRetryableSnapshotFailedRestrictedNetwork",
             ExtensionErrorCodeEnum.FailedRetryableSnapshotFailedNoNetwork : "FailedRetryableSnapshotFailedNoNetwork",
+            ExtensionErrorCodeEnum.FailedHostSnapshotRemoteServerError : "FailedHostSnapshotRemoteServerError",
             ExtensionErrorCodeEnum.FailedSnapshotLimitReached : "FailedSnapshotLimitReached",
             ExtensionErrorCodeEnum.FailedGuestAgentInvokedCommandTooLate : "FailedGuestAgentInvokedCommandTooLate",
             

--- a/VMBackup/main/Utils/HandlerUtil.py
+++ b/VMBackup/main/Utils/HandlerUtil.py
@@ -590,6 +590,10 @@ class HandlerUtility:
     def add_to_telemetery_data(key,value):
         HandlerUtility.telemetry_data[key]=value
 
+    @staticmethod
+    def get_telemetry_data(key):
+        return HandlerUtility.telemetry_data[key]
+    
     def add_telemetry_data(self):
         os_version,kernel_version = self.get_dist_info()
         workloads = self.get_workload_running()

--- a/VMBackup/main/common.py
+++ b/VMBackup/main/common.py
@@ -108,7 +108,7 @@ class CommonVariables:
     FailedFsFreezeTimeout = 122
     FailedUnableToOpenMount = 123
     FailedSafeFreezeBinaryNotFound = 124
-
+    FailedHostSnapshotRemoteServerError = 556
     """
     Pre-Post Plugin error code definitions
     """

--- a/VMBackup/main/freezesnapshotter.py
+++ b/VMBackup/main/freezesnapshotter.py
@@ -271,18 +271,18 @@ class FreezeSnapshotter(object):
                 elif blob_snapshot_info != None and blob_snapshot_info.isSuccessful == False:
                     any_failed = True
         
-        if run_result == CommonVariables.success and all_failed and HandlerUtil.HandlerUtility.get_telemetry_data(CommonVariables.hostStatusCodeDoSnapshot) == "556" and HandlerUtil.HandlerUtility.get_telemetry_data(CommonVariables.hostStatusCodePreSnapshot) == "200":
-            run_status = 'error'
-            run_result = CommonVariables.FailedHostSnapshotRemoteServerError
-            error_msg = 'T:S Enable failed with FailedHostSnapshotRemoteServerError errror'
-            self.extensionErrorCode = ExtensionErrorCodeHelper.ExtensionErrorCodeEnum.FailedHostSnapshotRemoteServerError
-            error_msg = error_msg + ExtensionErrorCodeHelper.ExtensionErrorCodeHelper.StatusCodeStringBuilder(self.extensionErrorCode)
-            self.logger.log(error_msg, True, 'Error')
-        elif run_result == CommonVariables.success and all_failed:
-            run_status = 'error'
-            run_result = CommonVariables.FailedRetryableSnapshotFailedNoNetwork
-            error_msg = 'T:S Enable failed with FailedRetryableSnapshotFailedNoNetwork errror'
-            self.extensionErrorCode = ExtensionErrorCodeHelper.ExtensionErrorCodeEnum.FailedRetryableSnapshotFailedNoNetwork
+        if all_failed:
+            doSnapshot_status = HandlerUtil.HandlerUtility.get_telemetry_data(CommonVariables.hostStatusCodeDoSnapshot)
+            preSnapshot_status = HandlerUtil.HandlerUtility.get_telemetry_data(CommonVariables.hostStatusCodePreSnapshot)
+
+            if run_result == CommonVariables.success and doSnapshot_status == "556" and preSnapshot_status == "200":
+                run_result = ExtensionErrorCodeHelper.ExtensionErrorCodeEnum.FailedHostSnapshotRemoteServerError
+                error_msg = 'T:S Enable failed with FailedHostSnapshotRemoteServerError error'
+                self.extensionErrorCode = ExtensionErrorCodeHelper.ExtensionErrorCodeEnum.FailedHostSnapshotRemoteServerError
+            else: 
+                run_result = ExtensionErrorCodeHelper.ExtensionErrorCodeEnum.FailedRetryableSnapshotFailedNoNetwork
+                error_msg = 'T:S Enable failed with FailedRetryableSnapshotFailedNoNetwork error'
+                self.extensionErrorCode = ExtensionErrorCodeHelper.ExtensionErrorCodeEnum.FailedRetryableSnapshotFailedNoNetwork
             error_msg = error_msg + ExtensionErrorCodeHelper.ExtensionErrorCodeHelper.StatusCodeStringBuilder(self.extensionErrorCode)
             self.logger.log(error_msg, True, 'Error')
         elif run_result == CommonVariables.success and any_failed:

--- a/VMBackup/main/freezesnapshotter.py
+++ b/VMBackup/main/freezesnapshotter.py
@@ -270,8 +270,15 @@ class FreezeSnapshotter(object):
                         any_failed = True
                 elif blob_snapshot_info != None and blob_snapshot_info.isSuccessful == False:
                     any_failed = True
-
-        if run_result == CommonVariables.success and all_failed:
+        
+        if run_result == CommonVariables.success and all_failed and HandlerUtil.HandlerUtility.get_telemetry_data(CommonVariables.hostStatusCodeDoSnapshot) == "556" and HandlerUtil.HandlerUtility.get_telemetry_data(CommonVariables.hostStatusCodePreSnapshot) == "200":
+            run_status = 'error'
+            run_result = CommonVariables.FailedHostSnapshotRemoteServerError
+            error_msg = 'T:S Enable failed with FailedHostSnapshotRemoteServerError errror'
+            self.extensionErrorCode = ExtensionErrorCodeHelper.ExtensionErrorCodeEnum.FailedHostSnapshotRemoteServerError
+            error_msg = error_msg + ExtensionErrorCodeHelper.ExtensionErrorCodeHelper.StatusCodeStringBuilder(self.extensionErrorCode)
+            self.logger.log(error_msg, True, 'Error')
+        elif run_result == CommonVariables.success and all_failed:
             run_status = 'error'
             run_result = CommonVariables.FailedRetryableSnapshotFailedNoNetwork
             error_msg = 'T:S Enable failed with FailedRetryableSnapshotFailedNoNetwork errror'


### PR DESCRIPTION
In Linux Extension code, 500 status code from the DoSnapshot API response from BHS was incorrectly converted to a client error in both the Extension and CRP. This caused the error to be misclassified, preventing early detection via LSI.

Example Response:
2024-10-22 22:49:39.187634  Info  dosnapshot responseBody: StatusCode:500, ErrorMessage: Could not find config corresponding to the Disk  - md-zt1h5xp3fb3q - 4gsgxhsfkwl2/abcd, bhsVersion:3.0.51.0  
Incorrect conversion in Extension:
{"Key": "extErrorCode", "Value": "FailedRetryableSnapshotFailedNoNetwork"}

Fix:
Updated the Extension code to correctly classify 500 responses from DoSnapshot API as BHS error instead of client errors.