### PR TITLE
VMAccess: Add Azure Linux / Mariner support to sshd_config reset

### DIFF
--- a/VMAccess/resources/azurelinux_default
+++ b/VMAccess/resources/azurelinux_default
@@ -1,0 +1,132 @@
+#	$OpenBSD: sshd_config,v 1.105 2024/12/03 14:12:47 dtucker Exp $
+
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/usr/local/bin:/usr/bin
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
+# To modify the system-wide sshd configuration, create a  *.conf  file under
+#  /etc/ssh/sshd_config.d/  which will be automatically included below
+Include /etc/ssh/sshd_config.d/*.conf
+
+# If you want to change the port on a SELinux system, you have to tell
+# SELinux about this change.
+# semanage port -a -t ssh_port_t -p tcp #PORTNUMBER
+#
+#Port 22
+#AddressFamily any
+#ListenAddress 0.0.0.0
+#ListenAddress ::
+
+#HostKey /etc/ssh/ssh_host_rsa_key
+#HostKey /etc/ssh/ssh_host_ecdsa_key
+#HostKey /etc/ssh/ssh_host_ed25519_key
+
+# Ciphers and keying
+#RekeyLimit default none
+
+# Logging
+#SyslogFacility AUTH
+#LogLevel INFO
+
+# Authentication:
+
+#LoginGraceTime 2m
+#PermitRootLogin prohibit-password
+#StrictModes yes
+#MaxAuthTries 6
+#MaxSessions 10
+
+#PubkeyAuthentication yes
+
+# The default is to check both .ssh/authorized_keys and .ssh/authorized_keys2
+# but this is overridden so installations will only check .ssh/authorized_keys
+AuthorizedKeysFile      .ssh/authorized_keys
+
+#AuthorizedPrincipalsFile none
+
+#AuthorizedKeysCommand none
+#AuthorizedKeysCommandUser nobody
+
+# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
+#HostbasedAuthentication no
+# Change to yes if you don't trust ~/.ssh/known_hosts for
+# HostbasedAuthentication
+#IgnoreUserKnownHosts no
+# Don't read the user's ~/.rhosts and ~/.shosts files
+#IgnoreRhosts yes
+
+# To disable tunneled clear text passwords, change to "no" here!
+#PasswordAuthentication yes
+#PermitEmptyPasswords no
+
+# Change to "no" to disable keyboard-interactive authentication.  Depending on
+# the system's configuration, this may involve passwords, challenge-response,
+# one-time passwords or some combination of these and other methods.
+#KbdInteractiveAuthentication yes
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+#KerberosGetAFSToken no
+#KerberosUseKuserok yes
+
+# GSSAPI options
+#GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
+#GSSAPIStrictAcceptorCheck yes
+#GSSAPIKeyExchange no
+#GSSAPIEnablek5users no
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the KbdInteractiveAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via KbdInteractiveAuthentication may bypass
+# the setting of "PermitRootLogin prohibit-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and KbdInteractiveAuthentication to 'no'.
+# WARNING: 'UsePAM no' is not supported in this build and may cause several
+# problems.
+#UsePAM no
+
+#AllowAgentForwarding yes
+#AllowTcpForwarding yes
+#GatewayPorts no
+#X11Forwarding no
+#X11DisplayOffset 10
+#X11UseLocalhost yes
+#PermitTTY yes
+#PrintMotd yes
+#PrintLastLog yes
+#TCPKeepAlive yes
+#PermitUserEnvironment no
+#Compression delayed
+#ClientAliveInterval 0
+#ClientAliveCountMax 3
+#UseDNS no
+#PidFile /var/run/sshd.pid
+#MaxStartups 10:30:100
+#PermitTunnel no
+#ChrootDirectory none
+#VersionAddendum none
+
+# no default banner path
+#Banner none
+
+# override default of no subsystems
+Subsystem       sftp    /usr/libexec/openssh/sftp-server
+
+# Example of overriding settings on a per-user basis
+#Match User anoncvs
+#       X11Forwarding no
+#       AllowTcpForwarding no
+#       PermitTTY no
+#       ForceCommand cvs server

--- a/VMAccess/vmaccess.py
+++ b/VMAccess/vmaccess.py
@@ -398,6 +398,8 @@ def _get_default_ssh_config_filename():
             return "debian_default"
         if re.search("fedora", OSName, re.IGNORECASE):
             return "fedora_default"
+        if re.search(r"azure\s?linux|mariner", OSName, re.IGNORECASE):
+            return "fedora_default"
         if re.search(r"red\s?hat", OSName, re.IGNORECASE):
             return "redhat_default"
         if re.search("suse", OSName, re.IGNORECASE):

--- a/VMAccess/vmaccess.py
+++ b/VMAccess/vmaccess.py
@@ -399,7 +399,7 @@ def _get_default_ssh_config_filename():
         if re.search("fedora", OSName, re.IGNORECASE):
             return "fedora_default"
         if re.search(r"azure\s?linux|mariner", OSName, re.IGNORECASE):
-            return "fedora_default"
+            return "azurelinux_default"
         if re.search(r"red\s?hat", OSName, re.IGNORECASE):
             return "redhat_default"
         if re.search("suse", OSName, re.IGNORECASE):


### PR DESCRIPTION
## Problem

As preparation for the release of Azure Linux 4.0, this patch adds support for Azure Linux and CBL-Mariner to the VMAccess extension's sshd_config reset functionality.

When `az vm user reset-ssh` is triggered on Azure Linux (or CBL-Mariner), `_get_default_ssh_config_filename()` falls through to the generic `default` resource file because `NAME="Azure Linux"` does not match any of the existing distro regexes (centos, debian, fedora, red hat, suse, ubuntu).

The `default` resource file is a Debian/Ubuntu-era sshd_config that causes the following problems on Azure Linux:

- **SFTP broken**: wrong Subsystem path (`/usr/lib/openssh/sftp-server` instead of `/usr/libexec/openssh/sftp-server`)
- **Multiple deprecated directive warnings** from sshd -t
- **Unable to load host key**: `/etc/ssh/ssh_host_dsa_key` (DSA removed)
- **Include directive dropped**: `Include /etc/ssh/sshd_config.d/*.conf` removed, causing all drop-in config snippets (cloud-init, Azure) to be silently lost
- **PasswordAuthentication explicitly set to yes**
- **PermitRootLogin** uses old `without-password` syntax

## Fix

1. Added `azure\s?linux|mariner` regex to `_get_default_ssh_config_filename()` returning `azurelinux_default`. This matches:
   - Azure Linux: `NAME="Azure Linux"`
   - CBL-Mariner: `NAME="Common Base Linux Mariner"`

2. Added `VMAccess/resources/azurelinux_default`: stock Azure Linux sshd_config with no deprecated directives, correct SFTP path, and Include directive preserved.

## Testing

Tested on an Azure Linux VM:

| Check | Before (default) | After (azurelinux_default) |
|---|---|---|
| sshd -t errors | 6 warnings/errors | 0 |
| SFTP Subsystem path | `/usr/lib/openssh/sftp-server` (wrong) | `/usr/libexec/openssh/sftp-server` (correct) |
| Include directive | Missing | Present |
| DSA host key reference | Present (file doesn't exist) | Absent |
| PasswordAuthentication | yes | Commented out (default: no) |
| sshd restart | Clean (after warnings) | Clean |

## Files Changed

- `VMAccess/vmaccess.py` — added Azure Linux / Mariner match in `_get_default_ssh_config_filename()`
- `VMAccess/resources/azurelinux_default` — new sshd_config template for Azure Linux