### PR TITLE
VMBackup: Document vmbackup.conf options including df -kl local flag

### DIFF
--- a/VMBackup/README.txt
+++ b/VMBackup/README.txt
@@ -2,6 +2,41 @@ VMBackup extension is used by Azure Backup service to provide application consis
 
 **Note:** This extension is not recommended to be installed outside Azure Backup service context. 
 
-## Deploying the extension to a VM
+Configuration
+-------------
+
+The VMBackup extension reads optional configuration from /etc/azure/vmbackup.conf.
+Below are the available options under the [SnapshotThread] section:
+
+  fsfreeze (default: True)
+    Whether to freeze filesystems (fsfreeze/thaw) before taking a snapshot.
+    Freezing ensures application-consistent backups by flushing pending I/O.
+    Set to False only if fsfreeze causes issues (e.g., unresponsive mounts).
+
+  onlyLocalFilesystems (default: False)
+    When set to True, the extension uses 'df -kl' instead of 'df -k' for size
+    calculation, restricting the listing to local filesystems only. This prevents
+    the df command from hanging when network mounts (NFS, CIFS, FUSE, etc.) are
+    unreachable or slow to respond. Recommended for VMs with network-mounted
+    filesystems.
+
+  MountsToSkip (default: empty)
+    Comma-separated list of mount points to exclude from filesystem freeze.
+    Useful when specific mounts should not be frozen during backup (e.g., large
+    shared storage that cannot be safely frozen).
+
+  seqsnapshot (default: 0)
+    Controls snapshot ordering. 0 = parallel snapshots, 1 = sequential (set
+    programmatically), 2 = sequential (set by customer). Use 2 to force
+    sequential disk snapshots if parallel snapshots cause issues.
+
+Example /etc/azure/vmbackup.conf:
+
+  [SnapshotThread]
+  fsfreeze = True
+  onlyLocalFilesystems = True
+  MountsToSkip = /mnt/nfs_share,/mnt/cifs_share
+
+Deploying the extension to a VM
 This extension gets deployed as part of first scheduled backup of the VM post you configure VM for backup. You can configure VM to be backed up using [Azure Portal](https://docs.microsoft.com/azure/backup/quick-backup-vm-portal), [Azure PowerShell](https://docs.microsoft.com/azure/backup/quick-backup-vm-powershell) or Azure CLI(https://docs.microsoft.com/azure/backup/quick-backup-vm-cli). 
 

--- a/VMBackup/main/tempPlugin/vmbackup.conf
+++ b/VMBackup/main/tempPlugin/vmbackup.conf
@@ -1,3 +1,20 @@
 [SnapshotThread]
+
+# Whether to freeze filesystems (fsfreeze/thaw) before taking a snapshot.
+# Freezing ensures application-consistent backups by flushing pending I/O.
+# Set to False only if fsfreeze causes issues (e.g., unresponsive mounts).
+# Default: True
 fsfreeze: True
+
+# Set to True to use 'df -kl' (local filesystems only) instead of 'df -k' for
+# size calculation. This prevents df from hanging when network mounts (NFS,
+# CIFS, FUSE, etc.) are unreachable or slow. Recommended for VMs with
+# network-mounted filesystems. Default: False
+# onlyLocalFilesystems: True
+
+# Comma-separated mount points to exclude from filesystem freeze.
+# MountsToSkip:
+
+# Snapshot ordering: 0=parallel, 1=sequential (programmatic), 2=sequential (customer).
+# seqsnapshot: 0
 


### PR DESCRIPTION
## Summary

Documents the user-facing configuration options available in `/etc/azure/vmbackup.conf`, which were previously undocumented outside of inline code comments.

This was prompted by the `onlyLocalFilesystems` option introduced in PR #1562, which switches `df -k` to `df -kl` to prevent the size calculation from hanging when network mounts (NFS, CIFS, FUSE, etc.) are unreachable or slow. That option had no documentation in the README or the template config file, making it essentially undiscoverable.

## What's documented

| Option | Purpose |
|--------|---------|
| `fsfreeze` | Freeze filesystems before snapshot for application consistency |
| `onlyLocalFilesystems` | Use `df -kl` to avoid hangs on network mounts (PR #1562) |
| `MountsToSkip` | Exclude specific mount points from freeze |
| `seqsnapshot` | Control parallel vs sequential disk snapshots |

## Changes

- **README.txt**: Added a Configuration section with plain-text descriptions of all user-relevant options and an example config.
- **vmbackup.conf template**: Added commented-out entries with descriptions for each option so they are discoverable without reading source code.

## Impact

Documentation-only change. No behavior changes.