### PR TITLE
AzureMonitorAgent: add Ubuntu 26.04 to supported distros

### DIFF
--- a/AzureMonitorAgent/ama_tst/modules/install/supported_distros.py
+++ b/AzureMonitorAgent/ama_tst/modules/install/supported_distros.py
@@ -8,7 +8,7 @@ supported_dists_x86_64 = {
     'redhat' : ['7', '8', '9', '10'], # RHEL
     'rocky' : ['8', '9', '10'], # Rocky
     'suse' : ['15', '16'], 'sles' : ['15', '16'], # SLES
-    'ubuntu' : ['16.04', '18.04', '20.04', '22.04', '24.04'], # Ubuntu
+    'ubuntu' : ['16.04', '18.04', '20.04', '22.04', '24.04', '26.04'], # Ubuntu
 }
 
 supported_dists_aarch64 = {
@@ -18,5 +18,5 @@ supported_dists_aarch64 = {
     'redhat' : ['8', '9', '10'], # RHEL
     'rocky' : ['8', '9', '10'], 'rocky linux' : ['8', '9', '10'],  # Rocky
     'sles' : ['15', '16'], # SLES
-    'ubuntu' : ['18.04', '20.04', '22.04', '24.04'], # Ubuntu
+    'ubuntu' : ['18.04', '20.04', '22.04', '24.04', '26.04'], # Ubuntu
 }


### PR DESCRIPTION
Adds Ubuntu 26.04 to both the x86_64 and aarch64 AMA supported-distro maps.

Companion changes:
- Test orchestrator: https://dev.azure.com/msazure/One/_git/EngSys-MDA-CloudAgent/pullrequest/16638681
- Azure Policy image allow-lists: https://dev.azure.com/msazure/One/_git/mgmt-Governance-Policy/pullrequest/16712951

Validation results (AMA 1.42.0, Ubuntu 26.04):

- x86_64 (`vm260730232620ubuntu26x8664`): Heartbeat 19, Syslog 5,095, Perf 45,244, InsightsMetrics 478, MyTable_CL 17, MyTableAst_CL 16. Heartbeat reported Category `Azure Monitor Agent`, Version `1.42.0`.
- aarch64 (`vm260730232620ubuntu26aarch64`): Heartbeat 6, Syslog 1,795, Perf 14,474, InsightsMetrics 147, MyTable_CL 5, MyTableAst_CL 5. Heartbeat reported Category `Azure Monitor Agent`, Version `1.42.0`.
- `MyTableAst_CL` was isolated per VM using `_ResourceId` because its `Computer` field is empty; all other tables were isolated using `Computer`.

Changes required to make logs flow:

No distro-specific changes were required. Canonical's Ubuntu 26.04 images include active rsyslog, and all expected tables flowed after the temporary unsupported-distro gate override used for validation.