### PR TITLE
VM Access 1.5.24 Update

### DIFF
--- a/VMAccess/manifest.xml
+++ b/VMAccess/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.OSTCExtensions</ProviderNameSpace>
   <Type>VMAccessForLinux</Type>
-  <Version>1.5.23</Version>
+  <Version>1.5.24</Version>
   <Label>Microsoft Azure VM Access Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>


### PR DESCRIPTION
1.5.24 includes (no release since 1.5.22 which only got to [Canary + FF](https://github.com/Azure/VMExtensions/releases/tag/LinuxVMAccessExtension1.5.22))

[Add fallbacks for import crypt
](https://github.com/Azure/azure-linux-extensions/pull/2156)

[Fix unexpected keyword argument 'crypt_id' on FreeBSD 14.1](https://github.com/Azure/azure-linux-extensions/pull/1955)

[Fixes issue preventing VmAccess from uninstalling](https://github.com/Azure/azure-linux-extensions/pull/2136)


1.5.22 included 
[Retrieves the sequence number for VMAccess from the environment variable](https://github.com/Azure/azure-linux-extensions/pull/2095)

[Verifies that protected settings is a dictionary before proceeding in VMAccess
](https://github.com/Azure/azure-linux-extensions/pull/2098)

[Fix python syntax warnings seen on selinux distros](https://github.com/Azure/azure-linux-extensions/pull/2099)

[Adding support for FIPS 140-3 
](https://github.com/Azure/azure-linux-extensions/pull/2007)
