### PR TITLE
Add alias for `which` via `command -v` for SUSE 16

### DIFF
--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -435,43 +435,7 @@ def install():
             hutil_log_info("'which' package missing from SLES {0} machine, attempting to install.".format(vm_ver))
             which_exit_code, which_output = run_command_and_log("zypper --non-interactive install which")
             if which_exit_code != 0:
-                hutil_log_info("Could not install 'which' via zypper (exit code {0}). Creating 'which' shim using 'command -v' as fallback.".format(which_exit_code))
-                # Create a shim script so that calls to 'which' in RPM post-install scripts still work
-                try:
-                    which_shim = "/usr/local/bin/which"
-                    with open(which_shim, "w") as f:
-                        f.write("#!/bin/sh\ncommand -v \"$@\"\n")
-                    os.chmod(which_shim, 0o755)
-                    hutil_log_info("Created 'which' shim at {0}".format(which_shim))
-                except Exception as ex:
-                    hutil_log_error("Failed to create 'which' shim: {0}".format(ex))
-
-    # Check if SLES 16+ VMs have 'which' package (changed from Requires to Recommends in spec, may not be installed)
-    if (vm_dist.startswith('suse') or vm_dist.startswith('sles')) and int(vm_ver.split('.')[0]) >= 16:
-        check_which, _ = run_command_and_log("rpm -q which")
-        if check_which != 0:
-            hutil_log_info("'which' package missing from SLES {0} machine, attempting to install.".format(vm_ver))
-            which_exit_code, which_output = run_command_and_log("zypper --non-interactive install which")
-            if which_exit_code != 0:
-                hutil_log_info("Could not install 'which' via zypper (exit code {0}). Creating 'which' shim using 'command -v' as fallback.".format(which_exit_code))
-                # Create a shim script so that calls to 'which' in RPM post-install scripts still work
-                try:
-                    which_shim = "/usr/local/bin/which"
-                    with open(which_shim, "w") as f:
-                        f.write("#!/bin/sh\ncommand -v \"$@\"\n")
-                    os.chmod(which_shim, 0o755)
-                    hutil_log_info("Created 'which' shim at {0}".format(which_shim))
-                except Exception as ex:
-                    hutil_log_error("Failed to create 'which' shim: {0}".format(ex))
-
-    # Check if SLES 16+ VMs have 'which' package (changed from Requires to Recommends in spec, may not be installed)
-    if (vm_dist.startswith('suse') or vm_dist.startswith('sles')) and int(vm_ver.split('.')[0]) >= 16:
-        check_which, _ = run_command_and_log("rpm -q which")
-        if check_which != 0:
-            hutil_log_info("'which' package missing from SLES {0} machine, attempting to install.".format(vm_ver))
-            which_exit_code, which_output = run_command_and_log("zypper --non-interactive install which")
-            if which_exit_code != 0:
-                hutil_log_info("Could not install 'which' via zypper (exit code {0}). Creating 'which' shim using 'command -v' as fallback.".format(which_exit_code))
+                hutil_log_info("Could not install 'which' via zypper (exit code {0}). Creating 'which' alias using 'command -v' as fallback.".format(which_exit_code))
                 # Create a shim script so that calls to 'which' in RPM post-install scripts still work
                 try:
                     which_shim = "/usr/local/bin/which"

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -434,6 +434,9 @@ def install():
         if check_which != 0:
             hutil_log_info("'which' package missing from SLES {0} machine, creating 'which' alias using 'command -v'.".format(vm_ver))
             try:
+                # Note: command -v also reports shell built-ins (e.g. echo, cd) unlike which,
+                # which only searches PATH for files. This is harmless for AMA's usages (e.g. 'which semanage')
+                # since those are always external executables.
                 which_alias = "/usr/local/bin/which"
                 with open(which_alias, "w") as f:
                     f.write("#!/bin/sh\ncommand -v \"$@\"\n")
@@ -636,11 +639,15 @@ def uninstall():
         # Clean up context marker (always do this)
         _cleanup_uninstall_context()
 
+        # Clean up 'which' alias created during install for SLES 16+
+        _cleanup_which_alias()
+
     except Exception as ex:
         exit_code = GenericErrorCode
         output = 'Uninstall failed with error: {0}\n' \
                 'Stacktrace: {1}'.format(ex, traceback.format_exc())
     return exit_code, output
+
 
 def force_uninstall_azure_monitor_agent():
     """
@@ -1275,6 +1282,27 @@ def _cleanup_uninstall_context():
             hutil_log_info("Uninstall context file does not exist, nothing to remove")
     except Exception as ex:
         hutil_log_error("Failed to cleanup uninstall context: {0}\n This may result in unintended behavior as described.\nIf the marker file exists and cannot be removed, uninstall will continue to keep the {1} path, leading users to have to remove it manually.".format(ex, AmaDataPath))
+
+def _cleanup_which_alias():
+    """
+    Clean up the 'which' alias created during install for SLES 16+.
+    Only removes the file if it is the shim we created (contains 'command -v').
+    """
+    try:
+        vm_dist, vm_ver = find_vm_distro('Uninstall')
+        vm_major = vm_ver.split('.')[0]
+        if not (vm_dist.startswith('suse') or vm_dist.startswith('sles')) or not vm_major.isdigit() or int(vm_major) < 16:
+            return
+
+        which_alias = "/usr/local/bin/which"
+        if os.path.exists(which_alias):
+            with open(which_alias, "r") as f:
+                content = f.read()
+            if "command -v" in content:
+                os.remove(which_alias)
+                hutil_log_info("Removed 'which' alias at {0}".format(which_alias))
+    except Exception as ex:
+        hutil_log_info("Failed to remove 'which' alias: {0}".format(ex))
 
 def restart_launcher():
     # start agent launcher

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -2897,8 +2897,8 @@ def get_settings():
         public_settings = HUtilObject.get_public_settings()
         protected_settings = HUtilObject.get_protected_settings()
     elif SettingsDict is not None:
-        public_settings = SettingsDict.get('public_settings')
-        protected_settings = SettingsDict.get('protected_settings')
+        public_settings = SettingsDict['public_settings']
+        protected_settings = SettingsDict['protected_settings']
     else:
         SettingsDict = {}
         handler_env = get_handler_env()

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -428,23 +428,19 @@ def install():
             if rsyslog_exit_code != 0:
                 return rsyslog_exit_code, rsyslog_output
     
-    # Check if SLES 16+ VMs have 'which' package
+    # Check if SLES 16+ VMs have 'which' package (changed from Requires to Recommends in spec, may not be installed)
     if (vm_dist.startswith('suse') or vm_dist.startswith('sles')) and int(vm_ver.split('.')[0]) >= 16:
         check_which, _ = run_command_and_log("rpm -q which")
         if check_which != 0:
-            hutil_log_info("'which' package missing from SLES {0} machine, attempting to install.".format(vm_ver))
-            which_exit_code, which_output = run_command_and_log("zypper --non-interactive install which")
-            if which_exit_code != 0:
-                hutil_log_info("Could not install 'which' via zypper (exit code {0}). Creating 'which' alias using 'command -v' as fallback.".format(which_exit_code))
-                # Create an alias so that calls to 'which' in RPM post-install scripts still work
-                try:
-                    which_alias = "/usr/local/bin/which"
-                    with open(which_alias, "w") as f:
-                        f.write("#!/bin/sh\ncommand -v \"$@\"\n")
-                    os.chmod(which_alias, 0o755)
-                    hutil_log_info("Created 'which' alias at {0}".format(which_alias))
-                except Exception as ex:
-                    hutil_log_error("Failed to create 'which' alias: {0}".format(ex))
+            hutil_log_info("'which' package missing from SLES {0} machine, creating 'which' alias using 'command -v'.".format(vm_ver))
+            try:
+                which_alias = "/usr/local/bin/which"
+                with open(which_alias, "w") as f:
+                    f.write("#!/bin/sh\ncommand -v \"$@\"\n")
+                os.chmod(which_alias, 0o755)
+                hutil_log_info("Created 'which' alias at {0}".format(which_alias))
+            except Exception as ex:
+                hutil_log_error("Failed to create 'which' alias: {0}".format(ex))
 
     # Flag to handle the case where the same package is already installed
     same_package_installed = False

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -2897,8 +2897,8 @@ def get_settings():
         public_settings = HUtilObject.get_public_settings()
         protected_settings = HUtilObject.get_protected_settings()
     elif SettingsDict is not None:
-        public_settings = SettingsDict['public_settings']
-        protected_settings = SettingsDict['protected_settings']
+        public_settings = SettingsDict.get('public_settings')
+        protected_settings = SettingsDict.get('protected_settings')
     else:
         SettingsDict = {}
         handler_env = get_handler_env()

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -428,6 +428,60 @@ def install():
             if rsyslog_exit_code != 0:
                 return rsyslog_exit_code, rsyslog_output
     
+    # Check if SLES 16+ VMs have 'which' package (changed from Requires to Recommends in spec, may not be installed)
+    if (vm_dist.startswith('suse') or vm_dist.startswith('sles')) and int(vm_ver.split('.')[0]) >= 16:
+        check_which, _ = run_command_and_log("rpm -q which")
+        if check_which != 0:
+            hutil_log_info("'which' package missing from SLES {0} machine, attempting to install.".format(vm_ver))
+            which_exit_code, which_output = run_command_and_log("zypper --non-interactive install which")
+            if which_exit_code != 0:
+                hutil_log_info("Could not install 'which' via zypper (exit code {0}). Creating 'which' shim using 'command -v' as fallback.".format(which_exit_code))
+                # Create a shim script so that calls to 'which' in RPM post-install scripts still work
+                try:
+                    which_shim = "/usr/local/bin/which"
+                    with open(which_shim, "w") as f:
+                        f.write("#!/bin/sh\ncommand -v \"$@\"\n")
+                    os.chmod(which_shim, 0o755)
+                    hutil_log_info("Created 'which' shim at {0}".format(which_shim))
+                except Exception as ex:
+                    hutil_log_error("Failed to create 'which' shim: {0}".format(ex))
+
+    # Check if SLES 16+ VMs have 'which' package (changed from Requires to Recommends in spec, may not be installed)
+    if (vm_dist.startswith('suse') or vm_dist.startswith('sles')) and int(vm_ver.split('.')[0]) >= 16:
+        check_which, _ = run_command_and_log("rpm -q which")
+        if check_which != 0:
+            hutil_log_info("'which' package missing from SLES {0} machine, attempting to install.".format(vm_ver))
+            which_exit_code, which_output = run_command_and_log("zypper --non-interactive install which")
+            if which_exit_code != 0:
+                hutil_log_info("Could not install 'which' via zypper (exit code {0}). Creating 'which' shim using 'command -v' as fallback.".format(which_exit_code))
+                # Create a shim script so that calls to 'which' in RPM post-install scripts still work
+                try:
+                    which_shim = "/usr/local/bin/which"
+                    with open(which_shim, "w") as f:
+                        f.write("#!/bin/sh\ncommand -v \"$@\"\n")
+                    os.chmod(which_shim, 0o755)
+                    hutil_log_info("Created 'which' shim at {0}".format(which_shim))
+                except Exception as ex:
+                    hutil_log_error("Failed to create 'which' shim: {0}".format(ex))
+
+    # Check if SLES 16+ VMs have 'which' package (changed from Requires to Recommends in spec, may not be installed)
+    if (vm_dist.startswith('suse') or vm_dist.startswith('sles')) and int(vm_ver.split('.')[0]) >= 16:
+        check_which, _ = run_command_and_log("rpm -q which")
+        if check_which != 0:
+            hutil_log_info("'which' package missing from SLES {0} machine, attempting to install.".format(vm_ver))
+            which_exit_code, which_output = run_command_and_log("zypper --non-interactive install which")
+            if which_exit_code != 0:
+                hutil_log_info("Could not install 'which' via zypper (exit code {0}). Creating 'which' shim using 'command -v' as fallback.".format(which_exit_code))
+                # Create a shim script so that calls to 'which' in RPM post-install scripts still work
+                try:
+                    which_shim = "/usr/local/bin/which"
+                    with open(which_shim, "w") as f:
+                        f.write("#!/bin/sh\ncommand -v \"$@\"\n")
+                    os.chmod(which_shim, 0o755)
+                    hutil_log_info("Created 'which' shim at {0}".format(which_shim))
+                except Exception as ex:
+                    hutil_log_error("Failed to create 'which' shim: {0}".format(ex))
+
     # Flag to handle the case where the same package is already installed
     same_package_installed = False
 

--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -428,7 +428,7 @@ def install():
             if rsyslog_exit_code != 0:
                 return rsyslog_exit_code, rsyslog_output
     
-    # Check if SLES 16+ VMs have 'which' package (changed from Requires to Recommends in spec, may not be installed)
+    # Check if SLES 16+ VMs have 'which' package
     if (vm_dist.startswith('suse') or vm_dist.startswith('sles')) and int(vm_ver.split('.')[0]) >= 16:
         check_which, _ = run_command_and_log("rpm -q which")
         if check_which != 0:
@@ -436,15 +436,15 @@ def install():
             which_exit_code, which_output = run_command_and_log("zypper --non-interactive install which")
             if which_exit_code != 0:
                 hutil_log_info("Could not install 'which' via zypper (exit code {0}). Creating 'which' alias using 'command -v' as fallback.".format(which_exit_code))
-                # Create a shim script so that calls to 'which' in RPM post-install scripts still work
+                # Create an alias so that calls to 'which' in RPM post-install scripts still work
                 try:
-                    which_shim = "/usr/local/bin/which"
-                    with open(which_shim, "w") as f:
+                    which_alias = "/usr/local/bin/which"
+                    with open(which_alias, "w") as f:
                         f.write("#!/bin/sh\ncommand -v \"$@\"\n")
-                    os.chmod(which_shim, 0o755)
-                    hutil_log_info("Created 'which' shim at {0}".format(which_shim))
+                    os.chmod(which_alias, 0o755)
+                    hutil_log_info("Created 'which' alias at {0}".format(which_alias))
                 except Exception as ex:
-                    hutil_log_error("Failed to create 'which' shim: {0}".format(ex))
+                    hutil_log_error("Failed to create 'which' alias: {0}".format(ex))
 
     # Flag to handle the case where the same package is already installed
     same_package_installed = False


### PR DESCRIPTION
Since `which` does not come by default with SUSE 16, we will create an alias via `command -v` to substitute for `which` on SUSE/SLES 16.