### PR TITLE
Home directory metadata for azuremetricsext user is set to `/nonexistent`

### DIFF
--- a/LAD-AMA-Common/metrics_ext_utils/metrics_ext_handler.py
+++ b/LAD-AMA-Common/metrics_ext_utils/metrics_ext_handler.py
@@ -1038,7 +1038,12 @@ def ensure_user_primary_group(user, group, create_if_missing=False, HUtilObj=Non
         if create_if_missing:
             try:
                 process = subprocess.Popen([
-                    'useradd', '--no-create-home', '--system', '--shell', '/usr/sbin/nologin', '-g', group, user
+                    'useradd',
+                    '--no-create-home',
+                    '--home-dir', '/nonexistent',
+                    '--system',
+                    '--shell', '/usr/sbin/nologin',
+                    '--gid', group, user
                 ], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 out, err = process.communicate()
                 if process.returncode != 0:


### PR DESCRIPTION
The Linux system user `azuremetricsext` does not create a home directory. However, within `/etc/passwd`, a home directory metadata gets entered with default values. This uses the default `base-dir` (`$HOME` in most cases) followed by the username, for example in this case it would be `/home/azuremetricsext`.

This might give the notion that a home directory is created for the user for some security scanners. To avoid this, setting the `--home-dir` as `/nonexistent` to make it obvious.