### PR TITLE
cleanup old installer.net runtimes in extension upgrade path left behind in uninstall causing aot runtime issues 

### DIFF
--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -396,7 +396,7 @@ def install():
     # Copy the AMACoreAgent and agentlauncher binaries
     copy_amacoreagent_binaries()
 
-    # Copy Kqle xtension binaries
+    # Copy KqlExtension binaries
     # Needs to be revisited for aarch64
     copy_kqlextension_binaries()
 
@@ -1980,6 +1980,14 @@ def get_ssl_cert_info(operation):
 def copy_kqlextension_binaries():
     kqlextension_bin_local_path = os.getcwd() + "/KqlExtensionBin/"
     kqlextension_bin = "/opt/microsoft/azuremonitoragent/bin/kqlextension/"
+    kqlextension_runtimesbin = "/opt/microsoft/azuremonitoragent/bin/kqlextension/runtimes/"
+    if os.path.exists(kqlextension_runtimesbin):
+        # only for versions of AMA with .NET runtimes
+        rmtree(kqlextension_runtimesbin)
+        # only for versions with Kql .net cleanup .NET files as it is causing issues with AOT runtime
+        for f in os.listdir(kqlextension_bin):
+            os.remove(os.path.join(kqlextension_bin, f))
+
     for f in os.listdir(kqlextension_bin_local_path):
         compare_and_copy_bin(kqlextension_bin_local_path + f, kqlextension_bin + f)
 


### PR DESCRIPTION
NET files are not used anymore, but when the files are left on the system they cause AOT runtime issues. Reproducible when the machine upgrades from old version of ama extension to the new one. This is caused by a bug in ama uninstall where package manager leaves some ama folders behind.