### PR TITLE
Fixing Watson crash1 for ICM 672412588

### DIFF
--- a/Diagnostic/mdsd/mdscommands/EventHubPublisher.cc
+++ b/Diagnostic/mdsd/mdscommands/EventHubPublisher.cc
@@ -208,7 +208,7 @@ EventHubPublisher::PublishAsync(
     }
     catch(...)
     {
-        MdsCmdLogError("Error: EH async publish to " + m_eventHubUrl + " failed with unknown exception");
+        MdsCmdLogError("Error: EH async publish to " + m_eventHubUrl + " failed with unknown exception.");
     }
 
     m_resetHttpClient = true;
@@ -231,7 +231,7 @@ EventHubPublisher::HandleServerResponseAsync(
     catch(...)
     {
         MdsCmdLogError("Error: EH async publish to " + m_eventHubUrl +
-            " failed with unknown http response exception");
+            " failed with unknown exception in response.");
     }
 
     m_resetHttpClient = true;


### PR DESCRIPTION
Looking at the stack trace from https://portal.watson.azure.com/dump?dumpUID=8510a37d-7d16-4786-96ec-07634c40ea70, the issue is a pure virtual function call happening in the HTTP pipeline, followed by an infinite loop in the terminate handler.

mdsd!__cxxabiv1::__cxa_pure_virtual+0x0
mdsd!web::http::client::http_pipeline::propagate+0x0
mdsd!web::http::client::http_client::request+0x0
mdsd!mdsd::details::EventHubPublisher::PublishAsync+0x0

Pure virtual function calls throw exceptions that may not inherit from std::exception. The catch(...) catches everything including the pure virtual function call exception and breaks the infinite terminate handler loop.