### PR TITLE
Add Rocky Linux 10 (x86_64) to AMA supported distros

### DIFF
--- a/AzureMonitorAgent/ama_tst/modules/install/supported_distros.py
+++ b/AzureMonitorAgent/ama_tst/modules/install/supported_distros.py
@@ -6,7 +6,7 @@ supported_dists_x86_64 = {
     'opensuse' : ['15'], # openSUSE
     'oracle' : ['7', '8', '9'], 'ol' : ['7', '8', '9'],  # Oracle
     'redhat' : ['7', '8', '9', '10'], # RHEL
-    'rocky' : ['8', '9'], # Rocky
+    'rocky' : ['8', '9', '10'], # Rocky
     'suse' : ['15', '16'], 'sles' : ['15', '16'], # SLES
     'ubuntu' : ['16.04', '18.04', '20.04', '22.04', '24.04'], # Ubuntu
 }


### PR DESCRIPTION
Rocky Linux 10 is validated working with AMA 1.42.0. Add '10' to the rocky entry in supported_dists_x86_64 so the ama_tst installer distro gate accepts Rocky 10 on x86_64.

Validated E2E on a Rocky 10.2 x86_64 VM: AMA installed and enabled, all LAW tables (Heartbeat/Syslog/Perf/InsightsMetrics/MyTable_CL/ MyTableAst_CL) receiving data.