### PR TITLE
Fixing protected settings key leak

### DIFF
--- a/AzureMonitorAgent/agent.py
+++ b/AzureMonitorAgent/agent.py
@@ -2447,9 +2447,13 @@ def parse_context(operation):
                         output = 'Logrotate removal failed with error: {0}\nStacktrace: {1}'.format(ex, traceback.format_exc())
                         hutil_log_info(output)
             else:
-                if not os.path.exists(AMAExtensionLogRotateFilePath):      
-                    logrotateFilePath = os.path.join(os.getcwd(), 'azuremonitoragentextension.logrotate')
-                    copyfile(logrotateFilePath,AMAExtensionLogRotateFilePath)
+                if not os.path.exists(AMAExtensionLogRotateFilePath):
+                    try:
+                        logrotateFilePath = os.path.join(os.getcwd(), 'azuremonitoragentextension.logrotate')
+                        copyfile(logrotateFilePath,AMAExtensionLogRotateFilePath)
+                    except Exception as ex:
+                        output = 'Logrotate config copy failed with error: {0}\nStacktrace: {1}'.format(ex, traceback.format_exc())
+                        hutil_log_info(output)
             
         # parse_context may throw KeyError if necessary JSON key is not
         # present in settings
@@ -3060,9 +3064,13 @@ def get_settings():
             protected_settings_str = None
             for decrypt_cmd in [cms_cmd, smime_cmd]:
                 try:
+                    # stderr is intentionally captured separately from stdout (and never
+                    # logged verbatim) so that non-fatal openssl warnings (e.g. a missing
+                    # openssl.cnf) can't get concatenated with the decrypted output, corrupt the
+                    # JSON payload, and risk the decrypted secret being echoed in error handling.
                     session = subprocess.Popen([decrypt_cmd], shell=True,
                                                stdin=subprocess.PIPE,
-                                               stderr=subprocess.STDOUT,
+                                               stderr=subprocess.PIPE,
                                                stdout=subprocess.PIPE)
                     output = session.communicate(decoded_settings)
                     # success only if return code is 0 and we have output

--- a/Utils/HandlerUtil.py
+++ b/Utils/HandlerUtil.py
@@ -222,8 +222,13 @@ class HandlerUtility:
                 jctxt = ''
                 try:
                     jctxt = json.loads(protected_settings_str)
-                except:
-                    self.error('JSON exception decoding ' + HandlerUtility.redact_protected_settings(protected_settings_str))
+                except Exception as e:
+                    # Do not log protected_settings_str here: it is the decrypted
+                    # plaintext of protectedSettings and may contain secrets (e.g.
+                    # workspace keys). redact_protected_settings() only knows how to
+                    # redact the outer (still-encrypted) envelope fields, so it would
+                    # not mask secrets that live inside this already-decrypted payload.
+                    self.error('JSON exception decoding protectedSettings: {0}'.format(e))
                 handlerSettings['protectedSettings']=jctxt
                 self.log('Config decoded correctly.')
         return config


### PR DESCRIPTION
Fixes a security incident where the decrypted protectedSettings value was leaked into extension logs.

**Root cause:**
On VMs where OpenSSL is misconfigured (missing /usr/local/ssl/openssl.cnf), openssl cms/smime prints a non-fatal warning to stderr. Because stderr was merged into the same stream as the decrypted stdout, the warning text got prepended to the decrypted JSON, breaking json.loads(). The resulting exception handler in HandlerUtil.py then logged the raw decrypted payload through redact_protected_settings() — but that helper only strips the outer, still-encrypted envelope fields (protectedSettings, protectedSettingsCertThumbprint); it doesn't recognize secrets inside the already-decrypted payload (e.g. workspaceKey), so the redaction was a silent no-op and the raw key was logged in plaintext.

Separately, agent.py's Install operation could crash outright (exit code 1) if logrotate.d doesn't exist on the VM, since the logrotate-config copy wasn't guarded against that failure.

**Changes:**

- HandlerUtil.py — _parse_config():

On JSON-decode failure of the decrypted protectedSettings, stop logging the (ineffectively "redacted") raw payload. Log only the exception message instead, which never contains the original content.

- agent.py — get_settings():

Changed the OpenSSL decrypt subprocess to capture stderr separately (subprocess.PIPE) instead of merging it into stdout (subprocess.STDOUT). Prevents non-fatal OpenSSL warnings from corrupting the JSON payload and causing decode failures in the first place — hardening the equivalent decrypt path used by Enable/metrics/syslog/transform-config operations.

- agent.py — parse_context():

Wrapped the logrotate config copyfile() in a try/except (mirroring the existing pattern for the sibling os.remove() call), so a missing logrotate.d directory logs a warning instead of failing the entire Install operation with exit code 1.

**Work-item:**
https://dev.azure.com/msazure/One/_workitems/edit/38590195 