### PR TITLE
Bug fixes for VMAccess

### DIFF
--- a/Utils/distroutils.py
+++ b/Utils/distroutils.py
@@ -53,7 +53,7 @@ def get_my_distro(config, os_name=None):
         if re.search("fedora", os_name, re.IGNORECASE):
             # Fedora
             return FedoraDistro(config)
-        if re.search("red\s?hat", os_name, re.IGNORECASE):
+        if re.search(r"red\s?hat", os_name, re.IGNORECASE):
             # Red Hat
             return RedhatDistro(config)
         if re.search("centos", os_name, re.IGNORECASE):

--- a/Utils/extensionutils.py
+++ b/Utils/extensionutils.py
@@ -198,7 +198,7 @@ def run_command_get_output(cmd, chk_err=True, log_cmd=True):
         if chk_err and log_cmd:
             logger.error(
                 'CalledProcessError.  Error message is ' + str(e))
-            return e.errno, str(e)
+        return e.errno, str(e)
     # noinspection PyUnboundLocalVariable
     return 0, output.decode('utf-8')
 

--- a/Utils/handlerutil2.py
+++ b/Utils/handlerutil2.py
@@ -181,8 +181,8 @@ class HandlerUtility:
 
     @staticmethod
     def redact_protected_settings(content):
-        redacted_tmp = re.sub('"protectedSettings":\s*"[^"]+=="', '"protectedSettings": "*** REDACTED ***"', content)
-        redacted = re.sub('"protectedSettingsCertThumbprint":\s*"[^"]+"', '"protectedSettingsCertThumbprint": "*** REDACTED ***"', redacted_tmp)
+        redacted_tmp = re.sub(r'"protectedSettings":\s*"[^"]+=="', '"protectedSettings": "*** REDACTED ***"', content)
+        redacted = re.sub(r'"protectedSettingsCertThumbprint":\s*"[^"]+"', '"protectedSettingsCertThumbprint": "*** REDACTED ***"', redacted_tmp)
         return redacted
 
     def _parse_config(self, ctxt):
@@ -206,12 +206,12 @@ class HandlerUtility:
                 pkey = constants.LibDir + '/' + thumb + '.prv'
                 unencodedSettings = base64.standard_b64decode(protectedSettings)
                 openSSLcmd_cms = ['openssl', 'cms', '-inform', 'DER', '-decrypt', '-recip' , cert, '-inkey', pkey]
-                cleartxt = ext_utils.run_send_stdin(openSSLcmd_cms, unencodedSettings)[1]
-                if cleartxt is None:
+                cms_retcode, cleartxt = ext_utils.run_send_stdin(openSSLcmd_cms, unencodedSettings)
+                if cms_retcode != 0:
                     self.log("OpenSSL decode error using cms command with thumbprint " + thumb + "\n trying smime command")
                     openSSLcmd_smime = ['openssl', 'smime', '-inform', 'DER', '-decrypt', '-recip' , cert, '-inkey', pkey]
-                    cleartxt = ext_utils.run_send_stdin(openSSLcmd_smime, unencodedSettings)[1]
-                    if cleartxt is None:
+                    smime_retcode, cleartxt = ext_utils.run_send_stdin(openSSLcmd_smime, unencodedSettings)
+                    if smime_retcode != 0:
                         self.error("OpenSSL decode error using smime command with thumbprint " + thumb)
                         self.do_exit(1, "Enable", 'error', '1', 'Failed to decrypt protectedSettings')
                 jctxt = ''
@@ -219,6 +219,7 @@ class HandlerUtility:
                     jctxt = json.loads(cleartxt)
                 except:
                     self.error('JSON exception decoding ' + HandlerUtility.redact_protected_settings(cleartxt))
+                    self.do_exit(1, "Enable", 'error', '1', 'Failed to decode protectedSettings')
                 handlerSettings['protectedSettings']=jctxt
                 self.log('Config decoded correctly.')
         return config

--- a/VMAccess/vmaccess.py
+++ b/VMAccess/vmaccess.py
@@ -72,6 +72,8 @@ class ConfigurationProvider(object):
             for line in ext_utils.get_file_contents(wala_config_file).split('\n'):
                 if not line.startswith("#") and "=" in line:
                     parts = line.split()[0].split('=')
+                    if len(parts) < 2:
+                        continue
                     value = parts[1].strip("\" ")
                     if value != "None":
                         self.values[parts[0]] = value
@@ -325,7 +327,7 @@ def _get_other_sudoers(user_name):
     if not os.path.isfile(sudoers_file):
         return None
     sudoers = ext_utils.get_file_contents(sudoers_file).split("\n")
-    pattern = '^{0}\s'.format(user_name)
+    pattern = r'^{0}\s'.format(user_name)
     sudoers = list(filter(lambda x: re.match(pattern, x) is None, sudoers))
     return sudoers
 
@@ -351,7 +353,11 @@ def _allow_password_auth(hutil):
 
 
 def _backup_and_update_sshd_config(hutil, attr_name, attr_value):
-    config = ext_utils.get_file_contents(SshdConfigPath).split("\n")
+    sshd_content = ext_utils.get_file_contents(SshdConfigPath)
+    if sshd_content is None:
+        hutil.log("Unable to read sshd_config at %s" % SshdConfigPath)
+        return
+    config = sshd_content.split("\n")
 
     for i in range(0, len(config)):
         if config[i].startswith(attr_name) and attr_value in config[i].lower():
@@ -392,7 +398,7 @@ def _get_default_ssh_config_filename():
             return "debian_default"
         if re.search("fedora", OSName, re.IGNORECASE):
             return "fedora_default"
-        if re.search("red\s?hat", OSName, re.IGNORECASE):
+        if re.search(r"red\s?hat", OSName, re.IGNORECASE):
             return "redhat_default"
         if re.search("suse", OSName, re.IGNORECASE):
             return "SuSE_default"


### PR DESCRIPTION
This PR aims to address a number of bugs in the VMAccess code: 

1. Invalid escape sequences (ex: /s) by using raw strings 
2. Adding null check to sshd content 
3. Add check for index out of range
4. Move exception to outside of if statement in check_output
5. Fail fast when cms/smime decryption fail 