### PR TITLE
[AMA] Improve the uninstall of AMA by removing files for clean uninstall situation

### DIFF
--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -574,6 +574,8 @@ def uninstall():
 
     uninstall_azureotelcollector()
 
+    remove_host_configs()
+
     # remove the logrotate config
     if os.path.exists(AMAExtensionLogRotateFilePath):   
         try:


### PR DESCRIPTION
This PR removes the files and directories related to Azure Monitor Agent if it is a clean uninstall with the command being `./shim.sh --uninstall --clean`. This does not affect the current uninstall logic in the event of an update.