### PR TITLE
add init.py to ama_tst folders for python2.7

### DIFF
--- a/AzureMonitorAgent/ama_tst/__init__.py
+++ b/AzureMonitorAgent/ama_tst/__init__.py
@@ -1,0 +1,1 @@
+# AMA troubleshooter modules

--- a/AzureMonitorAgent/ama_tst/modules/__init__.py
+++ b/AzureMonitorAgent/ama_tst/modules/__init__.py
@@ -1,0 +1,1 @@
+# AMA troubleshooter modules


### PR DESCRIPTION
add init.py to ama_tst folders for python2.7 to pick up the supported distros submodule