### PR TITLE
AzureMonitorAgent: add Oracle Linux 10 to supported distros

### DIFF
--- a/AzureMonitorAgent/ama_tst/modules/install/supported_distros.py
+++ b/AzureMonitorAgent/ama_tst/modules/install/supported_distros.py
@@ -4,7 +4,7 @@ supported_dists_x86_64 = {
     'azurelinux' : ['3', '4'], 'mariner' : ['2'], # Azure Linux
     'debian' : ['9', '10', '11', '12', '13'], # Debian
     'opensuse' : ['15'], # openSUSE
-    'oracle' : ['7', '8', '9'], 'ol' : ['7', '8', '9'],  # Oracle
+    'oracle' : ['7', '8', '9', '10'], 'ol' : ['7', '8', '9', '10'],  # Oracle
     'redhat' : ['7', '8', '9', '10'], # RHEL
     'rocky' : ['8', '9', '10'], # Rocky
     'suse' : ['15', '16'], 'sles' : ['15', '16'], # SLES
@@ -15,6 +15,7 @@ supported_dists_aarch64 = {
     'alma' : ['8'], # Alma
     'azurelinux' : ['3', '4'], 'mariner' : ['2'], # Azure Linux
     'debian' : ['11', '12', '13'], # Debian
+    'oracle' : ['10'], 'ol' : ['10'], # Oracle
     'redhat' : ['8', '9', '10'], # RHEL
     'rocky' : ['8', '9', '10'], 'rocky linux' : ['8', '9', '10'],  # Rocky
     'sles' : ['15', '16'], # SLES


### PR DESCRIPTION
Adds Oracle Linux 10 to the Azure Monitor Agent supported distro gate for x86_64 and aarch64, including both `oracle` and `ol` identifiers.

## Validation evidence

- x86_64 (`Oracle:Oracle-Linux:ol10-lvm-gen2`): Heartbeat 13, Syslog 5,415, Perf 52,439, InsightsMetrics 231, MyTable_CL 11, MyTableAst_CL 11. Heartbeat category `Azure Monitor Agent`, version `1.42.0`.
- aarch64 (`Oracle:Oracle-Linux:ol10-arm64-lvm-gen2`): Heartbeat 10, Syslog 3,743, Perf 40,016, InsightsMetrics 143, MyTable_CL 8, MyTableAst_CL 8. Heartbeat category `Azure Monitor Agent`, version `1.42.0`.
- MyTableAst_CL was isolated per VM with `_ResourceId` because that table emits an empty `Computer` field.

## Changes required to make logs flow

No distro-specific changes were required. Both Oracle Linux 10.2 images shipped with rsyslog installed and active; only the expected temporary unsupported-distro gate patch was needed for validation.

Companion PRs:
- EngSys-MDA-CloudAgent: https://msazure.visualstudio.com/One/_git/EngSys-MDA-CloudAgent/pullrequest/16651704
- mgmt-Governance-Policy: https://msazure.visualstudio.com/One/_git/mgmt-Governance-Policy/pullrequest/16703418
