### PR TITLE
Fix KeyError when PYTHONPATH is not set in WAAgentUtil.py

### DIFF
--- a/VMBackup/main/Utils/WAAgentUtil.py
+++ b/VMBackup/main/Utils/WAAgentUtil.py
@@ -44,7 +44,7 @@ def searchWAAgent():
     agentPath = os.path.join(os.getcwd(), "main/WaagentLib.py")
     if(os.path.isfile(agentPath)):
         return agentPath
-    user_paths = os.environ['PYTHONPATH'].split(os.pathsep)
+    user_paths = os.environ.get('PYTHONPATH', '').split(os.pathsep)
     for user_path in user_paths:
         agentPath = os.path.join(user_path, 'waagent')
         if(os.path.isfile(agentPath)):
@@ -55,7 +55,7 @@ def searchWAAgentOld():
     agentPath = '/usr/sbin/waagent'
     if(os.path.isfile(agentPath)):
         return agentPath
-    user_paths = os.environ['PYTHONPATH'].split(os.pathsep)
+    user_paths = os.environ.get('PYTHONPATH', '').split(os.pathsep)
     for user_path in user_paths:
         agentPath = os.path.join(user_path, 'waagent')
         if(os.path.isfile(agentPath)):


### PR DESCRIPTION
Use os.environ.get('PYTHONPATH', '') instead of os.environ['PYTHONPATH'] in both searchWAAgent() and searchWAAgentOld() to prevent a KeyError crash when the PYTHONPATH environment variable is not set, which is common on minimal cloud VM images.

Without this fix, if the primary path check (main/WaagentLib.py or /usr/sbin/waagent) fails, the extension crashes instead of gracefully returning None and allowing the caller to handle the missing agent.