### PR TITLE
Improve Linux AMA distro detection

### DIFF
--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -2264,6 +2264,12 @@ def find_vm_distro(operation):
         vm_dist = 'redhat'
     elif vm_dist == 'ol':
         vm_dist = 'oracle'
+
+    if vm_ver and '.' in vm_ver and vm_dist != 'ubuntu':
+        # For Ubuntu, keep major.minor format (e.g., "18.04")
+        # For other distributions, extract only the major version
+        # This is needed for matching with supported_distros.py
+        vm_ver = vm_ver.split('.')[0]
     
     # Add debugging info
     hutil_log_info("Final OS detection result: {0} {1}".format(vm_dist.lower(), vm_ver.lower()))

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -1265,7 +1265,7 @@ def remove_azureotelcollector():
                 azureotelcollector_uninstall_command,
                 retries = 5,
                 retry_check = retry_if_dpkg_or_rpm_locked,
-                final_check = final_check_if_dpkg_or rpm_locked
+                final_check = final_check_if_dpkg_or_rpm_locked
             )
 
             if exit_code == 0:

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -1265,7 +1265,7 @@ def remove_azureotelcollector():
                 azureotelcollector_uninstall_command,
                 retries = 5,
                 retry_check = retry_if_dpkg_or_rpm_locked,
-                final_check = final_check_if_dpkg_or_rpm_locked
+                final_check = final_check_if_dpkg_or rpm_locked
             )
 
             if exit_code == 0:
@@ -2123,9 +2123,9 @@ def find_vm_distro(operation):
                     vm_dist = os_release['ID_LIKE'].lower().split()[0].strip('"\'')
                     vm_dist = vm_dist.split('-')[0]
                 
-                hutil_log_info(f"OS detected from /etc/os-release: {vm_dist} {vm_ver}")
+                hutil_log_info("OS detected from /etc/os-release: {0} {1}".format(vm_dist, vm_ver))
         except Exception as e:
-            hutil_log_error(f"Error reading /etc/os-release: {str(e)}")
+            hutil_log_error("Error reading /etc/os-release: {0}".format(str(e)))
     
     # If we couldn't get the distribution from /etc/os-release, try other files
     if not vm_dist or not vm_ver:
@@ -2141,9 +2141,9 @@ def find_vm_distro(operation):
                         version_match = re.search(r'release\s+(\d+(\.\d+)?)', content)
                         if version_match:
                             vm_ver = version_match.group(1)
-                        hutil_log_info(f"OS detected from /etc/system-release: {vm_dist} {vm_ver}")
+                        hutil_log_info("OS detected from /etc/system-release: {0} {1}".format(vm_dist, vm_ver))
             except Exception as e:
-                hutil_log_error(f"Error reading /etc/system-release: {str(e)}")
+                hutil_log_error("Error reading /etc/system-release: {0}".format(str(e)))
         
         # SUSE specific detection
         if not vm_dist and os.path.exists('/etc/SuSE-release'):
@@ -2168,9 +2168,9 @@ def find_vm_distro(operation):
                     if sp_match and vm_ver:
                         vm_ver = '{0}.{1}'.format(vm_ver, sp_match.group(1))
                     
-                    hutil_log_info(f"OS detected from /etc/SuSE-release: {vm_dist} {vm_ver}")
+                    hutil_log_info("OS detected from /etc/SuSE-release: {0} {1}".format(vm_dist, vm_ver))
             except Exception as e:
-                hutil_log_error(f"Error reading /etc/SuSE-release: {str(e)}")
+                hutil_log_error("Error reading /etc/SuSE-release: {0}".format(str(e)))
         
         # Red Hat based systems
         if not vm_dist and os.path.exists('/etc/redhat-release'):
@@ -2199,9 +2199,9 @@ def find_vm_distro(operation):
                     if version_match:
                         vm_ver = version_match.group(1)
                     
-                    hutil_log_info(f"OS detected from /etc/redhat-release: {vm_dist} {vm_ver}")
+                    hutil_log_info("OS detected from /etc/redhat-release: {0} {1}".format(vm_dist, vm_ver))
             except Exception as e:
-                hutil_log_error(f"Error reading /etc/redhat-release: {str(e)}")
+                hutil_log_error("Error reading /etc/redhat-release: {0}".format(str(e)))
         
         # Debian based systems with lsb-release
         if not vm_dist and os.path.exists('/etc/lsb-release'):
@@ -2219,9 +2219,9 @@ def find_vm_distro(operation):
                 if 'DISTRIB_RELEASE' in lsb_data:
                     vm_ver = lsb_data['DISTRIB_RELEASE'].lower()
                 
-                hutil_log_info(f"OS detected from /etc/lsb-release: {vm_dist} {vm_ver}")
+                hutil_log_info("OS detected from /etc/lsb-release: {0} {1}".format(vm_dist, vm_ver))
             except Exception as e:
-                hutil_log_error(f"Error reading /etc/lsb-release: {str(e)}")
+                hutil_log_error("Error reading /etc/lsb-release: {0}".format(str(e)))
         
         # Debian specific detection
         if not vm_dist and os.path.exists('/etc/debian_version'):
@@ -2230,9 +2230,9 @@ def find_vm_distro(operation):
                 with open('/etc/debian_version', 'r') as fp:
                     vm_ver = fp.read().strip()
                 vm_dist = 'debian'
-                hutil_log_info(f"OS detected from /etc/debian_version: {vm_dist} {vm_ver}")
+                hutil_log_info("OS detected from /etc/debian_version: {0} {1}".format(vm_dist, vm_ver))
             except Exception as e:
-                hutil_log_error(f"Error reading /etc/debian_version: {str(e)}")
+                hutil_log_error("Error reading /etc/debian_version: {0}".format(str(e)))
     
     # Final fallback - try /proc/version
     if not vm_dist and os.path.exists('/proc/version'):
@@ -2250,13 +2250,13 @@ def find_vm_distro(operation):
                     vm_dist = 'suse'
                 
                 # Try to extract version - not always reliable from /proc/version
-                hutil_log_info(f"OS detected from /proc/version: {vm_dist}")
+                hutil_log_info("OS detected from /proc/version: {0}".format(vm_dist))
         except Exception as e:
-            hutil_log_error(f"Error reading /proc/version: {str(e)}")
+            hutil_log_error("Error reading /proc/version: {0}".format(str(e)))
     
     # If we still couldn't determine the OS, log what we tried and throw an error
     if not vm_dist:
-        error_msg = f'Indeterminate operating system. Files checked: {", ".join(detection_files_checked)}'
+        error_msg = 'Indeterminate operating system. Files checked: {0}'.format(", ".join(detection_files_checked))
         log_and_exit(operation, IndeterminateOperatingSystem, error_msg)
     
     # Normalize distribution names
@@ -2266,7 +2266,7 @@ def find_vm_distro(operation):
         vm_dist = 'oracle'
     
     # Add debugging info
-    hutil_log_info(f"Final OS detection result: {vm_dist.lower()} {vm_ver.lower()}")
+    hutil_log_info("Final OS detection result: {0} {1}".format(vm_dist.lower(), vm_ver.lower()))
     
     return vm_dist.lower(), vm_ver.lower()
 


### PR DESCRIPTION
This pull request enhances the `find_vm_distro` function in `AzureMonitorAgent/agent.py` to improve the detection of Linux distributions by parsing distribution-specific files directly. The changes prioritize reliability and expand support for detecting various distributions, including fallback mechanisms for less common cases.

### Improvements to Linux distribution detection:

* **Direct parsing of `/etc/os-release` for modern distributions:** The function now reads and parses `/etc/os-release` to detect the distribution and version, including fallback mechanisms using `ID_LIKE` for vendor-specific suffixes. Remove dependency on the python `platform` module
* **Support for additional files:** Added checks for `/etc/system-release`, `/etc/SuSE-release`, `/etc/redhat-release`, `/etc/lsb-release`, and `/etc/debian_version` to detect specific distributions like Amazon Linux, SUSE, Red Hat-based systems, Debian, and others. Each file is parsed with tailored logic for accurate detection.
* **Fallback to `/proc/version` for indeterminate cases:** As a last resort, `/proc/version` is used to identify distributions when other files fail. This ensures broader compatibility.
* **Better error handling**: Specific exception handling for each file read operation
* **Enhanced logging**: Records which files were checked, Logs the OS detected from each source, Provides detailed error message if detection fails
* **More distribution support**: Add `/etc/system-release` check (used by Amazon Linux), Added version as a last-resort fallback