### PR TITLE
Use modern Python unittest API for testing

### DIFF
--- a/AzureEnhancedMonitor/ext/test/test_aem.py
+++ b/AzureEnhancedMonitor/ext/test/test_aem.py
@@ -104,9 +104,9 @@ class TestAEM(unittest.TestCase):
         privateConfig = json.loads(TestPrivateConfig)
         config = aem.EnhancedMonitorConfig(publicConfig, privateConfig)
         self.assertNotEquals(None, config)
-        self.assertEquals(".table.core.windows.net", 
+        self.assertEqual(".table.core.windows.net", 
                           config.getStorageHostBase('asdf'))
-        self.assertEquals(".table.core.windows.net", 
+        self.assertEqual(".table.core.windows.net", 
                           config.getLADHostBase())
         return config
 
@@ -120,7 +120,7 @@ class TestAEM(unittest.TestCase):
         name = "Cloud Provider"
         counter = next((c for c in counters if c.name == name))
         self.assertNotEquals(None, counter)
-        self.assertEquals("Microsoft Azure", counter.value)
+        self.assertEqual("Microsoft Azure", counter.value)
         
         name = "Virtualization Solution Version"
         counter = next((c for c in counters if c.name == name))
@@ -135,27 +135,27 @@ class TestAEM(unittest.TestCase):
         name = "Instance Type"
         counter = next((c for c in counters if c.name == name))
         self.assertNotEquals(None, counter)
-        self.assertEquals("Small (A1)", counter.value)
+        self.assertEqual("Small (A1)", counter.value)
 
         name = "Data Sources"
         counter = next((c for c in counters if c.name == name))
         self.assertNotEquals(None, counter)
-        self.assertEquals("wad", counter.value)
+        self.assertEqual("wad", counter.value)
 
         name = "Data Provider Version"
         counter = next((c for c in counters if c.name == name))
         self.assertNotEquals(None, counter)
-        self.assertEquals("2.0.0", counter.value)
+        self.assertEqual("2.0.0", counter.value)
 
         name = "Memory Over-Provisioning"
         counter = next((c for c in counters if c.name == name))
         self.assertNotEquals(None, counter)
-        self.assertEquals("no", counter.value)
+        self.assertEqual("no", counter.value)
 
         name = "CPU Over-Provisioning"
         counter = next((c for c in counters if c.name == name))
         self.assertNotEquals(None, counter)
-        self.assertEquals("no", counter.value)
+        self.assertEqual("no", counter.value)
 
     def test_cpuinfo(self):
         cpuinfo = aem.CPUInfo.getCPUInfo()
@@ -163,18 +163,18 @@ class TestAEM(unittest.TestCase):
         self.assertNotEquals(0, cpuinfo.getNumOfCoresPerCPU())
         self.assertNotEquals(0, cpuinfo.getNumOfCores())
         self.assertNotEquals(None, cpuinfo.getProcessorType())
-        self.assertEquals(float, type(cpuinfo.getFrequency()))
-        self.assertEquals(bool, type(cpuinfo.isHyperThreadingOn()))
+        self.assertEqual(float, type(cpuinfo.getFrequency()))
+        self.assertEqual(bool, type(cpuinfo.isHyperThreadingOn()))
         percent = cpuinfo.getCPUPercent()
-        self.assertEquals(float, type(percent))
+        self.assertEqual(float, type(percent))
         self.assertTrue(percent >= 0 and percent <= 100)
 
     def test_meminfo(self):
         meminfo = aem.MemoryInfo()
         self.assertNotEquals(None, meminfo.getMemSize())
-        self.assertEquals(long, type(meminfo.getMemSize()))
+        self.assertEqual(long, type(meminfo.getMemSize()))
         percent = meminfo.getMemPercent()
-        self.assertEquals(float, type(percent))
+        self.assertEqual(float, type(percent))
         self.assertTrue(percent >= 0 and percent <= 100)
 
     def test_networkinfo(self):
@@ -201,7 +201,7 @@ class TestAEM(unittest.TestCase):
         #No hardware change
         lastChange = hwChangeInfo.getLastHardwareChange()
         hwChangeInfo = aem.HardwareChangeInfo(netinfo)
-        self.assertEquals(lastChange, hwChangeInfo.getLastHardwareChange())
+        self.assertEqual(lastChange, hwChangeInfo.getLastHardwareChange())
 
         #Create mock hardware
         waagent.SetFileContents(testHwInfoFile, ("0\nma-ca-sa-ds-02"))
@@ -307,9 +307,9 @@ class TestAEM(unittest.TestCase):
     def test_get_storage_key_range(self):
         startKey, endKey = aem.getStorageTableKeyRange()
         self.assertNotEquals(None, startKey)
-        self.assertEquals(13, len(startKey))
+        self.assertEqual(13, len(startKey))
         self.assertNotEquals(None, endKey)
-        self.assertEquals(13, len(endKey))
+        self.assertEqual(13, len(endKey))
 
     def test_storage_datasource(self):
         aem.getStorageMetrics = mock_getStorageMetrics
@@ -356,7 +356,7 @@ class TestAEM(unittest.TestCase):
         writer.write(counters, eventFile = testEventFile)
         with open(testEventFile) as F:
             content = F.read()
-            self.assertEquals(str(counters[0]), content)
+            self.assertEqual(str(counters[0]), content)
 
         testEventFile = "/dev/console"
         print("==============================")
@@ -366,13 +366,13 @@ class TestAEM(unittest.TestCase):
 
     def test_easyHash(self):
         hashVal = aem.easyHash('a')
-        self.assertEquals(97, hashVal)
+        self.assertEqual(97, hashVal)
         hashVal = aem.easyHash('ab')
-        self.assertEquals(87, hashVal)
+        self.assertEqual(87, hashVal)
         hashVal = aem.easyHash(("ciextension-SUSELinuxEnterpriseServer11SP3"
                                 "___role1___"
                                 "ciextension-SUSELinuxEnterpriseServer11SP3"))
-        self.assertEquals(5, hashVal)
+        self.assertEqual(5, hashVal)
     
     def test_get_ad_key_range(self):
         startKey, endKey = aem.getAzureDiagnosticKeyRange()
@@ -384,14 +384,14 @@ class TestAEM(unittest.TestCase):
         epoch = datetime.datetime.utcfromtimestamp(0)
         unixTimestamp = (int((date - epoch).total_seconds()))
         mdsTimestamp = aem.getMDSTimestamp(unixTimestamp)
-        self.assertEquals(635578412400000000, mdsTimestamp)
+        self.assertEqual(635578412400000000, mdsTimestamp)
     
     def test_get_storage_timestamp(self):
         date = datetime.datetime(2015, 1, 26, 3, 54)
         epoch = datetime.datetime.utcfromtimestamp(0)
         unixTimestamp = (int((date - epoch).total_seconds()))
         storageTimestamp = aem.getStorageTimestamp(unixTimestamp)
-        self.assertEquals("20150126T0354", storageTimestamp)
+        self.assertEqual("20150126T0354", storageTimestamp)
 
 def mock_getStorageMetrics(*args, **kwargs):
         with open(os.path.join(env.test_dir, "storage_metrics")) as F:

--- a/Utils/test/test_logutil.py
+++ b/Utils/test/test_logutil.py
@@ -23,10 +23,10 @@ class TestLogUtil(unittest.TestCase):
         with open("/tmp/testtail", "w+") as F:
             F.write(u"abcdefghijklmnopqrstu\u6211vwxyz".encode("utf-8"))
         tail = lu.tail("/tmp/testtail", 2)
-        self.assertEquals("yz", tail)
+        self.assertEqual("yz", tail)
 
         tail = lu.tail("/tmp/testtail")
-        self.assertEquals("abcdefghijklmnopqrstuvwxyz", tail)
+        self.assertEqual("abcdefghijklmnopqrstuvwxyz", tail)
 
 if __name__ == '__main__':
     unittest.main()

--- a/Utils/test/test_null_protected_settings.py
+++ b/Utils/test/test_null_protected_settings.py
@@ -27,7 +27,7 @@ class TestNullProtectedSettings(unittest.TestCase):
         hutil = Util.HandlerUtility(mock_log, mock_log, "UnitTest", "HandlerUtil.UnitTest", "0.0.1")
         config = hutil._parse_config(Settings)
         handlerSettings = config['runtimeSettings'][0]['handlerSettings']
-        self.assertEquals(handlerSettings["protectedSettings"], None)
+        self.assertEqual(handlerSettings["protectedSettings"], None)
 
 Settings="""\
 {

--- a/Utils/test/test_scriptutil.py
+++ b/Utils/test/test_scriptutil.py
@@ -35,18 +35,18 @@ class TestScriptUtil(unittest.TestCase):
         test_script = "mock.sh"
         os.chdir(os.path.join(env.root, "test"))
         exit_code = su.run_command(hutil, ["sh", test_script, "0"], os.getcwd(), 'RunScript-0', 'TestExtension', '1.0', True, 0.1)
-        self.assertEquals(0, exit_code)
-        self.assertEquals("do_exit", hutil.last)
+        self.assertEqual(0, exit_code)
+        self.assertEqual("do_exit", hutil.last)
         exit_code = su.run_command(hutil, ["sh", test_script, "75"], os.getcwd(), 'RunScript-1', 'TestExtension', '1.0', False, 0.1)
-        self.assertEquals(75, exit_code)
-        self.assertEquals("do_status_report", hutil.last)
+        self.assertEqual(75, exit_code)
+        self.assertEqual("do_status_report", hutil.last)
     
     def test_log_or_exit(self):        
         hutil = MockUtil(self)
         su.log_or_exit(hutil, True, 0, 'LogOrExit-0', 'Message1')
-        self.assertEquals("do_exit", hutil.last)
+        self.assertEqual("do_exit", hutil.last)
         su.log_or_exit(hutil, False, 0, 'LogOrExit-1', 'Message2')
-        self.assertEquals("do_status_report", hutil.last)
+        self.assertEqual("do_status_report", hutil.last)
         
 if __name__ == '__main__':
     unittest.main()

--- a/VMEncryption/test/test_disk_util.py
+++ b/VMEncryption/test/test_disk_util.py
@@ -61,29 +61,29 @@ class TestDiskUtil(unittest.TestCase):
         # empty line
         line = ""
         crypt_item = self.disk_util.parse_crypttab_line(line)
-        self.assertEquals(None, crypt_item)
+        self.assertEqual(None, crypt_item)
 
         # line with not enough entries
         line = "mapper_name dev_path"
         crypt_item = self.disk_util.parse_crypttab_line(line)
-        self.assertEquals(None, crypt_item)
+        self.assertEqual(None, crypt_item)
 
         # commented out line
         line = "# mapper_name dev_path"
         crypt_item = self.disk_util.parse_crypttab_line(line)
-        self.assertEquals(None, crypt_item)
+        self.assertEqual(None, crypt_item)
 
         # An unfamiliar key_file_path implies that we shouln't be processing this crypttab line
         line = "mapper_name /dev/dev_path /non_managed_key_file_path"
         crypt_item = self.disk_util.parse_crypttab_line(line)
-        self.assertEquals(None, crypt_item)
+        self.assertEqual(None, crypt_item)
 
         # a bare bones crypttab line
         line = "mapper_name /dev/dev_path /mnt/azure_bek_disk/LinuxPassPhraseFileName luks"
         expected_crypt_item = self._create_expected_crypt_item(mapper_name="mapper_name",
                                                                dev_path="/dev/dev_path")
         crypt_item = self.disk_util.parse_crypttab_line(line)
-        self.assertEquals(str(expected_crypt_item), str(crypt_item))
+        self.assertEqual(str(expected_crypt_item), str(crypt_item))
 
         # a line that implies a cleartext key
         line = "mapper_name /dev/dev_path /var/lib/azure_disk_encryption_config/cleartext_key_mapper_name luks"
@@ -91,7 +91,7 @@ class TestDiskUtil(unittest.TestCase):
                                                                dev_path="/dev/dev_path",
                                                                uses_cleartext_key=True)
         crypt_item = self.disk_util.parse_crypttab_line(line)
-        self.assertEquals(str(expected_crypt_item), str(crypt_item))
+        self.assertEqual(str(expected_crypt_item), str(crypt_item))
 
         # a line that implies a luks header
         line = "mapper_name /dev/dev_path /var/lib/azure_disk_encryption_config/cleartext_key_mapper_name luks,header=headerfile"
@@ -100,7 +100,7 @@ class TestDiskUtil(unittest.TestCase):
                                                                uses_cleartext_key=True,
                                                                luks_header_path="headerfile")
         crypt_item = self.disk_util.parse_crypttab_line(line)
-        self.assertEquals(str(expected_crypt_item), str(crypt_item))
+        self.assertEqual(str(expected_crypt_item), str(crypt_item))
 
     @mock.patch('__builtin__.open')
     @mock.patch('os.path.exists', return_value=True)


### PR DESCRIPTION
# PR Summary
This PR migrates from `unittest.assertEquals` to `unittest.assertEqual` which is deprecated from Python2.7:
```python
DeprecationWarning: Please use assertEqual instead.
```