### PR TITLE
Revised Install() and Uninstall() for agent.py

### DIFF
--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -117,8 +117,8 @@ if sys.version_info < (2,7):
 # Global Variables
 PackagesDirectory = 'packages'
 # The BundleFileName values will be replaced by actual values in the release pipeline. See apply_version.sh.
-BundleFileNameDeb = 'azuremonitoragent_1.35.9-1053_x86_64.deb'
-BundleFileNameRpm = 'azuremonitoragent-1.36.1-1078.x86_64.rpm'
+BundleFileNameDeb = 'azuremonitoragent.deb'
+BundleFileNameRpm = 'azuremonitoragent.rpm'
 BundleFileName = ''
 TelegrafBinName = 'telegraf'
 InitialRetrySleepSeconds = 30
@@ -441,7 +441,7 @@ def install():
             hutil_log_info("Current bundle file: {0}".format(current_bundle))
             package_name = installed_versions[0]
 
-            # This is to make sure dpkg's package name is in the same format as the BundileFileNameDeb
+            # This is to make sure dpkg's package name is in the same format as the BundleFileNameDeb
             if PackageManager == 'dpkg':
                 architecture = ''
                 if platform.machine() == 'x86_64':
@@ -673,8 +673,7 @@ def force_uninstall_azure_monitor_agent():
                     
                     hutil_log_info("Force uninstall command {0} returned exit code {1} and output: {2}".format(AMAUninstallCommandForce, exit_code, output))
 
-            hutil_log_info("Finished force_uninstall_azure_monitor_agent() for {0} with exit code {1} and output: {2}".format(PackageManager, exit_code, output))
-
+        hutil_log_info("Finished force_uninstall_azure_monitor_agent() for {0} with exit code {1} and output: {2}".format(PackageManager, exit_code, output))
         # Check if packages are still installed
         is_still_installed, remaining_packages = get_installed_package_version()
         if is_still_installed:

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -455,12 +455,6 @@ def install():
                 same_package_installed = True
         else:
             hutil_log_error("A different version of azuremonitoragent package is already installed. Attempting to uninstall it before installing the new version.")
-            exit_code, output = uninstall_azure_monitor_agent(installed_versions)
-
-            hutil_log_info("Uninstall exit code: {0}, output: {1}".format(exit_code, output))
-
-            if (exit_code != 0):
-                hutil_log_error("Force uninstall failed with error: {0}".format(output))
 
     # If the package is not already installed, proceed with installation otherwise skip since it is the same package version
     if not same_package_installed:

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -466,7 +466,7 @@ def install():
 
     # If the same bundle of Azure Monitor Agent package is not already installed, proceed with installation
     if not same_package_installed:
-        hutil_log_info("Installing Azure Monitor Agent package since same bundle is not installed.")
+        hutil_log_info("Installing Azure Monitor Agent package.")
         package_directory = os.path.join(os.getcwd(), PackagesDirectory)
         bundle_path = os.path.join(package_directory, BundleFileName)
         os.chmod(bundle_path, 100)

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -667,23 +667,22 @@ def uninstall_azure_monitor_agent():
                 exit_code, output = run_command_with_retries_output(AMAUninstallCommandForce, retries = 4,
                                                     retry_check = retry_if_dpkg_or_rpm_locked,
                                                     final_check = final_check_if_dpkg_or_rpm_locked)
-            
-                # Last verification to ensure all packages are uninstalled
-                exit_code, remaining_packages = get_installed_package_version()
-                if exit_code == 0:
-                    output = "Uninstall command did not remove all packages, remaining packages: {0}".format(remaining_packages)
-                    hutil_log_info("Uninstall command did not remove all packages, remaining packages: {0}".format(remaining_packages))
-                    return 1, output
-                else:
-                    hutil_log_info("Uninstall command removed all packages successfully after using --noscripts --nodeps.")
-                    return 0, "Uninstall command removed all packages successfully after using --noscripts --nodeps."
 
         hutil_log_info("Finished uninstall_azure_monitor_agent() for {0} with exit code {1} and output: {2}".format(PackageManager, exit_code, output))
-        return exit_code, output
+
+        # Check if packages are still installed
+        exit_code, remaining_packages = get_installed_package_version()
+        if exit_code == 0:
+            output = "Uninstall command did not remove all packages, remaining packages: {0}".format(remaining_packages)
+            hutil_log_info("Uninstall command did not remove all packages, remaining packages: {0}".format(remaining_packages))
+            return 1, output
+        else:
+            hutil_log_info("Uninstall command removed all packages successfully after using ____.")
+            return 0, "Azure Monitor Agent packages uninstalled successfully after using performing ___ "
     # Since there was no indication of AMA, we assume it was uninstalled successfully
     else:
-        hutil_log_info("Azure Monitor Agent packages uninstalled successfully")
-        return 0, "Azure Monitor Agent packages uninstalled successfully"
+        hutil_log_info("Azure Monitor Agent is not installed, nothing to uninstall.")
+        return 0, "Azure Monitor Agent is not installed, nothing to uninstall."
 def enable():
     """
     Start the Azure Monitor Linux Agent Service

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -649,6 +649,7 @@ def force_uninstall_azure_monitor_agent():
                                                 retry_check = retry_if_dpkg_or_rpm_locked,
                                                 final_check = final_check_if_dpkg_or_rpm_locked)
 
+            hutil_log_info("Force uninstall command {0} returned exit code {1} and output: {2}".format(AMAUninstallCommandForce, exit_code, output))
             commands_used.append(AMAUninstallCommand)
             # Query to see what is left after using the --allmatches uninstall
             is_still_installed, remaining_packages = get_installed_package_version()
@@ -672,8 +673,6 @@ def force_uninstall_azure_monitor_agent():
                                                         final_check = final_check_if_dpkg_or_rpm_locked)
                     
                     hutil_log_info("Force uninstall command {0} returned exit code {1} and output: {2}".format(AMAUninstallCommandForce, exit_code, output))
-
-        hutil_log_info("Finished force_uninstall_azure_monitor_agent() for {0} with exit code {1} and output: {2}".format(PackageManager, exit_code, output))
         # Check if packages are still installed
         is_still_installed, remaining_packages = get_installed_package_version()
         if is_still_installed:

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -117,8 +117,8 @@ if sys.version_info < (2,7):
 # Global Variables
 PackagesDirectory = 'packages'
 # The BundleFileName values will be replaced by actual values in the release pipeline. See apply_version.sh.
-BundleFileNameDeb = 'azuremonitoragent.deb'
-BundleFileNameRpm = 'azuremonitoragent.rpm'
+BundleFileNameDeb = 'azuremonitoragent_1.35.9-1053_x86_64.deb'
+BundleFileNameRpm = 'azuremonitoragent-1.36.1-1078.x86_64.rpm'
 BundleFileName = ''
 TelegrafBinName = 'telegraf'
 InitialRetrySleepSeconds = 30
@@ -658,21 +658,22 @@ def force_uninstall_azure_monitor_agent():
                 hutil_log_info("Failed to uninstall azuremonitoragent with --allmatches, trying to force uninstall each package individually.")
                 # --noscripts and --nodeps flags are used to avoid running any pre/post scripts and skip dependencies test
                 # https://jfearn.fedorapeople.org/en-US/RPM/4/html/RPM_Guide/ch03s03s03.html
-                AMAUninstallCommandForce = "rpm -e --noscripts --nodeps {0}"
                 for package in remaining_packages:
                     # Clean the package name and create uninstall command
                     package = package.strip()
                     if not package:
                         continue
-                    AMAUninstallCommandForce = AMAUninstallCommandForce.format(package)
+                    AMAUninstallCommandForce = "rpm -e --noscripts --nodeps {0}".format(package)
                     commands_used.append(AMAUninstallCommandForce)
                     hutil_log_info('Running command "{0}"'.format(AMAUninstallCommandForce))
                 
-                exit_code, output = run_command_with_retries_output(AMAUninstallCommandForce, retries = 4,
-                                                    retry_check = retry_if_dpkg_or_rpm_locked,
-                                                    final_check = final_check_if_dpkg_or_rpm_locked)
+                    exit_code, output = run_command_with_retries_output(AMAUninstallCommandForce, retries = 4,
+                                                        retry_check = retry_if_dpkg_or_rpm_locked,
+                                                        final_check = final_check_if_dpkg_or_rpm_locked)
+                    
+                    hutil_log_info("Force uninstall command {0} returned exit code {1} and output: {2}".format(AMAUninstallCommandForce, exit_code, output))
 
-        hutil_log_info("Finished force_uninstall_azure_monitor_agent() for {0} with exit code {1} and output: {2}".format(PackageManager, exit_code, output))
+            hutil_log_info("Finished force_uninstall_azure_monitor_agent() for {0} with exit code {1} and output: {2}".format(PackageManager, exit_code, output))
 
         # Check if packages are still installed
         is_still_installed, remaining_packages = get_installed_package_version()

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -117,8 +117,8 @@ if sys.version_info < (2,7):
 # Global Variables
 PackagesDirectory = 'packages'
 # The BundleFileName values will be replaced by actual values in the release pipeline. See apply_version.sh.
-BundleFileNameDeb = 'azuremonitoragent_1.35.9-1053_x86_64.deb'
-BundleFileNameRpm = 'azuremonitoragent-1.36.1-1078.x86_64.rpm'
+BundleFileNameDeb = 'azuremonitoragent.deb'
+BundleFileNameRpm = 'azuremonitoragent.rpm'
 BundleFileName = ''
 TelegrafBinName = 'telegraf'
 InitialRetrySleepSeconds = 30

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -464,9 +464,9 @@ def install():
                 hutil_log_error("'rpm -q azuremonitoragent' and for each version run: rpm -e azuremonitoragent-(version)-(bundle_number).(architecture), or rpm -e --deleteall azuremonitoragent\n An example of the command is as follows: rpm -e {0}".format(installed_versions[0]))
                 hutil_log_error("If the following does not work please try the following: rpm -e --noscripts --nodeps azuremonitoragent-(version)-(bundle_number).(architecture). I.e. rpm -e --noscripts --nodeps {0}".format(installed_versions[0]))
 
-    # If the package is not already installed, proceed with installation otherwise skip since it is the same package version
+    # If the same bundle of Azure Monitor Agent package is not already installed, proceed with installation
     if not same_package_installed:
-        hutil_log_info("No previous package found, installing Azure Monitor Agent package.")
+        hutil_log_info("Installing Azure Monitor Agent package since same bundle is not installed.")
         package_directory = os.path.join(os.getcwd(), PackagesDirectory)
         bundle_path = os.path.join(package_directory, BundleFileName)
         os.chmod(bundle_path, 100)

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -441,7 +441,7 @@ def install():
             hutil_log_info("Current bundle file: {0}".format(current_bundle))
             package_name = installed_versions[0]
 
-            # This is to make sure dpkg's packave name is in the same format as the BundileFileNameDeb
+            # This is to make sure dpkg's package name is in the same format as the BundileFileNameDeb
             if PackageManager == 'dpkg':
                 architecture = ''
                 if platform.machine() == 'x86_64':

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -370,7 +370,7 @@ def get_installed_package_version():
     Returns: (is_installed, version_list)
     """
     if PackageManager == "dpkg":
-        # In the case of dpkg, we specfiy only Package and Version as architecture is written as amd64/arm64 instead of x86_64/aarch64.
+        # In the case of dpkg, we specify only Package and Version as architecture is written as amd64/arm64 instead of x86_64/aarch64.
         cmd = "dpkg-query -W -f='${Package}_${Version}\n' 'azuremonitoragent*' 2>/dev/null"
     elif PackageManager == "rpm":
         cmd = "rpm -q azuremonitoragent"
@@ -1251,7 +1251,7 @@ def install_azureotelcollector():
     """
     This method will install the azureotelcollector package and start a systemd file watcher service that watches for configuration file changes.
     MetricsExtension is responsible for writing the configuration file.
-    Only if configuration is present, otelcollector process will start to run, the watcher service is responsible to monitor the configurartion file.
+    Only if configuration is present, otelcollector process will start to run, the watcher service is responsible to monitor the configuration file.
     """
     if is_feature_enabled("enableAzureOTelCollector") and is_systemd():
         find_package_manager("Install")


### PR DESCRIPTION
Implemented AMA package version detection to be used in `install()` and `uninstall()` while improving diagnostic logging to provide more information on multiple AMA package scenario. For RPM, we attempt to uninstall each package name specifically, followed by the `--allmatches` flag followed by `--noscripts --nodeps`.