### PR TITLE
Add Rocky Linux 10 (aarch64) to AMA supported distros

### DIFF
--- a/AzureMonitorAgent/ama_tst/modules/install/supported_distros.py
+++ b/AzureMonitorAgent/ama_tst/modules/install/supported_distros.py
@@ -16,7 +16,7 @@ supported_dists_aarch64 = {
     'azurelinux' : ['3'], 'mariner' : ['2'], # Azure Linux
     'debian' : ['11', '12', '13'], # Debian
     'redhat' : ['8', '9', '10'], # RHEL
-    'rocky' : ['8', '9'], 'rocky linux' : ['8', '9'],  # Rocky
+    'rocky' : ['8', '9', '10'], 'rocky linux' : ['8', '9', '10'],  # Rocky
     'sles' : ['15', '16'], # SLES
     'ubuntu' : ['18.04', '20.04', '22.04', '24.04'], # Ubuntu
 }


### PR DESCRIPTION
Rocky Linux 10 is validated working with AMA 1.42.0 on arm64. Add '10' to the rocky and 'rocky linux' entries in supported_dists_aarch64 so the ama_tst installer distro gate accepts Rocky 10 on aarch64.

Validated E2E on a Rocky 10.2 aarch64 VM: AMA installed and enabled, all LAW tables (Heartbeat/Syslog/Perf/InsightsMetrics/MyTable_CL/ MyTableAst_CL) receiving data.