### PR TITLE
Fix duplicate config filenames and add unit tests with CI

### DIFF
--- a/.github/workflows/lad-ama-common-tests.yml
+++ b/.github/workflows/lad-ama-common-tests.yml
@@ -1,0 +1,30 @@
+name: LAD-AMA-Common Tests
+
+on:
+  push:
+    branches: [master, main]
+    paths:
+      - 'LAD-AMA-Common/**'
+  pull_request:
+    branches: [master, main]
+    paths:
+      - 'LAD-AMA-Common/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Run tests
+        working-directory: LAD-AMA-Common
+        run: python -m unittest discover -s tests -v

--- a/LAD-AMA-Common/telegraf_utils/telegraf_config_handler.py
+++ b/LAD-AMA-Common/telegraf_utils/telegraf_config_handler.py
@@ -179,7 +179,7 @@ def parse_config(data, me_url, mdsd_url, is_lad, az_resource_id, subscription_id
                         all_config_ids.append(configId)
 
             for configId in all_config_ids:
-                config_file = {"filename" : omiclass+"-"+configId+".conf"}
+                config_file = {"filename" : omiclass+"-"+plugin+"-"+configId+".conf"}
                 input_str = ""
                 ama_rename_str = ""
                 metricsext_rename_str = ""

--- a/LAD-AMA-Common/tests/test_metrics_common_utils.py
+++ b/LAD-AMA-Common/tests/test_metrics_common_utils.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+"""
+Unit tests for metrics_ext_utils/metrics_common_utils.py
+"""
+
+import sys
+import os
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from metrics_ext_utils.metrics_common_utils import is_systemd, is_arc_installed, get_arc_endpoint
+
+
+class TestIsSystemd(unittest.TestCase):
+    """Tests for is_systemd function."""
+
+    @patch('os.path.isdir')
+    def test_returns_true_when_systemd_dir_exists(self, mock_isdir):
+        mock_isdir.return_value = True
+        self.assertTrue(is_systemd())
+        mock_isdir.assert_called_with("/run/systemd/system")
+
+    @patch('os.path.isdir')
+    def test_returns_false_when_systemd_dir_missing(self, mock_isdir):
+        mock_isdir.return_value = False
+        self.assertFalse(is_systemd())
+
+
+class TestIsArcInstalled(unittest.TestCase):
+    """Tests for is_arc_installed function."""
+
+    @patch('os.system')
+    def test_returns_true_when_himdsd_running(self, mock_system):
+        mock_system.return_value = 0
+        self.assertTrue(is_arc_installed())
+        mock_system.assert_called_with("systemctl status himdsd 1>/dev/null 2>&1")
+
+    @patch('os.system')
+    def test_returns_false_when_himdsd_not_running(self, mock_system):
+        mock_system.return_value = 3  # systemctl returns non-zero for inactive
+        self.assertFalse(is_arc_installed())
+
+
+class TestGetArcEndpoint(unittest.TestCase):
+    """Tests for get_arc_endpoint function."""
+
+    @patch('builtins.open', unittest.mock.mock_open(
+        read_data='DefaultEnvironment="IMDS_ENDPOINT=http://localhost:40342"\n'))
+    def test_parses_endpoint_from_conf(self):
+        endpoint = get_arc_endpoint()
+        self.assertEqual(endpoint, "http://localhost:40342")
+
+    @patch('builtins.open', unittest.mock.mock_open(
+        read_data='DefaultEnvironment="IMDS_ENDPOINT=http://10.0.0.1:40342"\nOTHER="value"\n'))
+    def test_parses_custom_endpoint(self):
+        endpoint = get_arc_endpoint()
+        self.assertEqual(endpoint, "http://10.0.0.1:40342")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/LAD-AMA-Common/tests/test_metrics_constants.py
+++ b/LAD-AMA-Common/tests/test_metrics_constants.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+"""
+Unit tests for metrics_ext_utils/metrics_constants.py
+"""
+
+import sys
+import os
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import metrics_ext_utils.metrics_constants as metrics_constants
+
+
+class TestMetricsConstants(unittest.TestCase):
+    """Tests for metrics_constants module values."""
+
+    def test_namespace_value(self):
+        self.assertEqual(metrics_constants.metrics_extension_namespace,
+                         "Azure.VM.Linux.GuestMetrics")
+
+    def test_ama_binary_path(self):
+        self.assertEqual(metrics_constants.ama_metrics_extension_bin,
+                         "/opt/microsoft/azuremonitoragent/bin/MetricsExtension")
+
+    def test_lad_binary_path(self):
+        self.assertEqual(metrics_constants.lad_metrics_extension_bin,
+                         "/usr/local/lad/bin/MetricsExtension")
+
+    def test_ama_telegraf_bin(self):
+        self.assertEqual(metrics_constants.ama_telegraf_bin,
+                         "/opt/microsoft/azuremonitoragent/bin/telegraf")
+
+    def test_lad_telegraf_bin(self):
+        self.assertEqual(metrics_constants.lad_telegraf_bin,
+                         "/usr/local/lad/bin/telegraf")
+
+    def test_service_names(self):
+        self.assertEqual(metrics_constants.metrics_extension_service_name, "metrics-extension")
+        self.assertEqual(metrics_constants.telegraf_service_name, "metrics-sourcer")
+        self.assertEqual(metrics_constants.lad_metrics_extension_service_name, "metrics-extension-lad")
+        self.assertEqual(metrics_constants.lad_telegraf_service_name, "metrics-sourcer-lad")
+
+    def test_udp_ports_are_strings(self):
+        self.assertIsInstance(metrics_constants.ama_metrics_extension_udp_port, str)
+        self.assertIsInstance(metrics_constants.lad_metrics_extension_udp_port, str)
+
+    def test_influx_url_format(self):
+        self.assertTrue(
+            metrics_constants.lad_metrics_extension_influx_udp_url.startswith("udp://"))
+        self.assertIn(metrics_constants.lad_metrics_extension_udp_port,
+                      metrics_constants.lad_metrics_extension_influx_udp_url)
+
+    def test_telegraf_influx_url(self):
+        self.assertTrue(
+            metrics_constants.telegraf_influx_url.startswith("unix://"))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/LAD-AMA-Common/tests/test_metrics_ext_handler.py
+++ b/LAD-AMA-Common/tests/test_metrics_ext_handler.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python
+"""
+Unit tests for metrics_ext_utils/metrics_ext_handler.py
+"""
+
+import sys
+import os
+import json
+import unittest
+from unittest.mock import patch, MagicMock, mock_open
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Mock Linux-only modules before importing the handler
+for mod_name in ('grp', 'pwd'):
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = MagicMock()
+
+import metrics_ext_utils.metrics_constants as metrics_constants
+from metrics_ext_utils.metrics_ext_handler import (
+    create_metrics_extension_conf,
+    create_custom_metrics_conf,
+    get_metrics_extension_service_name,
+    get_arm_domain,
+    ARMDomainMap,
+    PublicCloudName,
+    FairfaxCloudName,
+    MooncakeCloudName,
+    USNatCloudName,
+    USSecCloudName,
+)
+
+
+class TestCreateMetricsExtensionConf(unittest.TestCase):
+    """Tests for create_metrics_extension_conf."""
+
+    def test_contains_resource_id(self):
+        resource_id = "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1"
+        conf = create_metrics_extension_conf(resource_id, "https://login.microsoftonline.com/tenant1")
+        conf_json = json.loads(conf)
+        self.assertEqual(conf_json["azureResourceId"], resource_id)
+
+    def test_contains_aad_authority(self):
+        aad_url = "https://login.microsoftonline.com/tenant1"
+        conf = create_metrics_extension_conf("/sub/rg/vm1", aad_url)
+        conf_json = json.loads(conf)
+        self.assertEqual(conf_json["aadAuthority"], aad_url)
+
+    def test_valid_json(self):
+        conf = create_metrics_extension_conf("/some/id", "https://aad.url")
+        conf_json = json.loads(conf)
+        self.assertIn("timeToTerminateInMs", conf_json)
+        self.assertIn("maxPublicationMetricsPerMinute", conf_json)
+        self.assertEqual(conf_json["publicationIntervalInSec"], 60)
+
+    def test_publish_min_max_default_true(self):
+        conf = create_metrics_extension_conf("/id", "https://aad")
+        conf_json = json.loads(conf)
+        self.assertTrue(conf_json["publishMinMaxByDefault"])
+
+
+class TestCreateCustomMetricsConf(unittest.TestCase):
+    """Tests for create_custom_metrics_conf."""
+
+    def test_default_gig_endpoint(self):
+        conf = create_custom_metrics_conf("westus2")
+        conf_json = json.loads(conf)
+        self.assertEqual(conf_json["homeStampGslbHostname"], "westus2.monitoring.azure.com")
+        self.assertIn("https://westus2.monitoring.azure.com/api/v1/ingestion/ingest",
+                      conf_json["endpointsForClientPublication"])
+
+    def test_custom_gig_endpoint(self):
+        custom_ep = "https://custom.endpoint.example.com"
+        conf = create_custom_metrics_conf("eastus", gig_endpoint=custom_ep)
+        conf_json = json.loads(conf)
+        self.assertEqual(conf_json["homeStampGslbHostname"], "custom.endpoint.example.com")
+        self.assertIn(custom_ep + "/api/v1/ingestion/ingest",
+                      conf_json["endpointsForClientPublication"])
+
+    def test_valid_json_structure(self):
+        conf = create_custom_metrics_conf("centralus")
+        conf_json = json.loads(conf)
+        self.assertIn("version", conf_json)
+        self.assertEqual(conf_json["version"], 17)
+
+
+class TestGetMetricsExtensionServiceName(unittest.TestCase):
+    """Tests for get_metrics_extension_service_name."""
+
+    def test_lad_service_name(self):
+        name = get_metrics_extension_service_name(True)
+        self.assertEqual(name, metrics_constants.lad_metrics_extension_service_name)
+
+    def test_ama_service_name(self):
+        name = get_metrics_extension_service_name(False)
+        self.assertEqual(name, metrics_constants.metrics_extension_service_name)
+
+
+class TestGetArmDomain(unittest.TestCase):
+    """Tests for get_arm_domain."""
+
+    def test_public_cloud(self):
+        domain = get_arm_domain("AzurePublicCloud")
+        self.assertEqual(domain, "management.azure.com")
+
+    def test_fairfax_cloud(self):
+        domain = get_arm_domain("AzureUSGovernmentCloud")
+        self.assertEqual(domain, "management.usgovcloudapi.net")
+
+    def test_mooncake_cloud(self):
+        domain = get_arm_domain("AzureChinaCloud")
+        self.assertEqual(domain, "management.chinacloudapi.cn")
+
+    def test_usnat_cloud(self):
+        domain = get_arm_domain("USNat")
+        self.assertEqual(domain, "management.azure.eaglex.ic.gov")
+
+    def test_ussec_cloud(self):
+        domain = get_arm_domain("USSec")
+        self.assertEqual(domain, "management.azure.microsoft.scloud")
+
+    def test_unknown_cloud_raises(self):
+        with self.assertRaises(Exception) as ctx:
+            get_arm_domain("UnknownCloud")
+        self.assertIn("Unknown cloud environment", str(ctx.exception))
+
+    @patch('metrics_ext_utils.metrics_ext_handler.get_arca_endpoints_from_himds')
+    def test_arca_cloud(self, mock_arca):
+        mock_arca.return_value = ("https://arm.azurestackcloud.example.com", "https://mcs.example.com")
+        domain = get_arm_domain("AzureStackCloud")
+        self.assertEqual(domain, "arm.azurestackcloud.example.com")
+
+
+class TestGetMetricsExtensionServicePath(unittest.TestCase):
+    """Tests for get_metrics_extension_service_path."""
+
+    @patch('os.path.exists')
+    def test_lad_lib_systemd(self, mock_exists):
+        from metrics_ext_utils.metrics_ext_handler import get_metrics_extension_service_path
+        mock_exists.side_effect = lambda p: p == "/lib/systemd/system/"
+        path = get_metrics_extension_service_path(True)
+        self.assertEqual(path, metrics_constants.lad_metrics_extension_service_path)
+
+    @patch('os.path.exists')
+    def test_lad_usr_lib_systemd(self, mock_exists):
+        from metrics_ext_utils.metrics_ext_handler import get_metrics_extension_service_path
+        mock_exists.side_effect = lambda p: p == "/usr/lib/systemd/system/"
+        path = get_metrics_extension_service_path(True)
+        self.assertEqual(path, metrics_constants.lad_metrics_extension_service_path_usr_lib)
+
+    @patch('os.path.exists')
+    def test_lad_no_systemd_raises(self, mock_exists):
+        from metrics_ext_utils.metrics_ext_handler import get_metrics_extension_service_path
+        mock_exists.return_value = False
+        with self.assertRaises(Exception):
+            get_metrics_extension_service_path(True)
+
+    @patch('os.path.exists')
+    def test_ama_etc_systemd(self, mock_exists):
+        from metrics_ext_utils.metrics_ext_handler import get_metrics_extension_service_path
+        mock_exists.side_effect = lambda p: p == "/etc/systemd/system"
+        path = get_metrics_extension_service_path(False)
+        self.assertEqual(path, metrics_constants.metrics_extension_service_path_etc)
+
+    @patch('os.path.exists')
+    def test_ama_no_systemd_raises(self, mock_exists):
+        from metrics_ext_utils.metrics_ext_handler import get_metrics_extension_service_path
+        mock_exists.return_value = False
+        with self.assertRaises(Exception):
+            get_metrics_extension_service_path(False)
+
+
+class TestIsRunning(unittest.TestCase):
+    """Tests for is_running (metrics)."""
+
+    @patch('subprocess.Popen')
+    def test_returns_true_when_process_found(self, mock_popen):
+        from metrics_ext_utils.metrics_ext_handler import is_running
+        mock_proc = MagicMock()
+        mock_proc.communicate.return_value = (
+            b"/opt/microsoft/azuremonitoragent/bin/MetricsExtension --args", b""
+        )
+        mock_popen.return_value = mock_proc
+        self.assertTrue(is_running(False))
+
+    @patch('subprocess.Popen')
+    def test_returns_false_when_process_not_found(self, mock_popen):
+        from metrics_ext_utils.metrics_ext_handler import is_running
+        mock_proc = MagicMock()
+        mock_proc.communicate.return_value = (b"", b"")
+        mock_popen.return_value = mock_proc
+        self.assertFalse(is_running(False))
+
+
+class TestGetHandlerVars(unittest.TestCase):
+    """Tests for get_handler_vars in metrics_ext_handler."""
+
+    @patch('os.path.exists')
+    def test_returns_empty_when_no_handler_env(self, mock_exists):
+        from metrics_ext_utils.metrics_ext_handler import get_handler_vars
+        mock_exists.return_value = False
+        log_folder, config_folder = get_handler_vars()
+        self.assertEqual(log_folder, "")
+        self.assertEqual(config_folder, "")
+
+    @patch('os.path.exists', return_value=True)
+    @patch('builtins.open', mock_open(read_data=json.dumps([{
+        "handlerEnvironment": {
+            "logFolder": "/var/log/azure/ext",
+            "configFolder": "/etc/azure/ext"
+        }
+    }])))
+    def test_parses_handler_env_list(self, mock_exists):
+        from metrics_ext_utils.metrics_ext_handler import get_handler_vars
+        log_folder, config_folder = get_handler_vars()
+        self.assertEqual(log_folder, "/var/log/azure/ext")
+        self.assertEqual(config_folder, "/etc/azure/ext")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/LAD-AMA-Common/tests/test_telegraf_config_handler.py
+++ b/LAD-AMA-Common/tests/test_telegraf_config_handler.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python
+"""
+Unit tests for telegraf_config_handler.parse_config
+"""
+
+import sys
+import os
+import json
+import unittest
+from unittest.mock import patch, MagicMock
+
+# Add parent dir to path so we can import the modules under test
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from telegraf_utils.telegraf_config_handler import parse_config, write_configs
+
+
+def make_counter(display_name, interval="60s", sink=None, config_ids=None):
+    """Helper to create a counter entry for parse_config input data."""
+    if sink is None:
+        sink = ["mdsd", "me"]
+    if config_ids is None:
+        config_ids = ["configId1"]
+    return {
+        "displayName": display_name,
+        "interval": interval,
+        "sink": sink,
+        "configurationId": config_ids,
+    }
+
+
+ME_URL = "unix:///var/run/me/me_influx.socket"
+MDSD_URL = "unix:///var/run/mdsd/mdsd_influx.socket"
+AZ_RESOURCE_ID = "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1"
+SUBSCRIPTION_ID = "sub1"
+RESOURCE_GROUP = "rg1"
+REGION = "westus2"
+VM_NAME = ""
+
+
+class TestParseConfigBasic(unittest.TestCase):
+    """Basic tests for parse_config."""
+
+    def test_empty_data_raises(self):
+        """parse_config should raise on empty input."""
+        with self.assertRaises(Exception) as ctx:
+            parse_config([], ME_URL, MDSD_URL, False, AZ_RESOURCE_ID,
+                         SUBSCRIPTION_ID, RESOURCE_GROUP, REGION, VM_NAME)
+        self.assertIn("Empty config data", str(ctx.exception))
+
+    def test_none_urls_raises(self):
+        """parse_config should raise if me_url or mdsd_url is None."""
+        data = [make_counter("% Used Memory")]
+        with self.assertRaises(Exception):
+            parse_config(data, None, MDSD_URL, False, AZ_RESOURCE_ID,
+                         SUBSCRIPTION_ID, RESOURCE_GROUP, REGION, VM_NAME)
+        with self.assertRaises(Exception):
+            parse_config(data, ME_URL, None, False, AZ_RESOURCE_ID,
+                         SUBSCRIPTION_ID, RESOURCE_GROUP, REGION, VM_NAME)
+
+    @patch('telegraf_utils.telegraf_config_handler.get_handler_vars')
+    def test_single_counter_generates_config(self, mock_handler):
+        """A single valid counter should produce config output."""
+        mock_handler.return_value = ("/var/log/azure", "/etc/azure")
+        data = [make_counter("% Used Memory")]
+        output, namespaces = parse_config(data, ME_URL, MDSD_URL, False,
+                                          AZ_RESOURCE_ID, SUBSCRIPTION_ID,
+                                          RESOURCE_GROUP, REGION, VM_NAME)
+        # Should have intermediate.json + at least one plugin config + telegraf.conf
+        self.assertGreaterEqual(len(output), 3)
+        filenames = [f["filename"] for f in output]
+        self.assertIn("intermediate.json", filenames)
+        self.assertIn("telegraf.conf", filenames)
+
+    @patch('telegraf_utils.telegraf_config_handler.get_handler_vars')
+    def test_config_contains_input_plugin(self, mock_handler):
+        """Generated config should contain the correct [[inputs.*]] directive."""
+        mock_handler.return_value = ("/var/log/azure", "/etc/azure")
+        data = [make_counter("% Used Memory")]
+        output, _ = parse_config(data, ME_URL, MDSD_URL, False,
+                                 AZ_RESOURCE_ID, SUBSCRIPTION_ID,
+                                 RESOURCE_GROUP, REGION, VM_NAME)
+        plugin_configs = [f for f in output if f["filename"] not in ("intermediate.json", "telegraf.conf")]
+        self.assertTrue(len(plugin_configs) > 0)
+        # mem plugin should have [[inputs.mem]]
+        mem_configs = [f for f in plugin_configs if "mem" in f["filename"]]
+        self.assertTrue(len(mem_configs) > 0)
+        self.assertIn("[[inputs.mem]]", mem_configs[0]["data"])
+
+
+class TestParseConfigUniqueFilenames(unittest.TestCase):
+    """Tests that config filenames are unique across plugins in the same omiclass."""
+
+    @patch('telegraf_utils.telegraf_config_handler.get_handler_vars')
+    def test_multiple_plugins_same_omiclass_unique_filenames(self, mock_handler):
+        """
+        When multiple plugins share an omiclass (e.g. 'memory' has 'mem', 'swap',
+        'kernel_vmstat'), each should get a unique filename so they don't overwrite
+        each other.
+        """
+        mock_handler.return_value = ("/var/log/azure", "/etc/azure")
+        data = [
+            make_counter("% Used Memory", config_ids=["dcr1"]),
+            make_counter("Available MBytes Memory", config_ids=["dcr1"]),
+            make_counter("Used MBytes Swap Space", config_ids=["dcr1"]),
+            make_counter("% Used Swap Space", config_ids=["dcr1"]),
+            make_counter("Page Reads/sec", config_ids=["dcr1"]),
+            make_counter("Page Writes/sec", config_ids=["dcr1"]),
+            make_counter("Pages/sec", config_ids=["dcr1"]),
+        ]
+        output, _ = parse_config(data, ME_URL, MDSD_URL, False,
+                                 AZ_RESOURCE_ID, SUBSCRIPTION_ID,
+                                 RESOURCE_GROUP, REGION, VM_NAME)
+        plugin_configs = [f for f in output if f["filename"] not in ("intermediate.json", "telegraf.conf")]
+        filenames = [f["filename"] for f in plugin_configs]
+        # All filenames should be unique
+        self.assertEqual(len(filenames), len(set(filenames)),
+                         f"Duplicate filenames detected: {filenames}")
+
+    @patch('telegraf_utils.telegraf_config_handler.get_handler_vars')
+    def test_filesystem_disk_and_diskio_unique_filenames(self, mock_handler):
+        """
+        The 'filesystem' omiclass has both 'disk' and 'diskio' plugins.
+        They must produce different filenames.
+        """
+        mock_handler.return_value = ("/var/log/azure", "/etc/azure")
+        data = [
+            make_counter("% Used Space", config_ids=["dcr1"]),
+            make_counter("Free Megabytes", config_ids=["dcr1"]),
+            make_counter("Disk Transfers/sec", config_ids=["dcr1"]),
+            make_counter("Disk Reads/sec", config_ids=["dcr1"]),
+            make_counter("Disk Writes/sec", config_ids=["dcr1"]),
+        ]
+        output, _ = parse_config(data, ME_URL, MDSD_URL, False,
+                                 AZ_RESOURCE_ID, SUBSCRIPTION_ID,
+                                 RESOURCE_GROUP, REGION, VM_NAME)
+        plugin_configs = [f for f in output if f["filename"] not in ("intermediate.json", "telegraf.conf")]
+        filenames = [f["filename"] for f in plugin_configs]
+        # All filenames should be unique
+        self.assertEqual(len(filenames), len(set(filenames)),
+                         f"Duplicate filenames detected: {filenames}")
+        # Should have both disk and diskio configs
+        disk_files = [f for f in filenames if "-disk-" in f]
+        diskio_files = [f for f in filenames if "-diskio-" in f]
+        self.assertTrue(len(disk_files) > 0, "Expected disk config file")
+        self.assertTrue(len(diskio_files) > 0, "Expected diskio config file")
+
+    @patch('telegraf_utils.telegraf_config_handler.get_handler_vars')
+    def test_all_plugins_generate_config(self, mock_handler):
+        """
+        When mem, swap, and kernel_vmstat are all configured under 'memory' omiclass,
+        all three should produce config files (not just the last one).
+        """
+        mock_handler.return_value = ("/var/log/azure", "/etc/azure")
+        data = [
+            make_counter("% Used Memory", config_ids=["dcr1"]),
+            make_counter("Available MBytes Memory", config_ids=["dcr1"]),
+            make_counter("Used MBytes Swap Space", config_ids=["dcr1"]),
+            make_counter("Page Reads/sec", config_ids=["dcr1"]),
+        ]
+        output, _ = parse_config(data, ME_URL, MDSD_URL, False,
+                                 AZ_RESOURCE_ID, SUBSCRIPTION_ID,
+                                 RESOURCE_GROUP, REGION, VM_NAME)
+        plugin_configs = [f for f in output if f["filename"] not in ("intermediate.json", "telegraf.conf")]
+        all_data = "\n".join(f["data"] for f in plugin_configs)
+        self.assertIn("[[inputs.mem]]", all_data, "mem plugin config missing")
+        self.assertIn("[[inputs.swap]]", all_data, "swap plugin config missing")
+        self.assertIn("[[inputs.kernel_vmstat]]", all_data, "kernel_vmstat plugin config missing")
+
+
+class TestParseConfigMultipleDCRs(unittest.TestCase):
+    """Tests for multi-DCR scenarios (the fix this commit addresses)."""
+
+    @patch('telegraf_utils.telegraf_config_handler.get_handler_vars')
+    def test_multiple_config_ids_produce_separate_files(self, mock_handler):
+        """
+        When a counter is associated with multiple configurationIds (multiple DCRs),
+        each configId should get its own config file.
+        """
+        mock_handler.return_value = ("/var/log/azure", "/etc/azure")
+        data = [
+            make_counter("% Used Memory", config_ids=["dcr1", "dcr2"]),
+            make_counter("Available MBytes Memory", config_ids=["dcr1", "dcr2"]),
+        ]
+        output, _ = parse_config(data, ME_URL, MDSD_URL, False,
+                                 AZ_RESOURCE_ID, SUBSCRIPTION_ID,
+                                 RESOURCE_GROUP, REGION, VM_NAME)
+        plugin_configs = [f for f in output if f["filename"] not in ("intermediate.json", "telegraf.conf")]
+        # Should have 2 config files for mem (one per DCR)
+        mem_configs = [f for f in plugin_configs if "-mem-" in f["filename"]]
+        self.assertEqual(len(mem_configs), 2,
+                         f"Expected 2 mem configs for 2 DCRs, got {len(mem_configs)}: {[f['filename'] for f in mem_configs]}")
+
+    @patch('telegraf_utils.telegraf_config_handler.get_handler_vars')
+    def test_config_id_tag_in_output(self, mock_handler):
+        """Each config file should have the correct configurationId tag."""
+        mock_handler.return_value = ("/var/log/azure", "/etc/azure")
+        data = [
+            make_counter("% Used Memory", config_ids=["dcr-alpha"]),
+        ]
+        output, _ = parse_config(data, ME_URL, MDSD_URL, False,
+                                 AZ_RESOURCE_ID, SUBSCRIPTION_ID,
+                                 RESOURCE_GROUP, REGION, VM_NAME)
+        plugin_configs = [f for f in output if f["filename"] not in ("intermediate.json", "telegraf.conf")]
+        mem_configs = [f for f in plugin_configs if "-mem-" in f["filename"]]
+        self.assertTrue(len(mem_configs) > 0)
+        self.assertIn('configurationId="dcr-alpha"', mem_configs[0]["data"])
+
+    @patch('telegraf_utils.telegraf_config_handler.get_handler_vars')
+    def test_different_counters_different_dcrs(self, mock_handler):
+        """
+        When counters in the same plugin map to different DCRs, all DCR configs
+        should be generated.
+        """
+        mock_handler.return_value = ("/var/log/azure", "/etc/azure")
+        data = [
+            make_counter("% Used Memory", config_ids=["dcr1"]),
+            make_counter("Available MBytes Memory", config_ids=["dcr2"]),
+        ]
+        output, _ = parse_config(data, ME_URL, MDSD_URL, False,
+                                 AZ_RESOURCE_ID, SUBSCRIPTION_ID,
+                                 RESOURCE_GROUP, REGION, VM_NAME)
+        plugin_configs = [f for f in output if f["filename"] not in ("intermediate.json", "telegraf.conf")]
+        mem_configs = [f for f in plugin_configs if "-mem-" in f["filename"]]
+        self.assertEqual(len(mem_configs), 2,
+                         f"Expected 2 mem configs (dcr1 + dcr2), got {len(mem_configs)}")
+        all_data = "\n".join(f["data"] for f in mem_configs)
+        self.assertIn('configurationId="dcr1"', all_data)
+        self.assertIn('configurationId="dcr2"', all_data)
+
+
+class TestParseConfigContent(unittest.TestCase):
+    """Tests for correctness of generated telegraf config content."""
+
+    @patch('telegraf_utils.telegraf_config_handler.get_handler_vars')
+    def test_fieldpass_includes_all_fields(self, mock_handler):
+        """fieldpass should include all fields for the plugin."""
+        mock_handler.return_value = ("/var/log/azure", "/etc/azure")
+        data = [
+            make_counter("% Used Memory", config_ids=["dcr1"]),
+            make_counter("Available MBytes Memory", config_ids=["dcr1"]),
+        ]
+        output, _ = parse_config(data, ME_URL, MDSD_URL, False,
+                                 AZ_RESOURCE_ID, SUBSCRIPTION_ID,
+                                 RESOURCE_GROUP, REGION, VM_NAME)
+        plugin_configs = [f for f in output if "-mem-" in f["filename"]]
+        self.assertTrue(len(plugin_configs) > 0)
+        config_data = plugin_configs[0]["data"]
+        self.assertIn('"used_percent"', config_data)
+        self.assertIn('"available"', config_data)
+
+    @patch('telegraf_utils.telegraf_config_handler.get_handler_vars')
+    def test_interval_uses_shortest(self, mock_handler):
+        """When fields have different intervals, the shortest should be used."""
+        mock_handler.return_value = ("/var/log/azure", "/etc/azure")
+        data = [
+            make_counter("% Used Memory", interval="60s", config_ids=["dcr1"]),
+            make_counter("Available MBytes Memory", interval="30s", config_ids=["dcr1"]),
+        ]
+        output, _ = parse_config(data, ME_URL, MDSD_URL, False,
+                                 AZ_RESOURCE_ID, SUBSCRIPTION_ID,
+                                 RESOURCE_GROUP, REGION, VM_NAME)
+        plugin_configs = [f for f in output if "-mem-" in f["filename"]]
+        self.assertTrue(len(plugin_configs) > 0)
+        config_data = plugin_configs[0]["data"]
+        # interval should be half of min (30s) = 15s
+        self.assertIn('interval = "15s"', config_data)
+
+    @patch('telegraf_utils.telegraf_config_handler.get_handler_vars')
+    def test_rate_counter_has_aggregator(self, mock_handler):
+        """Rate counters (like diskio) should have aggregator config."""
+        mock_handler.return_value = ("/var/log/azure", "/etc/azure")
+        data = [
+            make_counter("Disk Reads/sec", config_ids=["dcr1"]),
+            make_counter("Disk Writes/sec", config_ids=["dcr1"]),
+        ]
+        output, _ = parse_config(data, ME_URL, MDSD_URL, False,
+                                 AZ_RESOURCE_ID, SUBSCRIPTION_ID,
+                                 RESOURCE_GROUP, REGION, VM_NAME)
+        plugin_configs = [f for f in output if "-diskio-" in f["filename"]]
+        self.assertTrue(len(plugin_configs) > 0)
+        config_data = plugin_configs[0]["data"]
+        self.assertIn("[[aggregators.basicstats]]", config_data)
+        self.assertIn('"rate"', config_data)
+
+    @patch('telegraf_utils.telegraf_config_handler.get_handler_vars')
+    def test_cpu_has_report_active(self, mock_handler):
+        """CPU plugin should include report_active = true."""
+        mock_handler.return_value = ("/var/log/azure", "/etc/azure")
+        data = [
+            make_counter("% Processor Time", config_ids=["dcr1"]),
+        ]
+        output, _ = parse_config(data, ME_URL, MDSD_URL, False,
+                                 AZ_RESOURCE_ID, SUBSCRIPTION_ID,
+                                 RESOURCE_GROUP, REGION, VM_NAME)
+        plugin_configs = [f for f in output if "-cpu-" in f["filename"]]
+        self.assertTrue(len(plugin_configs) > 0)
+        config_data = plugin_configs[0]["data"]
+        self.assertIn("report_active = true", config_data)
+
+
+class TestParseConfigTelegrafConf(unittest.TestCase):
+    """Tests for the main telegraf.conf content."""
+
+    @patch('telegraf_utils.telegraf_config_handler.get_handler_vars')
+    def test_telegraf_conf_has_me_output(self, mock_handler):
+        """telegraf.conf should have ME output when sink includes 'me'."""
+        mock_handler.return_value = ("/var/log/azure", "/etc/azure")
+        data = [make_counter("% Used Memory", sink=["mdsd", "me"])]
+        output, _ = parse_config(data, ME_URL, MDSD_URL, False,
+                                 AZ_RESOURCE_ID, SUBSCRIPTION_ID,
+                                 RESOURCE_GROUP, REGION, VM_NAME)
+        telegraf_conf = next(f for f in output if f["filename"] == "telegraf.conf")
+        self.assertIn("[[outputs.socket_writer]]", telegraf_conf["data"])
+        self.assertIn(ME_URL, telegraf_conf["data"])
+
+    @patch('telegraf_utils.telegraf_config_handler.get_handler_vars')
+    def test_telegraf_conf_has_mdsd_output(self, mock_handler):
+        """telegraf.conf should have MDSD output when sink includes 'mdsd'."""
+        mock_handler.return_value = ("/var/log/azure", "/etc/azure")
+        data = [make_counter("% Used Memory", sink=["mdsd", "me"])]
+        output, _ = parse_config(data, ME_URL, MDSD_URL, False,
+                                 AZ_RESOURCE_ID, SUBSCRIPTION_ID,
+                                 RESOURCE_GROUP, REGION, VM_NAME)
+        telegraf_conf = next(f for f in output if f["filename"] == "telegraf.conf")
+        self.assertIn(MDSD_URL, telegraf_conf["data"])
+
+    @patch('telegraf_utils.telegraf_config_handler.get_handler_vars')
+    def test_telegraf_conf_has_global_tags(self, mock_handler):
+        """telegraf.conf should include subscription, resourceGroup, region tags."""
+        mock_handler.return_value = ("/var/log/azure", "/etc/azure")
+        data = [make_counter("% Used Memory")]
+        output, _ = parse_config(data, ME_URL, MDSD_URL, False,
+                                 AZ_RESOURCE_ID, SUBSCRIPTION_ID,
+                                 RESOURCE_GROUP, REGION, VM_NAME)
+        telegraf_conf = next(f for f in output if f["filename"] == "telegraf.conf")
+        self.assertIn(SUBSCRIPTION_ID, telegraf_conf["data"])
+        self.assertIn(RESOURCE_GROUP, telegraf_conf["data"])
+        self.assertIn(REGION, telegraf_conf["data"])
+
+
+class TestWriteConfigs(unittest.TestCase):
+    """Tests for write_configs function."""
+
+    @patch('telegraf_utils.telegraf_config_handler.rmtree')
+    @patch('telegraf_utils.telegraf_config_handler.os.path.exists')
+    @patch('telegraf_utils.telegraf_config_handler.os.mkdir')
+    @patch('builtins.open', new_callable=unittest.mock.mock_open)
+    def test_write_configs_writes_all_files(self, mock_open, mock_mkdir, mock_exists, mock_rmtree):
+        """write_configs should write each config entry to the correct path."""
+        mock_exists.return_value = True
+        configs = [
+            {"filename": "telegraf.conf", "data": "agent config"},
+            {"filename": "memory-mem-dcr1.conf", "data": "mem config"},
+            {"filename": "memory-swap-dcr1.conf", "data": "swap config"},
+        ]
+        write_configs(configs, "/etc/telegraf/", "/etc/telegraf/telegraf.d/")
+        # Should have opened 3 files for writing
+        self.assertEqual(mock_open.call_count, 3)
+
+    @patch('telegraf_utils.telegraf_config_handler.rmtree')
+    @patch('telegraf_utils.telegraf_config_handler.os.path.exists')
+    @patch('telegraf_utils.telegraf_config_handler.os.mkdir')
+    @patch('builtins.open', new_callable=unittest.mock.mock_open)
+    def test_write_configs_removes_old_dir(self, mock_open, mock_mkdir, mock_exists, mock_rmtree):
+        """write_configs should remove existing conf directory before writing."""
+        mock_exists.return_value = True
+        configs = [{"filename": "telegraf.conf", "data": "data"}]
+        write_configs(configs, "/etc/telegraf/", "/etc/telegraf/telegraf.d/")
+        mock_rmtree.assert_called_once_with("/etc/telegraf/")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/LAD-AMA-Common/tests/test_telegraf_name_map.py
+++ b/LAD-AMA-Common/tests/test_telegraf_name_map.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python
+"""
+Unit tests for telegraf_utils/telegraf_name_map.py
+"""
+
+import sys
+import os
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from telegraf_utils.telegraf_name_map import name_map
+
+
+class TestNameMapStructure(unittest.TestCase):
+    """Tests for the telegraf name_map data structure."""
+
+    def test_name_map_is_dict(self):
+        self.assertIsInstance(name_map, dict)
+
+    def test_name_map_not_empty(self):
+        self.assertGreater(len(name_map), 0)
+
+    def test_all_entries_have_plugin(self):
+        """Every entry must have a 'plugin' key."""
+        for counter, mapping in name_map.items():
+            self.assertIn("plugin", mapping,
+                          f"Counter '{counter}' missing 'plugin' key")
+
+    def test_all_entries_have_field(self):
+        """Every entry must have a 'field' key."""
+        for counter, mapping in name_map.items():
+            self.assertIn("field", mapping,
+                          f"Counter '{counter}' missing 'field' key")
+
+    def test_lad_entries_have_ladtablekey(self):
+        """LAD entries (with '->') should have a 'ladtablekey'."""
+        for counter, mapping in name_map.items():
+            if "->" in counter:
+                self.assertIn("ladtablekey", mapping,
+                              f"LAD counter '{counter}' missing 'ladtablekey'")
+
+    def test_ama_entries_have_module(self):
+        """AMA entries (without '->') should have a 'module' key."""
+        for counter, mapping in name_map.items():
+            if "->" not in counter:
+                self.assertIn("module", mapping,
+                              f"AMA counter '{counter}' missing 'module' key")
+
+    def test_plugin_names_are_strings(self):
+        for counter, mapping in name_map.items():
+            self.assertIsInstance(mapping["plugin"], str)
+            self.assertGreater(len(mapping["plugin"]), 0)
+
+    def test_field_names_are_strings(self):
+        for counter, mapping in name_map.items():
+            self.assertIsInstance(mapping["field"], str)
+            self.assertGreater(len(mapping["field"]), 0)
+
+
+class TestNameMapExpectedCounters(unittest.TestCase):
+    """Tests that expected counters exist in the map."""
+
+    def test_cpu_counters_present(self):
+        self.assertIn("% Processor Time", name_map)
+        self.assertIn("% Idle Time", name_map)
+        self.assertIn("% User Time", name_map)
+
+    def test_memory_counters_present(self):
+        self.assertIn("% Used Memory", name_map)
+        self.assertIn("Available MBytes Memory", name_map)
+
+    def test_disk_counters_present(self):
+        self.assertIn("% Used Space", name_map)
+        self.assertIn("Free Megabytes", name_map)
+        self.assertIn("Disk Reads/sec", name_map)
+
+    def test_network_counters_present(self):
+        self.assertIn("Total Bytes Received", name_map)
+        self.assertIn("Total Bytes Transmitted", name_map)
+        self.assertIn("Total Packets Transmitted", name_map)
+
+    def test_swap_counters_present(self):
+        self.assertIn("% Used Swap Space", name_map)
+        self.assertIn("Available MBytes Swap", name_map)
+
+    def test_system_counters_present(self):
+        self.assertIn("Uptime", name_map)
+        self.assertIn("Load1", name_map)
+
+    def test_lad_processor_counters(self):
+        self.assertIn("processor->cpu user time", name_map)
+        self.assertIn("processor->cpu idle time", name_map)
+
+    def test_lad_memory_counters(self):
+        self.assertIn("memory->memory used", name_map)
+        self.assertIn("memory->page reads", name_map)
+
+    def test_lad_filesystem_counters(self):
+        self.assertIn("filesystem->filesystem used space", name_map)
+        self.assertIn("filesystem->filesystem transfers/sec", name_map)
+
+    def test_lad_disk_counters(self):
+        self.assertIn("disk->disk read guest os", name_map)
+        self.assertIn("disk->disk writes", name_map)
+
+
+class TestNameMapPluginMapping(unittest.TestCase):
+    """Tests that counters map to the correct plugins."""
+
+    def test_cpu_counters_map_to_cpu_plugin(self):
+        self.assertEqual(name_map["% Processor Time"]["plugin"], "cpu")
+        self.assertEqual(name_map["% Idle Time"]["plugin"], "cpu")
+
+    def test_memory_counters_map_to_mem_plugin(self):
+        self.assertEqual(name_map["% Used Memory"]["plugin"], "mem")
+        self.assertEqual(name_map["Available MBytes Memory"]["plugin"], "mem")
+
+    def test_swap_counters_map_to_swap_plugin(self):
+        self.assertEqual(name_map["% Used Swap Space"]["plugin"], "swap")
+
+    def test_disk_counters_map_to_disk_plugin(self):
+        self.assertEqual(name_map["% Used Space"]["plugin"], "disk")
+
+    def test_diskio_counters_map_to_diskio_plugin(self):
+        self.assertEqual(name_map["Disk Reads/sec"]["plugin"], "diskio")
+        self.assertEqual(name_map["Disk Writes/sec"]["plugin"], "diskio")
+
+    def test_network_counters_map_to_net_plugin(self):
+        self.assertEqual(name_map["Total Bytes Received"]["plugin"], "net")
+
+    def test_kernel_vmstat_counters(self):
+        self.assertEqual(name_map["Page Reads/sec"]["plugin"], "kernel_vmstat")
+        self.assertEqual(name_map["Pages/sec"]["plugin"], "kernel_vmstat")
+
+    def test_rate_counters_have_op(self):
+        """Counters with rate operations should have 'op': 'rate'."""
+        rate_counters = ["Disk Reads/sec", "Disk Writes/sec", "Page Reads/sec"]
+        for counter in rate_counters:
+            self.assertIn("op", name_map[counter],
+                          f"Counter '{counter}' should have 'op' key")
+            self.assertEqual(name_map[counter]["op"], "rate")
+
+    def test_non_rate_counters_no_op(self):
+        """Non-rate counters should not have 'op' key."""
+        non_rate = ["% Used Memory", "% Used Space", "% Idle Time"]
+        for counter in non_rate:
+            self.assertNotIn("op", name_map[counter],
+                             f"Counter '{counter}' should not have 'op' key")
+
+
+class TestNameMapModuleMapping(unittest.TestCase):
+    """Tests that AMA counters map to correct modules."""
+
+    def test_cpu_module(self):
+        self.assertEqual(name_map["% Processor Time"]["module"], "processor")
+
+    def test_memory_module(self):
+        self.assertEqual(name_map["% Used Memory"]["module"], "memory")
+        self.assertEqual(name_map["Page Reads/sec"]["module"], "memory")
+
+    def test_filesystem_module(self):
+        self.assertEqual(name_map["% Used Space"]["module"], "filesystem")
+        self.assertEqual(name_map["Disk Reads/sec"]["module"], "filesystem")
+
+    def test_network_module(self):
+        self.assertEqual(name_map["Total Bytes Received"]["module"], "network")
+
+    def test_system_module(self):
+        self.assertEqual(name_map["Uptime"]["module"], "system")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Fix telegraf config filename collision: include plugin name in filename to prevent plugins in the same omiclass from overwriting each other (e.g. mem/swap/kernel_vmstat under 'memory')
- Add comprehensive unit tests for all LAD-AMA-Common modules (91 tests)
- Add GitHub Actions CI workflow triggered on LAD-AMA-Common changes