### PR TITLE
Remove contents of go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,0 @@
-module github.com/ChrisCoe/azure-linux-extensions
-
-go 1.21


### PR DESCRIPTION
Remove contents of `go.mod` for LAD3 since there are no dependencies attached to it.