### PR TITLE
AzureMonitorAgent: support Azure Linux 4

### DIFF
--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -473,6 +473,15 @@ def install():
             if rsyslog_exit_code != 0:
                 return rsyslog_exit_code, rsyslog_output
     
+    # Check if Azure Linux 4+ VMs have rsyslog package (Azure Linux 4 ships journald-only, no rsyslog by default)
+    if (vm_dist.startswith('azurelinux')) and int(vm_ver.split('.')[0]) >= 4:
+        check_rsyslog, _ = run_command_and_log("rpm -q rsyslog")
+        if check_rsyslog != 0:
+            hutil_log_info("'rsyslog' package missing from Azure Linux {0} machine, installing to allow AMA to run.".format(vm_ver))
+            rsyslog_exit_code, rsyslog_output = run_command_and_log("dnf install -y rsyslog")
+            if rsyslog_exit_code != 0:
+                return rsyslog_exit_code, rsyslog_output
+    
     # Check if SLES 16+ VMs have 'which' package (changed from Requires to Recommends in spec, may not be installed)
     if (vm_dist.startswith('suse') or vm_dist.startswith('sles')) and int(vm_ver.split('.')[0]) >= 16:
         check_which, _ = run_command_and_log("rpm -q which")

--- a/AzureMonitorAgent/ama_tst/modules/install/supported_distros.py
+++ b/AzureMonitorAgent/ama_tst/modules/install/supported_distros.py
@@ -1,7 +1,7 @@
 supported_dists_x86_64 = {
     'alma' : ['8', '9'], # Alma
     'amzn' : ['2', '2023'], # Amazon Linux 2
-    'azurelinux' : ['3'], 'mariner' : ['2'], # Azure Linux
+    'azurelinux' : ['3', '4'], 'mariner' : ['2'], # Azure Linux
     'debian' : ['9', '10', '11', '12', '13'], # Debian
     'opensuse' : ['15'], # openSUSE
     'oracle' : ['7', '8', '9'], 'ol' : ['7', '8', '9'],  # Oracle
@@ -13,7 +13,7 @@ supported_dists_x86_64 = {
 
 supported_dists_aarch64 = {
     'alma' : ['8'], # Alma
-    'azurelinux' : ['3'], 'mariner' : ['2'], # Azure Linux
+    'azurelinux' : ['3', '4'], 'mariner' : ['2'], # Azure Linux
     'debian' : ['11', '12', '13'], # Debian
     'redhat' : ['8', '9', '10'], # RHEL
     'rocky' : ['8', '9', '10'], 'rocky linux' : ['8', '9', '10'],  # Rocky


### PR DESCRIPTION
Adds Azure Linux 4 (x86_64 + aarch64) support:
- supported_distros.py: add '4' to the 'azurelinux' key in supported_dists_x86_64 and supported_dists_aarch64 so the extension no longer rejects Azure Linux 4 with 'Unsupported operating system'.
- agent.py install(): Azure Linux 4 ships journald-only with no rsyslog pre-installed, so AMA's Syslog collection produces no data until rsyslog is present. Mirror the existing Debian 12/13 and Amazon Linux 2023 handling by installing rsyslog via dnf when missing.

Validated end-to-end on a real Azure Linux 4.0 VM (AMA 1.42.0)