### PR TITLE
Use EnableDcrManagedSources command line arg in AMA ME service

### DIFF
--- a/AzureMonitorAgent/services/metrics-extension-cmv2.service
+++ b/AzureMonitorAgent/services/metrics-extension-cmv2.service
@@ -8,7 +8,7 @@ Environment="OTLP_GRPC_PORT=4317"
 Environment="OTLP_GRPC_PROM_HOST=127.0.0.1"
 Environment="OTLP_GRPC_PROM_PORT=4316"
 EnvironmentFile=-/etc/metrics-extension.d/options.conf
-ExecStart=%ME_BIN% -TokenSource AMCS -ManagedIdentity %ME_MANAGED_IDENTITY% -DataDirectory %ME_DATA_DIRECTORY% -Input influxdb_local,otlp_grpc,otlp_grpc_prom -InfluxDbSocketPath /var/run/azuremonitoragent/mdm_influxdb.socket -LogLevel Info -Logger Console -OperationEnvironment AMA-Linux/AMA_VERSION -ConfigOverrides "{\"otlp\":{\"endpoints\":[\"${OTLP_GRPC_PROM_HOST}:${OTLP_GRPC_PROM_PORT}\"]}}"
+ExecStart=%ME_BIN% -EnableDcrManagedSources -ManagedIdentity %ME_MANAGED_IDENTITY% -DataDirectory %ME_DATA_DIRECTORY% -Input influxdb_local -InfluxDbSocketPath /var/run/azuremonitoragent/mdm_influxdb.socket -LogLevel Info -Logger Console -OperationEnvironment AMA-Linux/AMA_VERSION -ConfigOverrides "{\"otlp\":{\"endpoints\":[\"${OTLP_GRPC_PROM_HOST}:${OTLP_GRPC_PROM_PORT}\"]}}"
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartForceExitStatus=SIGPIPE

--- a/AzureMonitorAgent/services/metrics-extension-otlp.service
+++ b/AzureMonitorAgent/services/metrics-extension-otlp.service
@@ -6,7 +6,7 @@ After=network.target
 Environment="OTLP_GRPC_HOST=127.0.0.1"
 Environment="OTLP_GRPC_PORT=4317"
 EnvironmentFile=-/etc/metrics-extension.d/options.conf
-ExecStart=%ME_BIN% -EnableDcrManagedSources -ManagedIdentity %ME_MANAGED_IDENTITY% -Input influxdb_local -InfluxDbSocketPath %ME_INFLUX_SOCKET_FILE_PATH% -LogLevel Info -Logger Console -OperationEnvironment AMA-Linux/AMA_VERSION
+ExecStart=%ME_BIN% -TokenSource AMCS -ManagedIdentity %ME_MANAGED_IDENTITY% -Input influxdb_local,otlp_grpc -InfluxDbSocketPath %ME_INFLUX_SOCKET_FILE_PATH% -LogLevel Info -Logger Console -OperationEnvironment AMA-Linux/AMA_VERSION
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=control-group
 

--- a/AzureMonitorAgent/services/metrics-extension-otlp.service
+++ b/AzureMonitorAgent/services/metrics-extension-otlp.service
@@ -6,7 +6,7 @@ After=network.target
 Environment="OTLP_GRPC_HOST=127.0.0.1"
 Environment="OTLP_GRPC_PORT=4317"
 EnvironmentFile=-/etc/metrics-extension.d/options.conf
-ExecStart=%ME_BIN% -TokenSource AMCS -ManagedIdentity %ME_MANAGED_IDENTITY% -Input influxdb_local,otlp_grpc -InfluxDbSocketPath /var/run/azuremonitoragent/mdm_influxdb.socket -LogLevel Info -Logger Console -OperationEnvironment AMA-Linux/AMA_VERSION
+ExecStart=%ME_BIN% -EnableDcrManagedSources -ManagedIdentity %ME_MANAGED_IDENTITY% -Input influxdb_local -InfluxDbSocketPath /var/run/azuremonitoragent/mdm_influxdb.socket -LogLevel Info -Logger Console -OperationEnvironment AMA-Linux/AMA_VERSION
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartForceExitStatus=SIGPIPE


### PR DESCRIPTION
- Add ```-EnableDcrManagedSources``` command-line argument to control OTLP sources for ME in AMA

Verified changes to service file on ubuntu 24.04 vm with latest ME version 