### PR TITLE
Adding crypt_r support for python 3.13 (Ubuntu 25.04, distros with ro…

### DIFF
--- a/Utils/distroutils.py
+++ b/Utils/distroutils.py
@@ -9,6 +9,15 @@ import Utils.logger as logger
 import Utils.extensionutils as ext_utils
 import Utils.constants as constants
 
+crypt = get_crypto_module()
+
+def get_crypto_module():
+    import sys
+    if sys.version_info >= (3, 13):
+        import crypt_r as crypt
+    else:
+        import crypt
+    return crypt
 
 def get_my_distro(config, os_name=None):
     if 'FreeBSD' in platform.system():


### PR DESCRIPTION
…lling release)

Ubuntu 25.04 comes with python 3.13 as default, where crypt has been deprecated. The change is done by modifying Utils/distroutils.py

We also need to ask canonical to add python3-crypt-r to the Canonical:ubuntu-25_04:* vm images.

Fixes the deprecation warning in Ubuntu 24.04 from #1935, which is now a fail in Ubuntu 25.04 and newer.
It is also a warning in #1908.