### PR TITLE
AzureMonitorAgent: add tested Ubuntu 26.04 support

### DIFF
--- a/.github/workflows/azure-monitor-agent-tests.yml
+++ b/.github/workflows/azure-monitor-agent-tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v4

--- a/AzureMonitorAgent/ama_tst/modules/install/check_os.py
+++ b/AzureMonitorAgent/ama_tst/modules/install/check_os.py
@@ -10,11 +10,12 @@ def format_alternate_versions(supported_dist, versions):
     """
     print out warning if running the wrong version of OS
     """
-    last = versions.pop()
-    if (versions == []):
+    last = versions[-1]
+    preceding_versions = versions[:-1]
+    if (preceding_versions == []):
         s = "{0}".format(last)
     else:
-        s = "{0} or {1}".format(', '.join(versions), last)
+        s = "{0} or {1}".format(', '.join(preceding_versions), last)
     return s
 
 

--- a/AzureMonitorAgent/ama_tst/modules/install/supported_distros.py
+++ b/AzureMonitorAgent/ama_tst/modules/install/supported_distros.py
@@ -8,7 +8,7 @@ supported_dists_x86_64 = {
     'redhat' : ['7', '8', '9', '10'], # RHEL
     'rocky' : ['8', '9', '10'], # Rocky
     'suse' : ['15', '16'], 'sles' : ['15', '16'], # SLES
-    'ubuntu' : ['16.04', '18.04', '20.04', '22.04', '24.04'], # Ubuntu
+    'ubuntu' : ['16.04', '18.04', '20.04', '22.04', '24.04', '26.04'], # Ubuntu
 }
 
 supported_dists_aarch64 = {
@@ -18,5 +18,5 @@ supported_dists_aarch64 = {
     'redhat' : ['8', '9', '10'], # RHEL
     'rocky' : ['8', '9', '10'], 'rocky linux' : ['8', '9', '10'],  # Rocky
     'sles' : ['15', '16'], # SLES
-    'ubuntu' : ['18.04', '20.04', '22.04', '24.04'], # Ubuntu
+    'ubuntu' : ['18.04', '20.04', '22.04', '24.04', '26.04'], # Ubuntu
 }

--- a/AzureMonitorAgent/tests/test_agent.py
+++ b/AzureMonitorAgent/tests/test_agent.py
@@ -7,7 +7,7 @@ import sys
 import os
 import re
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, mock_open
 
 # Mock Linux-only modules before importing
 for mod_name in ('grp', 'pwd'):
@@ -231,6 +231,35 @@ class TestConstants(unittest.TestCase):
     def test_config_keys(self):
         self.assertEqual(agent.GenevaConfigKey, "genevaConfiguration")
         self.assertEqual(agent.AzureMonitorConfigKey, "azureMonitorConfiguration")
+
+
+class TestFindVmDistro(unittest.TestCase):
+    """Tests for production OS detection."""
+
+    @patch('agent.os.path.exists', return_value=True)
+    @patch('builtins.open', mock_open(read_data='ID=ubuntu\nVERSION_ID="26.04"\n'))
+    def test_ubuntu_2604_preserves_major_minor_version(self, _):
+        self.assertEqual(agent.find_vm_distro("Install"), ("ubuntu", "26.04"))
+
+
+class TestIsVmSupportedForExtension(unittest.TestCase):
+    """Tests for the production supported-OS gate."""
+
+    @patch('agent.platform.machine', return_value='x86_64')
+    @patch('agent.find_vm_distro', return_value=('ubuntu', '26.04'))
+    def test_ubuntu_2604_x86_64_supported(self, _, __):
+        self.assertEqual(
+            agent.is_vm_supported_for_extension("Install"),
+            (True, "ubuntu", "26.04")
+        )
+
+    @patch('agent.platform.machine', return_value='aarch64')
+    @patch('agent.find_vm_distro', return_value=('ubuntu', '26.04'))
+    def test_ubuntu_2604_aarch64_supported(self, _, __):
+        self.assertEqual(
+            agent.is_vm_supported_for_extension("Install"),
+            (True, "ubuntu", "26.04")
+        )
 
 
 class TestGenerateLocalsyslogConfigsEarlyReturn(unittest.TestCase):

--- a/AzureMonitorAgent/tests/test_check_os.py
+++ b/AzureMonitorAgent/tests/test_check_os.py
@@ -37,8 +37,13 @@ class TestSupportedDistros(unittest.TestCase):
 
     def test_ubuntu_versions_x86(self):
         versions = supported_distros.supported_dists_x86_64['ubuntu']
+        self.assertIn('26.04', versions)
         self.assertIn('22.04', versions)
         self.assertIn('20.04', versions)
+
+    def test_ubuntu_2604_in_aarch64_versions(self):
+        versions = supported_distros.supported_dists_aarch64['ubuntu']
+        self.assertIn('26.04', versions)
 
     def test_all_versions_are_strings(self):
         for dist, versions in supported_distros.supported_dists_x86_64.items():
@@ -62,6 +67,11 @@ class TestFormatAlternateVersions(unittest.TestCase):
         result = format_alternate_versions("rhel", ["7", "8", "9"])
         self.assertEqual(result, "7, 8 or 9")
 
+    def test_does_not_mutate_versions(self):
+        versions = ["20.04", "22.04", "24.04", "26.04"]
+        format_alternate_versions("ubuntu", versions)
+        self.assertEqual(versions, ["20.04", "22.04", "24.04", "26.04"])
+
 
 class TestCheckVmSupported(unittest.TestCase):
     """Tests for check_vm_supported."""
@@ -77,6 +87,11 @@ class TestCheckVmSupported(unittest.TestCase):
     @patch('platform.machine', return_value='x86_64')
     def test_ubuntu_2004_supported(self, _):
         result = check_vm_supported("ubuntu", "20.04")
+        self.assertEqual(result, error_codes.NO_ERROR)
+
+    @patch('platform.machine', return_value='x86_64')
+    def test_ubuntu_2604_supported(self, _):
+        result = check_vm_supported("ubuntu", "26.04")
         self.assertEqual(result, error_codes.NO_ERROR)
 
     @patch('platform.machine', return_value='x86_64')
@@ -102,6 +117,11 @@ class TestCheckVmSupported(unittest.TestCase):
     @patch('platform.machine', return_value='aarch64')
     def test_aarch64_ubuntu_2204(self, _):
         result = check_vm_supported("ubuntu", "22.04")
+        self.assertEqual(result, error_codes.NO_ERROR)
+
+    @patch('platform.machine', return_value='aarch64')
+    def test_aarch64_ubuntu_2604(self, _):
+        result = check_vm_supported("ubuntu", "26.04")
         self.assertEqual(result, error_codes.NO_ERROR)
 
     @patch('platform.machine', return_value='aarch64')

--- a/AzureMonitorAgent/tests/test_helpers.py
+++ b/AzureMonitorAgent/tests/test_helpers.py
@@ -73,6 +73,14 @@ class TestFindVmDistro(unittest.TestCase):
         self.assertEqual(ver, '22.04')
         self.assertIsNone(err)
 
+    @patch('builtins.open', mock_open(read_data='ID=ubuntu\nVERSION_ID="26.04"\n'))
+    def test_parses_os_release_ubuntu_2604(self):
+        from helpers import find_vm_distro
+        dist, ver, err = find_vm_distro()
+        self.assertEqual(dist, 'ubuntu')
+        self.assertEqual(ver, '26.04')
+        self.assertIsNone(err)
+
     @patch('builtins.open', mock_open(read_data='ID=rhel\nVERSION_ID="8.5"\n'))
     def test_parses_os_release_rhel(self):
         from helpers import find_vm_distro


### PR DESCRIPTION
## Summary

Closes #2200. Related to the observed installation failure in #2173.

Add Ubuntu 26.04 to the Azure Monitor Agent supported-distribution maps for x86_64 and aarch64, with regression coverage for the production installer gate, troubleshooting gate, distro detection, and Python 3.14 runtime.

## Attribution

This change is based on and credits #2199 by @kamilon for the original Ubuntu 26.04 allowlist change and public x86_64/aarch64 end-to-end validation.

This alternative adds repository-level coverage so the support declaration is protected by CI. The test changes can also be reviewed or reused independently if the project prefers #2199 as the merge vehicle.

## Changes

- Add Ubuntu `26.04` to `supported_dists_x86_64` and `supported_dists_aarch64`.
- Verify the production `is_vm_supported_for_extension` gate accepts Ubuntu 26.04 on both architectures.
- Verify the troubleshooting `check_vm_supported` gate accepts Ubuntu 26.04 on both architectures.
- Verify both support maps explicitly contain Ubuntu 26.04.
- Verify production and troubleshooting distro detection preserve `VERSION_ID="26.04"`.
- Extend the GitHub Actions Python matrix with Python 3.13 and 3.14.
- Prevent `format_alternate_versions` from mutating the shared support list while formatting an unsupported-version message.

## Why the mutation fix is included

The new support-map assertion exposed that `format_alternate_versions` used `pop()` on the shared list. Running an unsupported-version check therefore removed the newest supported version for the remainder of the process. Formatting now uses a slice and leaves the support declaration unchanged.

## Validation

The complete 127-test AzureMonitorAgent suite passes locally on:

- Python 3.9.21
- Python 3.12.11
- Python 3.13.1
- Python 3.14.6

All six GitHub Actions jobs pass in the public fork for Python 3.9 through 3.14.

The existing #2199 provides real-VM ingestion validation for Ubuntu 26.04 on both x86_64 and aarch64; this PR adds the missing repository regression and runtime coverage.