### PR TITLE
Collect MDSD environment variables for AMA Troubleshooter

### DIFF
--- a/AzureMonitorAgent/ama_tst/AMA-Troubleshooting-Tool.md
+++ b/AzureMonitorAgent/ama_tst/AMA-Troubleshooting-Tool.md
@@ -74,3 +74,4 @@ The AMA Linux Troubleshooter requires Python 2.6+ installed on the machine, but 
 	* Run through scenarios 1-6 in order
 8. (L) Collect logs
 	* Collects all of the logs needed to troubleshoot AMA in a zip file
+	* Includes MDSD process environment variables


### PR DESCRIPTION
This PR helps improve the AMA troubleshooter by collecting MDSD environment variables and writing them to `amalinux.out` and its own file, `mdsd_environ.txt`.