### PR TITLE
Verifies that protected settings is a dictionary before proceeding in VMAccess

### DIFF
--- a/Utils/handlerutil2.py
+++ b/Utils/handlerutil2.py
@@ -364,7 +364,11 @@ class HandlerUtility:
 
     def get_protected_settings(self):
         if (self._context._config != None):
-            return self.get_handler_settings().get('protectedSettings')
+            protectedSettings = self.get_handler_settings().get('protectedSettings')
+            if (isinstance(protectedSettings, dict)):
+                return protectedSettings
+            else:
+                self.error("Protected settings is not of type dictionary")
         return None
 
     def get_public_settings(self):


### PR DESCRIPTION
This prevents the following errors:

VM has reported a failure when processing extension 'enablevmaccess' (publisher 'Microsoft.OSTCExtensions' and type 'VMAccessForLinux'). Error message: 'Enable failed: 'NoneType' object has no attribute 'get''.

Also this one:
Error message: 'Enable failed: 'str' object has no attribute 'get''.