### PR TITLE
Support AlmaLinux 10 in Azure Monitor Agent

### DIFF
--- a/AzureMonitorAgent/ama_tst/modules/install/supported_distros.py
+++ b/AzureMonitorAgent/ama_tst/modules/install/supported_distros.py
@@ -1,5 +1,5 @@
 supported_dists_x86_64 = {
-    'alma' : ['8', '9'], # Alma
+    'alma' : ['8', '9', '10'], # Alma
     'amzn' : ['2', '2023'], # Amazon Linux 2
     'azurelinux' : ['3', '4'], 'mariner' : ['2'], # Azure Linux
     'debian' : ['9', '10', '11', '12', '13'], # Debian
@@ -12,7 +12,7 @@ supported_dists_x86_64 = {
 }
 
 supported_dists_aarch64 = {
-    'alma' : ['8'], # Alma
+    'alma' : ['8', '10'], # Alma
     'azurelinux' : ['3', '4'], 'mariner' : ['2'], # Azure Linux
     'debian' : ['11', '12', '13'], # Debian
     'redhat' : ['8', '9', '10'], # RHEL


### PR DESCRIPTION
## Summary

- Add AlmaLinux 10 to the Azure Monitor Agent supported distro gate for x86_64 and aarch64.
- Leave all other distro names, aliases, and versions unchanged.

## Validation

- Python syntax check passed.
- test_check_os.py: 18 tests passed.
- Direct AlmaLinux 10.2 gate checks passed for x86_64 and aarch64.
- Git diff check passed.

## Related changes

- Orchestrator: https://msazure.visualstudio.com/One/_git/EngSys-MDA-CloudAgent/pullrequest/16651814
- Policy: https://msazure.visualstudio.com/One/_git/mgmt-Governance-Policy/pullrequest/16695744